### PR TITLE
Fix: type/trait App is not found

### DIFF
--- a/rabbita/top.mbt
+++ b/rabbita/top.mbt
@@ -69,6 +69,7 @@ pub fn App::with_route(
 ///|
 /// Registers a one-shot command to be queued when `mount` runs.
 /// This API is still evolving and may change in future releases.
+#cfg(target="js")
 #internal(unstable, "Experimental API")
 pub fn App::with_init(self : Self, cmd : Cmd) -> Unit {
   self.init_cmd = Some(cmd)


### PR DESCRIPTION
Hi,

When trying to build SSR example, I got this error:

```
cd example/SSR
npm install
npm run build
moon run ./main --target native

Error: [4024]
    ╭─[ rabbita/rabbita/top.mbt:73:8 ]
    │
 73 │ pub fn App::with_init(self : Self, cmd : Cmd) -> Unit {
    │        ─┬─  
    │         ╰─── The type/trait App is not found.
────╯
```

This fn was missing `#cfg(target="js")` like the other ones