### PR TITLE
Fix async function error annotation in perform function

### DIFF
--- a/src/cmd/cmd.mbti
+++ b/src/cmd/cmd.mbti
@@ -12,7 +12,7 @@ fn[M] batch(Array[Cmd[M]]) -> Cmd[M]
 
 fn[M] none() -> Cmd[M]
 
-fn[A, M] perform((A) -> M, async () -> A) -> Cmd[M]
+fn[A, M] perform((A) -> M, async () -> A noraise) -> Cmd[M]
 
 fn[M] task(M) -> Cmd[M]
 

--- a/src/rabbit-tea.mbti
+++ b/src/rabbit-tea.mbti
@@ -16,7 +16,7 @@ fn[M] batch(Array[@cmd.Cmd[M]]) -> @cmd.Cmd[M]
 
 fn[M] none() -> @cmd.Cmd[M]
 
-fn[A, M] perform((A) -> M, async () -> A) -> @cmd.Cmd[M]
+fn[A, M] perform((A) -> M, async () -> A noraise) -> @cmd.Cmd[M]
 
 fn[Model, Message] startup(model~ : Model, update~ : (Message, Model) -> (@cmd.Cmd[Message], Model), view~ : (Model) -> @html.Html[Message], mount~ : String = ..) -> Unit
 


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

The perform function in src/cmd/command.mbt was correctly implemented with the 
`noraise` annotation, but the generated MBTI files were missing this annotation.
This caused error [0054] when users tried to use the perform function.

Fixed by manually updating the MBTI files to include the `noraise` annotation
in the function signature, making it consistent with the implementation.

The issue appears to be a bug in the MoonBit toolchain where `moon info` 
doesn't properly include the `noraise` annotation in the generated interface files.