### PR TITLE
feat: inline svg

### DIFF
--- a/src/svg/pkg.generated.mbti
+++ b/src/svg/pkg.generated.mbti
@@ -34,9 +34,7 @@ fn[M] property(String, @variant.Variant) -> Attribute[M]
 
 fn[M] rect(id? : String, class? : String, style? : Array[String], x~ : Int, y~ : Int, width~ : Int, height~ : Int, rx? : Int, ry? : Int, fill? : String, stroke? : String, stroke_width? : Int) -> Svg[M]
 
-fn[M] svg(Array[Attribute[M]], Array[Svg[M]]) -> @html.Html[M]
-
-fn[M] svg_element(id? : String, class? : String, style? : Array[String], width~ : Int, height~ : Int, Array[Svg[M]], view_box? : String, xmlns? : String) -> @html.Html[M]
+fn[M] svg(Array[Attribute[M]], Array[Svg[M]], id? : String, class? : String, style? : Array[String], width? : Int, height? : Int, view_box? : String, xmlns? : String) -> @html.Html[M]
 
 fn[M] svg_text(id? : String, class? : String, style? : Array[String], x~ : Int, y~ : Int, text~ : String, dx? : Int, dy? : Int, rotate? : String, length_adjust? : String, text_length? : Int) -> Svg[M]
 
@@ -48,9 +46,11 @@ fn[M] view(id? : String, class? : String, style? : Array[String], view_box? : St
 
 // Types and methods
 pub(all) struct Attribute[M](@vdom.Attribute[M])
+#deprecated
 fn[M] Attribute::inner(Self[M]) -> @vdom.Attribute[M]
 
 pub(all) struct Svg[M](@vdom.Node[M])
+#deprecated
 fn[M] Svg::inner(Self[M]) -> @vdom.Node[M]
 
 // Type aliases

--- a/src/svg/svg.mbt
+++ b/src/svg/svg.mbt
@@ -32,7 +32,40 @@ pub fn[M] property(key : String, value : @variant.Variant) -> Attribute[M] {
 pub fn[M] svg(
   attrs : Array[Attribute[M]],
   children : Array[Svg[M]],
+  // common attributes
+  id? : String,
+  class? : String,
+  style? : Array[String],
+  // required
+  width? : Int,
+  height? : Int,
+  // optional
+  view_box? : String,
+  xmlns? : String,
 ) -> @html.Html[M] {
+  let attrs : Array[Attribute[M]] = [..attrs]
+  if width is Some(val) {
+    attrs.push(attribute("width", val.to_string()))
+  }
+  if height is Some(val) {
+    attrs.push(attribute("height", val.to_string()))
+  }
+  if id is Some(val) {
+    attrs.push(attribute("id", val))
+  }
+  if class is Some(val) {
+    attrs.push(attribute("class", val))
+  }
+  if style is Some(val) {
+    attrs.push(attribute("style", val.join(";")))
+  }
+  let attrs : Array[Attribute[M]] = []
+  if view_box is Some(val) {
+    attrs.push(attribute("viewBox", val))
+  }
+  if xmlns is Some(val) {
+    attrs.push(attribute("xmlns", val))
+  }
   @vdom.node_ns(
     @dom.namespace_svg,
     "svg",
@@ -76,44 +109,6 @@ fn[M] common_svg_node(
     attrs.push(attribute("style", val.join(";")))
   }
   node(tag_name, attrs, children.unwrap_or([]))
-}
-
-///|
-/// <svg > element
-pub fn[M] svg_element(
-  // common attributes
-  id? : String,
-  class? : String,
-  style? : Array[String],
-  // required
-  width~ : Int,
-  height~ : Int,
-  children : Array[Svg[M]],
-  // optional
-  view_box? : String,
-  xmlns? : String,
-) -> @html.Html[M] {
-  let attrs : Array[Attribute[M]] = []
-  if id is Some(val) {
-    attrs.push(attribute("id", val))
-  }
-  if class is Some(val) {
-    attrs.push(attribute("class", val))
-  }
-  if style is Some(val) {
-    attrs.push(attribute("style", val.join(";")))
-  }
-  let attrs : Array[Attribute[M]] = [
-    attribute("width", width.to_string()),
-    attribute("height", height.to_string()),
-  ]
-  if view_box is Some(val) {
-    attrs.push(attribute("viewBox", val))
-  }
-  if xmlns is Some(val) {
-    attrs.push(attribute("xmlns", val))
-  }
-  svg(attrs, children)
 }
 
 ///|


### PR DESCRIPTION
Added svg elements in `<svg>...</svg>`

https://developer.mozilla.org/en-US/docs/Web/SVG

```mbt
fnalias @svg.(svg_element, rect, circle, svg_text, g, line)

///|
fn view(model : Model) -> Html[Msg] {
  div([
    svg_element(width=300, height=300, [
      rect(x=model.counter, y=10, width=50, height=50, fill="red"),
      circle(
        cx=model.player.position.x,
        cy=model.player.position.y,
        r=30,
        fill="blue",
      ),
      svg_text(x=10, y=80, text="Hello \{model.counter}"),
      g([
        rect(x=100, y=0, width=50, height=50, fill="blue"),
        svg_text(x=0, y=70, text="World"),
        circle(cx=125, cy=125, r=30, fill="green"),
      ]),
      line(x1=200, y1=200, x2=250, y2=250, stroke="black", stroke_width=5),
    ]),
  ])
}
```

<img width="401" height="347" alt="image" src="https://github.com/user-attachments/assets/0643b06c-39d9-4d67-888f-57a5b1201230" />

## NOTE

I use `svg_element` instead of `svg()`. This is used for `svg.from_string`