### PR TITLE
Fix async function error annotation in command.mbt

### DIFF
--- a/src/cmd/command.mbt
+++ b/src/cmd/command.mbt
@@ -86,7 +86,7 @@ pub fn[M] task(message : M) -> Cmd[M] {
 /// 
 /// The async function `f` will be called, and the result will be wrapped in a 
 /// message `msg`, then trigger another update with this message.
-pub fn[A, M] perform(msg : (A) -> M, f : async () -> A) -> Cmd[M] {
+pub fn[A, M] perform(msg : (A) -> M, f : async () -> A noraise) -> Cmd[M] {
   Cmd(events => @js.async_run(() => events.trigger_update(msg(f()))))
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Add missing 'noraise' annotation to the async function parameter in the perform() function. This resolves the compiler warning about async functions requiring error annotations.