### PR TITLE
Fix: SSR ex: value identifier server_main is unbound

### DIFF
--- a/examples/SSR/main/server.mbt
+++ b/examples/SSR/main/server.mbt
@@ -70,7 +70,7 @@ let path : String = match @env.args() {
 }
 
 ///|
-#cfg(not(target="js"))
+#cfg(target="native")
 async fn main {
   let app = @rabbita.simple_cell(model=0, update~, view~)
   let html =


### PR DESCRIPTION
The project was building without any problem, but VSCode was complaining about `server_main` not being found

![value_unbound](https://github.com/user-attachments/assets/01ab1735-8e13-4834-8395-64c77d5c64d3)

I think since `#cfg(not(target="js"))` has a wider scope than just `target="native"` like on its definition, it says it can't find it