### PR TITLE
Add TransitionEvent bindings to DOM package

### DIFF
--- a/src/dom/dom.mbti
+++ b/src/dom/dom.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "Yoorkin/rabbit-tea/dom"
 
 import(
@@ -473,6 +474,13 @@ type TextTrackList
 
 type TimeRanges
 
+type TransitionEvent
+fn TransitionEvent::get_elapsed_time(Self) -> Double
+fn TransitionEvent::get_property_name(Self) -> String
+fn TransitionEvent::get_pseudo_element(Self) -> String
+impl IsEvent for TransitionEvent
+impl @js.Cast for TransitionEvent
+
 type UIEvent
 impl IsEvent for UIEvent
 impl IsUIEvent for UIEvent
@@ -566,6 +574,7 @@ pub trait IsEvent : @js.Cast {
   to_custom_event(Self) -> CustomEvent?
   to_drag_event(Self) -> DragEvent?
   to_wheel_event(Self) -> WheelEvent?
+  to_transition_event(Self) -> TransitionEvent?
 }
 
 pub trait IsEventTarget : @js.Cast {

--- a/src/dom/event.mbt
+++ b/src/dom/event.mbt
@@ -27,6 +27,7 @@ pub trait IsEvent: @js.Cast {
   to_custom_event(Self) -> CustomEvent? = _
   to_drag_event(Self) -> DragEvent? = _
   to_wheel_event(Self) -> WheelEvent? = _
+  to_transition_event(Self) -> TransitionEvent? = _
 }
 
 ///|
@@ -133,6 +134,11 @@ impl IsEvent with to_wheel_event(s) {
 }
 
 ///|
+impl IsEvent with to_transition_event(s) {
+  s |> js_identity |> ffi_to_transition_event |> _.to_option()
+}
+
+///|
 extern "js" fn ffi_event_target(x : @js.Value) -> EventTarget = "(self) => self.target"
 
 ///|
@@ -206,6 +212,12 @@ extern "js" fn ffi_to_drag_event(x : @js.Value) -> @js.Nullable[DragEvent] =
 ///|
 extern "js" fn ffi_to_wheel_event(x : @js.Value) -> @js.Nullable[WheelEvent] =
   #| (e) => e instanceof WheelEvent ? e : null
+
+///|
+extern "js" fn ffi_to_transition_event(
+  x : @js.Value
+) -> @js.Nullable[TransitionEvent] =
+  #| (e) => e instanceof TransitionEvent ? e : null
 
 ///|
 extern "js" fn ffi_to_event(x : @js.Value) -> @js.Nullable[Event] =

--- a/src/dom/transition_event.mbt
+++ b/src/dom/transition_event.mbt
@@ -1,0 +1,25 @@
+///| https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent
+#external
+type TransitionEvent
+
+///|
+pub impl IsEvent for TransitionEvent
+
+///|
+pub impl @js.Cast for TransitionEvent with into(value) {
+  value |> ffi_to_transition_event |> _.to_option()
+}
+
+///|
+pub impl @js.Cast for TransitionEvent with from(value) {
+  value |> js_identity
+}
+
+///|
+pub extern "js" fn TransitionEvent::get_property_name(self : Self) -> String = "(e) => e.propertyName"
+
+///|
+pub extern "js" fn TransitionEvent::get_elapsed_time(self : Self) -> Double = "(e) => e.elapsedTime"
+
+///|
+pub extern "js" fn TransitionEvent::get_pseudo_element(self : Self) -> String = "(e) => e.pseudoElement"


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Implements TransitionEvent interface following MDN specification
- Adds get_property_name(), get_elapsed_time(), and get_pseudo_element() methods
- Properly implements IsEvent trait for integration with event system
- Adds to_transition_event() conversion method to IsEvent trait
- Updates .mbti interface with TransitionEvent exports
- Follows existing patterns from KeyboardEvent and AnimationEvent
- Supports all CSS transition events: transitionstart, transitionend, transitioncancel, transitionrun