### PR TITLE
fix(security): reject path traversal via `.." in SSR server and warren VFS

### DIFF
--- a/examples/SSR/main/server.mbt
+++ b/examples/SSR/main/server.mbt
@@ -54,7 +54,7 @@ pub async fn server_main(
       return
     } else {
       let file_path = "\{path}/dist\{req_path}"
-      guard req_path.contains("..") || @fs.exists(file_path) else {
+      guard !req_path.contains("..") && @fs.exists(file_path) else {
         serve_404(conn)
         return
       }

--- a/warren/vfs/vfs.mbt
+++ b/warren/vfs/vfs.mbt
@@ -112,6 +112,7 @@ pub async fn VirtualFileSystem::read(self : Self, path : String) -> &@io.Data? {
     .map(part => part.to_owned())
     .filter(part => part != "")
     .collect()
+  guard parts.iter().all(fn(p) { p != ".." }) else { return None }
   let (current, i) = match parts {
     [] =>
       match self.roots.get("") {


### PR DESCRIPTION
## Summary

- **SSR example server** (`examples/SSR/main/server.mbt:57`): the `guard` condition was inverted — `req_path.contains("..")` made the guard **pass** instead of fail, so requests like `GET /../../etc/passwd` bypassed the check and served arbitrary files (HTTP 200).
- **Warren dev server VFS** (`warren/vfs/vfs.mbt`): no `..` filtering at all. `SourcePath::join` correctly resolves `..` upward via `normalize()`, which allows a crafted URL to escape the `public/` directory.

Both are one-line fixes:

```diff
- guard req_path.contains("..") || @fs.exists(file_path) else {
+ guard !req_path.contains("..") && @fs.exists(file_path) else {
```

```diff
  .collect()
+ guard parts.iter().all(fn(p) { p != ".." }) else { return None }
  let (current, i) = match parts {
```

## Reproduction

```bash
# SSR server
cd examples/SSR && moon build --target native
./_build/.../main.exe .
curl --path-as-is http://localhost:8006/../../../../../../etc/passwd
# → HTTP 200, returns /etc/passwd

# Warren dev server
cd examples/counter
warren dev --port 14300
curl --noproxy '*' --path-as-is http://127.0.0.1:14300/../../../../../../etc/passwd
# → HTTP 200, returns /etc/passwd
```

After fix, both return 404. Normal requests are unaffected.

## Test plan

- [x] `moon check` — 0 warnings, 0 errors
- [x] Path traversal `GET /../../etc/passwd` → 404 (SSR)
- [x] Path traversal `GET /../../etc/passwd` → 404 (Warren)
- [x] Normal `GET /` → 200 with correct HTML (SSR)
- [x] Normal `GET /` → 200 with correct HTML (Warren)