### PR TITLE
Add ErrorEvent bindings to rabbit-tea/dom package

### DIFF
--- a/src/dom/dom.mbti
+++ b/src/dom/dom.mbti
@@ -246,6 +246,15 @@ impl @js.Cast for Element
 
 type ElementInternals
 
+type ErrorEvent
+fn ErrorEvent::get_colno(Self) -> Int
+fn ErrorEvent::get_error(Self) -> @js.Value
+fn ErrorEvent::get_filename(Self) -> String
+fn ErrorEvent::get_lineno(Self) -> Int
+fn ErrorEvent::get_message(Self) -> String
+impl IsEvent for ErrorEvent
+impl @js.Cast for ErrorEvent
+
 type Event
 impl IsEvent for Event
 impl @js.Cast for Event
@@ -566,6 +575,7 @@ pub trait IsEvent : @js.Cast {
   to_custom_event(Self) -> CustomEvent?
   to_drag_event(Self) -> DragEvent?
   to_wheel_event(Self) -> WheelEvent?
+  to_error_event(Self) -> ErrorEvent?
 }
 
 pub trait IsEventTarget : @js.Cast {

--- a/src/dom/error_event.mbt
+++ b/src/dom/error_event.mbt
@@ -1,0 +1,31 @@
+///| https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent
+#external
+type ErrorEvent
+
+///|
+pub impl IsEvent for ErrorEvent
+
+///|
+pub impl @js.Cast for ErrorEvent with into(value) {
+  value |> ffi_to_error_event |> _.to_option()
+}
+
+///|
+pub impl @js.Cast for ErrorEvent with from(value) {
+  value |> js_identity
+}
+
+///| A string containing a human-readable error message describing the problem.
+pub extern "js" fn ErrorEvent::get_message(self : Self) -> String = "(e) => e.message"
+
+///| A string containing the name of the script file in which the error occurred.
+pub extern "js" fn ErrorEvent::get_filename(self : Self) -> String = "(e) => e.filename"
+
+///| An integer containing the line number of the script file on which the error occurred.
+pub extern "js" fn ErrorEvent::get_lineno(self : Self) -> Int = "(e) => e.lineno"
+
+///| An integer containing the column number of the script file on which the error occurred.
+pub extern "js" fn ErrorEvent::get_colno(self : Self) -> Int = "(e) => e.colno"
+
+///| A JavaScript value representing the error associated with this event.
+pub extern "js" fn ErrorEvent::get_error(self : Self) -> @js.Value = "(e) => e.error"

--- a/src/dom/event.mbt
+++ b/src/dom/event.mbt
@@ -27,6 +27,7 @@ pub trait IsEvent: @js.Cast {
   to_custom_event(Self) -> CustomEvent? = _
   to_drag_event(Self) -> DragEvent? = _
   to_wheel_event(Self) -> WheelEvent? = _
+  to_error_event(Self) -> ErrorEvent? = _
 }
 
 ///|
@@ -133,6 +134,11 @@ impl IsEvent with to_wheel_event(s) {
 }
 
 ///|
+impl IsEvent with to_error_event(s) {
+  s |> js_identity |> ffi_to_error_event |> _.to_option()
+}
+
+///|
 extern "js" fn ffi_event_target(x : @js.Value) -> EventTarget = "(self) => self.target"
 
 ///|
@@ -206,6 +212,10 @@ extern "js" fn ffi_to_drag_event(x : @js.Value) -> @js.Nullable[DragEvent] =
 ///|
 extern "js" fn ffi_to_wheel_event(x : @js.Value) -> @js.Nullable[WheelEvent] =
   #| (e) => e instanceof WheelEvent ? e : null
+
+///|
+extern "js" fn ffi_to_error_event(x : @js.Value) -> @js.Nullable[ErrorEvent] =
+  #| (e) => e instanceof ErrorEvent ? e : null
 
 ///|
 extern "js" fn ffi_to_event(x : @js.Value) -> @js.Nullable[Event] =


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This PR implements ErrorEvent bindings following the same pattern as other event types like KeyboardEvent and AnimationEvent.

Based on the MDN documentation for ErrorEvent (https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent), this implementation includes:

- ErrorEvent type declaration with #external attribute
- IsEvent trait implementation for ErrorEvent
- @js.Cast trait implementation for proper casting
- All read-only properties as defined in the MDN spec:
  - get_message(): A string containing a human-readable error message
  - get_filename(): A string containing the name of the script file where error occurred
  - get_lineno(): An integer containing the line number where error occurred
  - get_colno(): An integer containing the column number where error occurred  
  - get_error(): A JavaScript value representing the error associated with this event

- FFI conversion function ffi_to_error_event for instanceof checking
- to_error_event() method added to IsEvent trait for downcasting
- Updated dom.mbti interface to export the new ErrorEvent type and methods

The implementation follows the established patterns in the codebase and uses get_xx naming convention for property accessors as requested.