### PR TITLE
fix: check ctrl and meta key while handling click event for the a link

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "Yoorkin/rabbit-tea",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "deps": {
     "rami3l/js-ffi": "0.2.4"
   },

--- a/src/dom/dom.mbti
+++ b/src/dom/dom.mbti
@@ -308,12 +308,16 @@ fn KeyboardEvent::repeat(Self) -> Bool
 fn KeyboardEvent::shift_key(Self) -> Bool
 
 type MouseEvent
+fn MouseEvent::alt_key(Self) -> Bool
 fn MouseEvent::client_x(Self) -> Int
 fn MouseEvent::client_y(Self) -> Int
+fn MouseEvent::ctrl_key(Self) -> Bool
+fn MouseEvent::meta_key(Self) -> Bool
 fn MouseEvent::offset_x(Self) -> Int
 fn MouseEvent::offset_y(Self) -> Int
 fn MouseEvent::screen_x(Self) -> Int
 fn MouseEvent::screen_y(Self) -> Int
+fn MouseEvent::shift_key(Self) -> Bool
 
 pub extern type Navigator
 fn Navigator::clipboard(Self) -> Clipboard

--- a/src/dom/dom_event.mbt
+++ b/src/dom/dom_event.mbt
@@ -82,6 +82,18 @@ pub extern "js" fn MouseEvent::offset_x(self : MouseEvent) -> Int = "(e) => e.of
 pub extern "js" fn MouseEvent::offset_y(self : MouseEvent) -> Int = "(e) => e.offsetY"
 
 ///|
+pub extern "js" fn MouseEvent::ctrl_key(self : MouseEvent) -> Bool = "(e) => e.ctrlKey"
+
+///|
+pub extern "js" fn MouseEvent::shift_key(self : MouseEvent) -> Bool = "(e) => e.shiftKey"
+
+///|
+pub extern "js" fn MouseEvent::alt_key(self : MouseEvent) -> Bool = "(e) => e.altKey"
+
+///|
+pub extern "js" fn MouseEvent::meta_key(self : MouseEvent) -> Bool = "(e) => e.metaKey"
+
+///|
 extern type InputEvent
 
 ///|

--- a/src/html/html.mbt
+++ b/src/html/html.mbt
@@ -209,12 +209,19 @@ pub fn[M] span(
 
 ///| Create `a` element.
 /// 
-/// The `escape` parameter is an optional boolean that determines whether the link 
-/// should be escaped. By default, it is set to `false`. 
+/// # Parameters
 /// 
-/// When `escape` is set to `true`, clicking the escaped link will cause the browser 
-/// to immediately navigate to the `href` target, bypassing any interception logic. 
-/// As a result, the `UrlRequest` message will not be triggered.
+/// - `escape`: an optional boolean that determines whether the link 
+///  should be escaped. By default, it is set to `false`. 
+/// 
+///   When `escape` is set to `true`, clicking the escaped link will cause the browser 
+///   to immediately navigate to the `href` target, bypassing any interception logic. 
+///   As a result, the `UrlRequest` message will not be triggered.
+/// 
+/// - `target`: an optional `Target` that specifies where to open the link.
+/// 
+/// If the user holds the `ctrl` key (or the command key on macOS) while clicking the link,
+/// the click event will be handled by the browser, and the `UrlRequest` will not be triggered either.
 pub fn[M] a(
   style~ : Array[String] = [],
   id? : String,

--- a/src/internal/vdom/dom.mbt
+++ b/src/internal/vdom/dom.mbt
@@ -231,6 +231,8 @@ fn[Msg, Model, View] Node::to_node(
       //
       // If the `url_request` message was not provided, let the browser 
       // handle the click event.
+      // 
+      // If the user hold the meta key or ctrl key, let the browser handle the click event.
       let element = match (sandbox.get_on_url_request(), tag) {
         (Some(url_request), NORMAL_LINK_TAG) => {
           let element = @dom.document().create_element(tag)
@@ -239,18 +241,27 @@ fn[Msg, Model, View] Node::to_node(
           .to_node()
           .to_event_target()
           .add_event_listener("click", fn(event) {
-            event.prevent_default()
-            let href = element.get_property("href")
-            guard @url.parse?(@dom.window().current_url()) is Ok(curr)
-            guard @url.parse?(href) is Ok(next)
-            let request = if curr.protocol == next.protocol &&
-              curr.host == next.host &&
-              curr.port == next.port {
-              @url.Internal(next)
-            } else {
-              External(href)
+            let mouse_event = event
+              .to_ui_event()
+              .to_option()
+              .unwrap()
+              .to_mouse_event()
+              .to_option()
+              .unwrap()
+            if not(mouse_event.meta_key() || mouse_event.ctrl_key()) {
+              event.prevent_default()
+              let href = element.get_property("href")
+              guard @url.parse?(@dom.window().current_url()) is Ok(curr)
+              guard @url.parse?(href) is Ok(next)
+              let request = if curr.protocol == next.protocol &&
+                curr.host == next.host &&
+                curr.port == next.port {
+                @url.Internal(next)
+              } else {
+                External(href)
+              }
+              sandbox.update(url_request(request))
             }
-            sandbox.update(url_request(request))
           })
           element
         }


### PR DESCRIPTION
If the link is clicked while the user holds the Ctrl key (or the meta key on macOS), let the browser handle the click event. In this case, the browser will open a new tab.

related https://taolun.moonbitlang.com/t/topic/1226