### PR TITLE
rui: components library

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,18 +44,18 @@ jobs:
       - name: moon check
         run: |
           cd rabbita
-          moon check --target js --deny-warn
+          moon check . --target js --deny-warn
 
       - name: moon info
         run: |
           cd rabbita
-          moon info --target js
+          moon info . --target js
           git diff --exit-code
 
       - name: format diff
         run: |
           cd rabbita
-          moon fmt
+          moon fmt .
           git diff --exit-code
 
   typo-check:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -9,6 +9,7 @@ on:
       - 'doc/**'
       - 'examples/**'
       - 'rabbita/**'
+      - 'rui/**'
       - 'warren/**'
       - 'utils/shiki/**'
       - 'moon.work'

--- a/moon.work
+++ b/moon.work
@@ -14,4 +14,5 @@ members = [
   "./utils/shiki",
   "./website/homepage",
   "./website/playground",
+  "./rui",
 ]

--- a/rabbita/dom/Document.mbt
+++ b/rabbita/dom/Document.mbt
@@ -127,6 +127,27 @@ pub extern "js" fn Document::query_selector_all(
 ) -> NodeList = "(self,selectors) => self.querySelectorAll(selectors)"
 
 ///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
+#cfg(target="js")
+pub fn Document::get_active_element(self : Self) -> Element? {
+  ffi_document_get_active_element(self).to_option()
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Document/body
+#cfg(target="js")
+pub fn Document::get_body(self : Self) -> HTMLElement? {
+  ffi_document_get_body(self).to_option()
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement
+#cfg(target="js")
+pub fn Document::get_document_element(self : Self) -> Element? {
+  ffi_document_get_document_element(self).to_option()
+}
+
+///|
 /// https://developer.mozilla.org/en-US/docs/Web/API/Document/hidden
 #cfg(target="js")
 pub extern "js" fn Document::hidden(self : Self) -> Bool = "(doc) => doc.hidden"
@@ -134,3 +155,21 @@ pub extern "js" fn Document::hidden(self : Self) -> Bool = "(doc) => doc.hidden"
 ///|
 #cfg(target="js")
 pub extern "js" fn Document::to_node(self : Self) -> Node = "(x) => x"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_document_get_active_element(
+  doc : Document,
+) -> @js.Nullable[Element] = "(doc) => doc.activeElement"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_document_get_body(
+  doc : Document,
+) -> @js.Nullable[HTMLElement] = "(doc) => doc.body"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_document_get_document_element(
+  doc : Document,
+) -> @js.Nullable[Element] = "(doc) => doc.documentElement"

--- a/rabbita/dom/animation.mbt
+++ b/rabbita/dom/animation.mbt
@@ -1,0 +1,34 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Animation
+#cfg(target="js")
+#external
+type Animation
+
+///|
+#cfg(target="js")
+pub impl IsEventTarget for Animation
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for Animation with fn into(value) {
+  value |> ffi_to_animation |> animation => { animation.to_option() }
+}
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for Animation with fn from(value) {
+  value |> js_identity
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Animation/finish
+#cfg(target="js")
+pub extern "js" fn Animation::finish(self : Self) -> Unit = "(self) => self.finish()"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_to_animation(value : @js.Value) -> @js.Nullable[Animation] =
+  #| (value) => typeof Animation !== "undefined"
+  #|   && value instanceof Animation
+  #|   ? value
+  #|   : null

--- a/rabbita/dom/core_primitives_wbtest.mbt
+++ b/rabbita/dom/core_primitives_wbtest.mbt
@@ -1,0 +1,523 @@
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_element() -> Element =
+  #| () => {
+  #|   const selected = { nodeType: 1, id: "selected" }
+  #|   const parent = { nodeType: 1, id: "parent" }
+  #|   const captured = new Set()
+  #|   return {
+  #|     nodeType: 1,
+  #|     children: [selected],
+  #|     querySelector: selector => selector === ".hit" ? selected : null,
+  #|     querySelectorAll: selector => selector === ".hit" ? [selected] : [],
+  #|     closest: selector => selector === ".root" ? parent : null,
+  #|     matches: selector => selector === ".root",
+  #|     contains: node => node === selected,
+  #|     hasAttribute: name => name === "data-ready",
+  #|     getAttribute: name => name === "data-ready" ? "yes" : null,
+  #|     parentElement: parent,
+  #|     isConnected: true,
+  #|     clientWidth: 320,
+  #|     clientHeight: 180,
+  #|     clientLeft: 2,
+  #|     clientTop: 3,
+  #|     getClientRects: () => [{}, {}],
+  #|     setPointerCapture: id => {
+  #|       if (id < 0) throw new Error("invalid pointer")
+  #|       captured.add(id)
+  #|     },
+  #|     releasePointerCapture: id => {
+  #|       if (!captured.has(id)) throw new Error("missing pointer")
+  #|       captured.delete(id)
+  #|     },
+  #|     hasPointerCapture: id => captured.has(id),
+  #|     scrollIntoView(options) { this.__scrollOptions = options },
+  #|     getAnimations: () => [{ finish() { this.finished = true } }],
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_scroll_options(element : Element) -> String =
+  #| element => {
+  #|   const options = element.__scrollOptions
+  #|   return [options.behavior, options.block, options.inline, options.container].join(",")
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_document() -> Document =
+  #| () => ({
+  #|   activeElement: { nodeType: 1, id: "active" },
+  #|   body: { nodeType: 1, id: "body" },
+  #|   documentElement: { nodeType: 1, id: "document-element" },
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_event_target() -> EventTarget =
+  #| () => ({
+  #|   addEventListener(type, listener, options) {
+  #|     this.__listenerOptions = ["add", type, options.capture, options.passive, options.once]
+  #|   },
+  #|   removeEventListener(type, listener, options) {
+  #|     this.__listenerOptions = ["remove", type, options.capture]
+  #|   },
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_listener_options(
+  target : EventTarget,
+) -> String = "target => target.__listenerOptions.join(',')"
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_html_element() -> HTMLElement =
+  #| () => ({
+  #|   nodeType: 1,
+  #|   focus(options) { this.__focusOptions = options },
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_popover_element() -> HTMLElement =
+  #| () => ({
+  #|   nodeType: 1,
+  #|   __open: false,
+  #|   showPopover() {
+  #|     this.__open = true
+  #|   },
+  #|   hidePopover() {
+  #|     this.__open = false
+  #|   },
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_popover_open(element : HTMLElement) -> Bool = "element => element.__open"
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_focus_options(
+  element : HTMLElement,
+) -> String =
+  #| element => [element.__focusOptions.preventScroll, element.__focusOptions.focusVisible].join(",")
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_focus_event() -> FocusEvent = "() => ({ relatedTarget: null })"
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_mouse_event() -> MouseEvent = "() => ({ relatedTarget: null })"
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_event_options(event : Event) -> String =
+  #| event => [event.type, event.bubbles, event.cancelable, event.composed].join(",")
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_input() -> HTMLInputElement = "() => ({ nodeType: 1, value: 'before' })"
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_window() -> Window =
+  #| () => ({
+  #|   setTimeout(callback, ms) {
+  #|     this.__timeoutDelay = ms
+  #|     callback()
+  #|     return ms + 1
+  #|   },
+  #|   clearTimeout(id) { this.__clearedTimeout = id },
+  #|   queueMicrotask(callback) { callback() },
+  #|   performance: { now: () => 123.5 },
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_cleared_timeout(window_ : Window) -> Int = "window => window.__clearedTimeout"
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_image_target() -> EventTarget =
+  #| () => {
+  #|   globalThis.__domTestHTMLImageElement = globalThis.HTMLImageElement
+  #|   globalThis.HTMLImageElement = class HTMLImageElement extends EventTarget {
+  #|     constructor() {
+  #|       super()
+  #|       this.complete = true
+  #|       this.naturalWidth = 640
+  #|     }
+  #|   }
+  #|   return new HTMLImageElement()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_restore_image_type() -> Unit =
+  #| () => {
+  #|   if (globalThis.__domTestHTMLImageElement === undefined) delete globalThis.HTMLImageElement
+  #|   else globalThis.HTMLImageElement = globalThis.__domTestHTMLImageElement
+  #|   delete globalThis.__domTestHTMLImageElement
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_subtype_events() -> Array[Event] =
+  #| () => {
+  #|   globalThis.__domTestPointerEvent = globalThis.PointerEvent
+  #|   globalThis.__domTestTransitionEvent = globalThis.TransitionEvent
+  #|   globalThis.__domTestToggleEvent = globalThis.ToggleEvent
+  #|   globalThis.PointerEvent = class PointerEvent {
+  #|     constructor() {
+  #|       this.pointerId = 7
+  #|       this.width = 8.5
+  #|       this.height = 9.5
+  #|       this.pressure = 0.75
+  #|       this.tangentialPressure = 0.25
+  #|       this.tiltX = 10
+  #|       this.tiltY = 11
+  #|       this.twist = 12
+  #|       this.altitudeAngle = 0.5
+  #|       this.azimuthAngle = 1.5
+  #|       this.pointerType = "pen"
+  #|       this.isPrimary = true
+  #|     }
+  #|   }
+  #|   globalThis.TransitionEvent = class TransitionEvent {
+  #|     constructor() {
+  #|       this.propertyName = "opacity"
+  #|       this.elapsedTime = 0.2
+  #|       this.pseudoElement = "::before"
+  #|     }
+  #|   }
+  #|   globalThis.ToggleEvent = class ToggleEvent {
+  #|     constructor() {
+  #|       this.oldState = "closed"
+  #|       this.newState = "open"
+  #|     }
+  #|   }
+  #|   return [new PointerEvent(), new TransitionEvent(), new ToggleEvent()]
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_restore_event_types() -> Unit =
+  #| () => {
+  #|   if (globalThis.__domTestPointerEvent === undefined) delete globalThis.PointerEvent
+  #|   else globalThis.PointerEvent = globalThis.__domTestPointerEvent
+  #|   if (globalThis.__domTestTransitionEvent === undefined) delete globalThis.TransitionEvent
+  #|   else globalThis.TransitionEvent = globalThis.__domTestTransitionEvent
+  #|   if (globalThis.__domTestToggleEvent === undefined) delete globalThis.ToggleEvent
+  #|   else globalThis.ToggleEvent = globalThis.__domTestToggleEvent
+  #|   delete globalThis.__domTestPointerEvent
+  #|   delete globalThis.__domTestTransitionEvent
+  #|   delete globalThis.__domTestToggleEvent
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_platform_window() -> Window =
+  #| () => {
+  #|   const names = [
+  #|     "CSS",
+  #|     "ResizeObserver",
+  #|     "MutationObserver",
+  #|     "IntersectionObserver",
+  #|   ]
+  #|   globalThis.__domTestPlatformGlobals = Object.fromEntries(names.map(name => [
+  #|     name,
+  #|     {
+  #|       had: Object.prototype.hasOwnProperty.call(globalThis, name),
+  #|       value: globalThis[name],
+  #|     },
+  #|   ]))
+  #|   globalThis.__domTestObserverLog = []
+  #|   globalThis.CSS = {
+  #|     supports: (property, value) => property === "position-anchor" && value === "--trigger",
+  #|   }
+  #|   globalThis.ResizeObserver = class ResizeObserver {
+  #|     constructor(callback) { this.callback = callback }
+  #|     observe() { globalThis.__domTestObserverLog.push("resize:observe") }
+  #|     unobserve() { globalThis.__domTestObserverLog.push("resize:unobserve") }
+  #|     disconnect() { globalThis.__domTestObserverLog.push("resize:disconnect") }
+  #|   }
+  #|   globalThis.MutationObserver = class MutationObserver {
+  #|     constructor(callback) { this.callback = callback }
+  #|     observe(target, options) {
+  #|       const option = name => Object.prototype.hasOwnProperty.call(options, name)
+  #|         ? options[name]
+  #|         : "omitted"
+  #|       const attributeFilter = option("attributeFilter")
+  #|       globalThis.__domTestObserverLog.push(
+  #|         `mutation:${option("attributes")}:${option("childList")}:${option("subtree")}:${attributeFilter === "omitted" ? attributeFilter : attributeFilter.join("|")}:${option("attributeOldValue")}:${option("characterData")}:${option("characterDataOldValue")}`,
+  #|       )
+  #|     }
+  #|     disconnect() { globalThis.__domTestObserverLog.push("mutation:disconnect") }
+  #|   }
+  #|   globalThis.IntersectionObserver = class IntersectionObserver {
+  #|     constructor(callback, options) {
+  #|       this.callback = callback
+  #|       const thresholds = options === undefined ? null : options.threshold
+  #|       if (thresholds !== null && thresholds.some(value => value < 0 || value > 1)) {
+  #|         throw new RangeError("threshold out of range")
+  #|       }
+  #|       const threshold = thresholds === null ? "default" : thresholds.join("|")
+  #|       globalThis.__domTestObserverLog.push(`intersection:${threshold}`)
+  #|     }
+  #|     observe() { globalThis.__domTestObserverLog.push("intersection:observe") }
+  #|     unobserve() { globalThis.__domTestObserverLog.push("intersection:unobserve") }
+  #|     disconnect() { globalThis.__domTestObserverLog.push("intersection:disconnect") }
+  #|   }
+  #|   const visualViewport = {
+  #|     width: 640,
+  #|     height: 480,
+  #|     offsetLeft: 12,
+  #|     offsetTop: 18,
+  #|     addEventListener() {},
+  #|     removeEventListener() {},
+  #|     dispatchEvent() { return true },
+  #|   }
+  #|   return {
+  #|     visualViewport,
+  #|     matchMedia(query) {
+  #|       return {
+  #|         matches: query === "(reduce)",
+  #|         addEventListener() {},
+  #|         removeEventListener() {},
+  #|         dispatchEvent() { return true },
+  #|       }
+  #|     },
+  #|     getComputedStyle() {
+  #|       return { getPropertyValue: property => property === "direction" ? "rtl" : "" }
+  #|     },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_observer_log() -> String =
+  #| () => globalThis.__domTestObserverLog.join(",")
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_mutation_record() -> MutationRecord =
+  #| () => ({ attributeName: "data-open" })
+
+///|
+#cfg(target="js")
+extern "js" fn core_primitives_test_restore_platform_globals() -> Unit =
+  #| () => {
+  #|   for (const [name, saved] of Object.entries(globalThis.__domTestPlatformGlobals)) {
+  #|     if (saved.had) globalThis[name] = saved.value
+  #|     else delete globalThis[name]
+  #|   }
+  #|   delete globalThis.__domTestPlatformGlobals
+  #|   delete globalThis.__domTestObserverLog
+  #| }
+
+///|
+#cfg(target="js")
+test "element and document core primitives expose browser values" {
+  let element = core_primitives_test_element()
+  guard element.query_selector(".hit") is Some(selected) else {
+    fail("expected querySelector to find the child")
+  }
+  assert_eq(element.query_selector_all(".hit").length(), 1)
+  assert_true(element.query_selector(".missing") is None)
+  assert_true(element.closest(".root") is Some(_))
+  assert_true(element.matches(".root"))
+  assert_true(element.contains(selected.as_node()))
+  assert_true(element.has_attribute("data-ready"))
+  assert_eq(element.get_attribute("data-ready"), Some("yes"))
+  assert_eq(element.get_attribute("data-missing"), None)
+  assert_true(element.get_parent_element() is Some(_))
+  assert_true(element.get_is_connected())
+  assert_eq(element.get_client_width(), 320.0)
+  assert_eq(element.get_client_height(), 180.0)
+  assert_eq(element.get_client_left(), 2.0)
+  assert_eq(element.get_client_top(), 3.0)
+  assert_eq(element.get_client_rects().length(), 2)
+  element.set_pointer_capture(7)
+  assert_true(element.has_pointer_capture(7))
+  element.release_pointer_capture(7)
+  assert_false(element.has_pointer_capture(7))
+  element.scroll_into_view_with_options(
+    behavior="smooth",
+    block="center",
+    inline="end",
+    container="nearest",
+  )
+  assert_eq(
+    core_primitives_test_scroll_options(element),
+    "smooth,center,end,nearest",
+  )
+  let document = core_primitives_test_document()
+  assert_true(document.get_active_element() is Some(_))
+  assert_true(document.get_body() is Some(_))
+  assert_true(document.get_document_element() is Some(_))
+}
+
+///|
+#cfg(target="js")
+test "popover primitives mirror browser methods" {
+  let popover = core_primitives_test_popover_element()
+  popover.show_popover()
+  assert_true(core_primitives_test_popover_open(popover))
+  popover.hide_popover()
+  assert_false(core_primitives_test_popover_open(popover))
+}
+
+///|
+#cfg(target="js")
+test "event, listener, focus, and input primitives preserve optional values" {
+  let event = Event::new("ready", bubbles=true, cancelable=true, composed=true)
+  assert_eq(core_primitives_test_event_options(event), "ready,true,true,true")
+  assert_false(event.get_default_prevented())
+  event.prevent_default()
+  assert_true(event.get_default_prevented())
+  assert_true(event.get_time_stamp() >= 0.0)
+  assert_eq(event.composed_path().length(), 0)
+  event.stop_immediate_propagation()
+  let target = core_primitives_test_event_target()
+  let listener : Listener = _ => ()
+  target.add_event_listener_with_options(
+    "wheel",
+    listener,
+    capture=true,
+    passive=true,
+    once=true,
+  )
+  assert_eq(
+    core_primitives_test_listener_options(target),
+    "add,wheel,true,true,true",
+  )
+  target.remove_event_listener_with_options("wheel", listener, capture=true)
+  assert_eq(core_primitives_test_listener_options(target), "remove,wheel,true")
+  let focusable = core_primitives_test_html_element()
+  focusable.focus_with_options(prevent_scroll=true, focus_visible=true)
+  assert_eq(core_primitives_test_focus_options(focusable), "true,true")
+  focusable.focus_with_options()
+  assert_eq(core_primitives_test_focus_options(focusable), "false,")
+  assert_true(core_primitives_test_focus_event().related_target() is None)
+  assert_true(core_primitives_test_mouse_event().get_related_target() is None)
+  let input = core_primitives_test_input()
+  assert_eq(input.value(), "before")
+  input.set_value("after")
+  assert_eq(input.value(), "after")
+  let image_target = core_primitives_test_image_target()
+  guard image_target.to_html_image_element() is Some(image) else {
+    fail("expected HTMLImageElement conversion")
+  }
+  assert_true(image.get_complete())
+  assert_eq(image.get_natural_width(), 640.0)
+  let _ : EventTarget = image.as_event_target()
+  core_primitives_test_restore_image_type()
+}
+
+///|
+#cfg(target="js")
+test "pointer, transition, and toggle event conversions expose subtype fields" {
+  let events = core_primitives_test_subtype_events()
+  guard events[0].to_pointer_event() is Some(pointer) else {
+    fail("expected PointerEvent conversion")
+  }
+  assert_eq(pointer.get_pointer_id(), 7)
+  assert_eq(pointer.get_width(), 8.5)
+  assert_eq(pointer.get_pressure(), 0.75)
+  assert_eq(pointer.get_pointer_type(), "pen")
+  assert_true(pointer.get_is_primary())
+  let transition_event : TransitionEvent? = @js.Cast::into(
+    @js.Value::cast_from(events[1]),
+  )
+  guard transition_event is Some(transition) else {
+    fail("expected TransitionEvent conversion")
+  }
+  assert_eq(transition.get_property_name(), "opacity")
+  assert_eq(transition.get_elapsed_time(), 0.2)
+  assert_eq(transition.get_pseudo_element(), "::before")
+  let toggle_event : ToggleEvent? = @js.Cast::into(
+    @js.Value::cast_from(events[2]),
+  )
+  guard toggle_event is Some(toggle) else {
+    fail("expected ToggleEvent conversion")
+  }
+  assert_eq(toggle.get_old_state(), "closed")
+  assert_eq(toggle.get_new_state(), "open")
+  core_primitives_test_restore_event_types()
+}
+
+///|
+#cfg(target="js")
+test "window scheduling and performance primitives mirror browser APIs" {
+  let window = core_primitives_test_window()
+  let timeout_called = [false]
+  let timeout_id = window.set_timeout(() => timeout_called[0] = true, 12)
+  assert_true(timeout_called[0])
+  assert_eq(timeout_id, 13)
+  window.clear_timeout(timeout_id)
+  assert_eq(core_primitives_test_cleared_timeout(window), 13)
+  let microtask_called = [false]
+  window.queue_microtask(() => microtask_called[0] = true)
+  assert_true(microtask_called[0])
+  assert_eq(window.get_performance().now(), 123.5)
+}
+
+///|
+#cfg(target="js")
+test "CSS, viewport, media, animation, and observer primitives mirror browser APIs" {
+  let window = core_primitives_test_platform_window()
+  assert_true(CSS::supports("position-anchor", "--trigger"))
+  assert_false(CSS::supports("unknown", "value"))
+  let element = core_primitives_test_element()
+  assert_eq(
+    window.get_computed_style(element).get_property_value("direction"),
+    "rtl",
+  )
+  guard window.get_visual_viewport() is Some(viewport) else {
+    fail("expected visual viewport")
+  }
+  assert_eq(viewport.get_width(), 640.0)
+  assert_eq(viewport.get_height(), 480.0)
+  assert_eq(viewport.get_offset_left(), 12.0)
+  assert_eq(viewport.get_offset_top(), 18.0)
+  let media = window.match_media("(reduce)")
+  assert_true(media.get_matches())
+  let animations = element.get_animations()
+  assert_eq(animations.length(), 1)
+  animations[0].finish()
+  let resize = ResizeObserver::new((_, _) => ())
+  resize.observe(element)
+  resize.unobserve(element)
+  resize.disconnect()
+  let mutation = MutationObserver::new((_, _) => ())
+  mutation.observe(element.as_node(), child_list=true, subtree=true, attribute_filter=[
+    "data-open", "aria-expanded",
+  ])
+  mutation.observe(
+    element.as_node(),
+    attributes=false,
+    child_list=true,
+    attribute_old_value=false,
+    character_data=true,
+    character_data_old_value=true,
+  )
+  mutation.disconnect()
+  assert_eq(
+    core_primitives_test_mutation_record().get_attribute_name(),
+    Some("data-open"),
+  )
+  let intersection = IntersectionObserver::new((_, _) => (), threshold=[
+    0.0, 1.0,
+  ])
+  intersection.observe(element)
+  intersection.unobserve(element)
+  intersection.disconnect()
+  assert_eq(
+    core_primitives_test_observer_log(),
+    "resize:observe,resize:unobserve,resize:disconnect,mutation:omitted:true:true:data-open|aria-expanded:omitted:omitted:omitted,mutation:false:true:omitted:omitted:false:true:true,mutation:disconnect,intersection:0|1,intersection:observe,intersection:unobserve,intersection:disconnect",
+  )
+  core_primitives_test_restore_platform_globals()
+}

--- a/rabbita/dom/css.mbt
+++ b/rabbita/dom/css.mbt
@@ -1,0 +1,12 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/CSS
+#warnings("-unused_type_declaration")
+#cfg(target="js")
+#external
+type CSS
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/CSS/supports_static
+#cfg(target="js")
+pub extern "js" fn CSS::supports(property : String, value : String) -> Bool =
+  #| (property, value) => CSS.supports(property, value)

--- a/rabbita/dom/element.mbt
+++ b/rabbita/dom/element.mbt
@@ -8,13 +8,48 @@ type Element
 pub trait IsElement: IsNode {
   fn as_element(Self) -> Element = _
   fn get_children(Self) -> Array[Element] = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector
+  fn query_selector(Self, String) -> Element? = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll
+  fn query_selector_all(Self, String) -> Array[Element] = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+  fn closest(Self, String) -> Element? = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+  fn matches(Self, String) -> Bool = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttribute
+  fn has_attribute(Self, String) -> Bool = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth
+  fn get_client_width(Self) -> Double = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight
+  fn get_client_height(Self) -> Double = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft
+  fn get_client_left(Self) -> Double = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop
+  fn get_client_top(Self) -> Double = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/getClientRects
+  fn get_client_rects(Self) -> Array[DOMRect] = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
+  fn set_pointer_capture(Self, Int) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture
+  fn release_pointer_capture(Self, Int) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture
+  fn has_pointer_capture(Self, Int) -> Bool = _
   fn set_attribute(Self, String, String) -> Unit = _
-  fn get_attribute(Self, String) -> String = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute
+  fn get_attribute(Self, String) -> String? = _
   fn remove_attribute(Self, String) -> Unit = _
   fn set_property(Self, String, @js.Value) -> Unit = _
   fn get_property(Self, String) -> @js.Optional[String] = _
   fn remove_property(Self, String) -> Unit = _
   fn scroll_into_view(Self, behavior? : String) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+  fn scroll_into_view_with_options(
+    Self,
+    behavior? : String,
+    block? : String,
+    inline? : String,
+    container? : String,
+  ) -> Unit = _
   fn get_scroll_top(Self) -> Double = _
   fn set_scroll_top(Self, Double) -> Unit = _
   fn get_scroll_left(Self) -> Double = _
@@ -23,6 +58,8 @@ pub trait IsElement: IsNode {
   fn get_scroll_height(Self) -> Double = _
   fn set_inner_html(Self, String) -> Unit = _
   fn get_bounding_client_rect(Self) -> DOMRect = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations
+  fn get_animations(Self) -> Array[Animation] = _
 }
 
 ///|
@@ -63,6 +100,90 @@ impl IsElement with fn get_children(s) {
 
 ///|
 #cfg(target="js")
+impl IsElement with fn query_selector(s, selectors) {
+  s
+  |> js_identity
+  |> ffi_element_query_selector(selectors)
+  |> result => { result.to_option() }
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn query_selector_all(s, selectors) {
+  s |> js_identity |> ffi_element_query_selector_all(selectors)
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn closest(s, selectors) {
+  s
+  |> js_identity
+  |> ffi_element_closest(selectors)
+  |> result => { result.to_option() }
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn matches(s, selectors) {
+  s |> js_identity |> ffi_element_matches(selectors)
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn has_attribute(s, attr) {
+  s |> js_identity |> ffi_element_has_attribute(attr)
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn get_client_width(s) {
+  s |> js_identity |> ffi_element_get_client_width
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn get_client_height(s) {
+  s |> js_identity |> ffi_element_get_client_height
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn get_client_left(s) {
+  s |> js_identity |> ffi_element_get_client_left
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn get_client_top(s) {
+  s |> js_identity |> ffi_element_get_client_top
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn get_client_rects(s) {
+  s |> js_identity |> ffi_element_get_client_rects
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn set_pointer_capture(s, pointer_id) {
+  s |> js_identity |> ffi_element_set_pointer_capture(pointer_id)
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn release_pointer_capture(s, pointer_id) {
+  s |> js_identity |> ffi_element_release_pointer_capture(pointer_id)
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn has_pointer_capture(s, pointer_id) {
+  s |> js_identity |> ffi_element_has_pointer_capture(pointer_id)
+}
+
+///|
+#cfg(target="js")
 impl IsElement with fn set_attribute(s, attr, value) {
   s |> js_identity |> ffi_element_set_attribute(attr, value)
 }
@@ -70,7 +191,10 @@ impl IsElement with fn set_attribute(s, attr, value) {
 ///|
 #cfg(target="js")
 impl IsElement with fn get_attribute(s, attr) {
-  s |> js_identity |> ffi_element_get_attribute(attr)
+  s
+  |> js_identity
+  |> ffi_element_get_attribute(attr)
+  |> value => { value.to_option() }
 }
 
 ///|
@@ -105,6 +229,26 @@ impl IsElement with fn scroll_into_view(s, behavior?) {
     None => "auto"
   }
   s |> js_identity |> ffi_element_scroll_into_view(behavior)
+}
+
+///|
+#cfg(target="js")
+impl IsElement with fn scroll_into_view_with_options(
+  s,
+  behavior?,
+  block?,
+  inline?,
+  container?,
+) {
+  let behavior = behavior.unwrap_or("auto")
+  let block = block.unwrap_or("start")
+  let inline = inline.unwrap_or("nearest")
+  let container = container.unwrap_or("all")
+  s
+  |> js_identity
+  |> ffi_element_scroll_into_view_with_options(
+    behavior, block, inline, container,
+  )
 }
 
 ///|
@@ -157,8 +301,84 @@ impl IsElement with fn get_bounding_client_rect(s) {
 
 ///|
 #cfg(target="js")
+impl IsElement with fn get_animations(s) {
+  s |> js_identity |> ffi_element_get_animations
+}
+
+///|
+#cfg(target="js")
 extern "js" fn ffi_element_children(x : @js.Value) -> Array[Element] =
   #| (self) => self.children
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_query_selector(
+  x : @js.Value,
+  selectors : String,
+) -> @js.Nullable[Element] = "(self, selectors) => self.querySelector(selectors)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_query_selector_all(
+  x : @js.Value,
+  selectors : String,
+) -> Array[Element] = "(self, selectors) => Array.from(self.querySelectorAll(selectors))"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_closest(
+  x : @js.Value,
+  selectors : String,
+) -> @js.Nullable[Element] = "(self, selectors) => self.closest(selectors)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_matches(x : @js.Value, selectors : String) -> Bool = "(self, selectors) => self.matches(selectors)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_has_attribute(x : @js.Value, attr : String) -> Bool = "(self, attr) => self.hasAttribute(attr)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_get_client_width(x : @js.Value) -> Double = "(self) => self.clientWidth"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_get_client_height(x : @js.Value) -> Double = "(self) => self.clientHeight"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_get_client_left(x : @js.Value) -> Double = "(self) => self.clientLeft"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_get_client_top(x : @js.Value) -> Double = "(self) => self.clientTop"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_get_client_rects(x : @js.Value) -> Array[DOMRect] = "(self) => Array.from(self.getClientRects())"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_set_pointer_capture(
+  x : @js.Value,
+  pointer_id : Int,
+) -> Unit = "(self, pointerId) => self.setPointerCapture(pointerId)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_release_pointer_capture(
+  x : @js.Value,
+  pointer_id : Int,
+) -> Unit = "(self, pointerId) => self.releasePointerCapture(pointerId)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_has_pointer_capture(
+  x : @js.Value,
+  pointer_id : Int,
+) -> Bool = "(self, pointerId) => self.hasPointerCapture(pointerId)"
 
 // NOTE: The DOM tree also includes the TEXT_NODE, which is not an element.
 // Therefore, a vdom patch algorithm should not be based on the ffi above.
@@ -177,7 +397,7 @@ extern "js" fn ffi_element_set_attribute(
 extern "js" fn ffi_element_get_attribute(
   x : @js.Value,
   attr : String,
-) -> String = "(self,attr) => self.getAttribute(attr)"
+) -> @js.Nullable[String] = "(self,attr) => self.getAttribute(attr)"
 
 ///|
 #cfg(target="js")
@@ -208,6 +428,23 @@ extern "js" fn ffi_element_get_property(
 #cfg(target="js")
 extern "js" fn ffi_element_scroll_into_view(x : @js.Value, behavior : String) =
   #| (self, behavior) => self.scrollIntoView({ behavior })
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+#cfg(target="js")
+extern "js" fn ffi_element_scroll_into_view_with_options(
+  x : @js.Value,
+  behavior : String,
+  block : String,
+  inline : String,
+  container : String,
+) =
+  #| (self, behavior, block, inline, container) => self.scrollIntoView({
+  #|   behavior,
+  #|   block,
+  #|   inline,
+  #|   container,
+  #| })
 
 ///|
 /// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
@@ -247,3 +484,8 @@ extern "js" fn ffi_element_set_inner_html(x : @js.Value, html : String) -> Unit 
 #cfg(target="js")
 extern "js" fn ffi_element_get_bounding_client_rect(x : @js.Value) -> DOMRect =
   #| (self) => self.getBoundingClientRect()
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_element_get_animations(x : @js.Value) -> Array[Animation] =
+  #| (self) => Array.from(self.getAnimations())

--- a/rabbita/dom/event.mbt
+++ b/rabbita/dom/event.mbt
@@ -4,6 +4,21 @@
 type Event
 
 ///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Event/Event
+#cfg(target="js")
+pub extern "js" fn Event::new(
+  type_ : String,
+  bubbles? : Bool = false,
+  cancelable? : Bool = false,
+  composed? : Bool = false,
+) -> Self =
+  #| (type, bubbles, cancelable, composed) => new Event(type, {
+  #|   bubbles,
+  #|   cancelable,
+  #|   composed,
+  #| })
+
+///|
 #cfg(target="js")
 fn[A, B] js_identity(a : A) -> B {
   @js.Value::cast_from(a).cast()
@@ -14,12 +29,22 @@ fn[A, B] js_identity(a : A) -> B {
 pub trait IsEvent: @js.Cast {
   fn target(Self) -> EventTarget = _
   fn current_target(Self) -> @js.Nullable[EventTarget] = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Event/defaultPrevented
+  fn get_default_prevented(Self) -> Bool = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp
+  fn get_time_stamp(Self) -> DOMHighResTimeStamp = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
+  fn composed_path(Self) -> Array[EventTarget] = _
   fn prevent_default(Self) -> Unit = _
   fn stop_propagation(Self) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Event/stopImmediatePropagation
+  fn stop_immediate_propagation(Self) -> Unit = _
   fn as_event(Self) -> Event = _
   fn to_ui_event(Self) -> UIEvent? = _
   fn to_clipboard_event(Self) -> ClipboardEvent? = _
   fn to_mouse_event(Self) -> MouseEvent? = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
+  fn to_pointer_event(Self) -> PointerEvent? = _
   fn to_input_event(Self) -> InputEvent? = _
   fn to_focus_event(Self) -> FocusEvent? = _
   fn to_keyboard_event(Self) -> KeyboardEvent? = _
@@ -64,6 +89,24 @@ impl IsEvent with fn current_target(s) {
 
 ///|
 #cfg(target="js")
+impl IsEvent with fn get_default_prevented(s) {
+  s |> js_identity |> ffi_event_get_default_prevented
+}
+
+///|
+#cfg(target="js")
+impl IsEvent with fn get_time_stamp(s) {
+  s |> js_identity |> ffi_event_get_time_stamp
+}
+
+///|
+#cfg(target="js")
+impl IsEvent with fn composed_path(s) {
+  s |> js_identity |> ffi_event_composed_path
+}
+
+///|
+#cfg(target="js")
 impl IsEvent with fn prevent_default(s) {
   s.as_event() |> ffi_event_prevent_default
 }
@@ -72,6 +115,12 @@ impl IsEvent with fn prevent_default(s) {
 #cfg(target="js")
 impl IsEvent with fn stop_propagation(s) {
   s.as_event() |> ffi_event_stop_propagation
+}
+
+///|
+#cfg(target="js")
+impl IsEvent with fn stop_immediate_propagation(s) {
+  s.as_event() |> ffi_event_stop_immediate_propagation
 }
 
 ///|
@@ -96,6 +145,12 @@ impl IsEvent with fn to_clipboard_event(s) {
 #cfg(target="js")
 impl IsEvent with fn to_mouse_event(s) {
   s |> js_identity |> ffi_to_mouse_event |> y => { y.to_option() }
+}
+
+///|
+#cfg(target="js")
+impl IsEvent with fn to_pointer_event(s) {
+  s |> js_identity |> ffi_to_pointer_event |> y => { y.to_option() }
 }
 
 ///|
@@ -182,6 +237,18 @@ extern "js" fn ffi_event_current_target(
 
 ///|
 #cfg(target="js")
+extern "js" fn ffi_event_get_default_prevented(x : @js.Value) -> Bool = "(self) => self.defaultPrevented"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_event_get_time_stamp(x : @js.Value) -> DOMHighResTimeStamp = "(self) => self.timeStamp"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_event_composed_path(x : @js.Value) -> Array[EventTarget] = "(self) => self.composedPath()"
+
+///|
+#cfg(target="js")
 extern "js" fn ffi_to_ui_event(x : @js.Value) -> @js.Nullable[UIEvent] =
   #| (x) => x instanceof UIEvent ? x : null
 
@@ -202,8 +269,37 @@ extern "js" fn ffi_event_stop_propagation(x : Event) = "(self) => self.stopPropa
 
 ///|
 #cfg(target="js")
+extern "js" fn ffi_event_stop_immediate_propagation(x : Event) = "(self) => self.stopImmediatePropagation()"
+
+///|
+#cfg(target="js")
 extern "js" fn ffi_to_mouse_event(x : @js.Value) -> @js.Nullable[MouseEvent] =
   #| (e) => e instanceof MouseEvent ? e : null
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_to_pointer_event(
+  x : @js.Value,
+) -> @js.Nullable[PointerEvent] =
+  #| (e) => typeof PointerEvent !== "undefined" && e instanceof PointerEvent
+  #|   ? e
+  #|   : null
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_to_transition_event(
+  x : @js.Value,
+) -> @js.Nullable[TransitionEvent] =
+  #| (e) => typeof TransitionEvent !== "undefined" && e instanceof TransitionEvent
+  #|   ? e
+  #|   : null
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_to_toggle_event(x : @js.Value) -> @js.Nullable[ToggleEvent] =
+  #| (e) => typeof ToggleEvent !== "undefined" && e instanceof ToggleEvent
+  #|   ? e
+  #|   : null
 
 ///|
 #cfg(target="js")

--- a/rabbita/dom/event_target.mbt
+++ b/rabbita/dom/event_target.mbt
@@ -8,7 +8,18 @@ type EventTarget
 pub trait IsEventTarget: @js.Cast {
   fn as_event_target(Self) -> EventTarget = _
   fn add_event_listener(Self, String, Listener) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+  fn add_event_listener_with_options(
+    Self,
+    String,
+    Listener,
+    capture? : Bool,
+    passive? : Bool,
+    once? : Bool,
+  ) -> Unit = _
   fn remove_event_listener(Self, String, Listener) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
+  fn remove_event_listener_with_options(Self, String, Listener, capture? : Bool) -> Unit = _
   fn dispatch_event(Self, Event) -> Unit = _
   fn to_clipboard(Self) -> Clipboard? = _
   fn to_node(Self) -> Node? = _
@@ -59,8 +70,46 @@ impl IsEventTarget with fn add_event_listener(s, type_, callback) {
 
 ///|
 #cfg(target="js")
+impl IsEventTarget with fn add_event_listener_with_options(
+  s,
+  type_,
+  callback,
+  capture?,
+  passive?,
+  once?,
+) {
+  s
+  |> js_identity
+  |> ffi_add_event_listener_with_options(
+    type_,
+    callback,
+    capture.unwrap_or(false),
+    passive.unwrap_or(false),
+    once.unwrap_or(false),
+  )
+}
+
+///|
+#cfg(target="js")
 impl IsEventTarget with fn remove_event_listener(s, type_, callback) {
   s |> js_identity |> ffi_remove_event_listener(type_, callback)
+}
+
+///|
+#cfg(target="js")
+impl IsEventTarget with fn remove_event_listener_with_options(
+  s,
+  type_,
+  callback,
+  capture?,
+) {
+  s
+  |> js_identity
+  |> ffi_remove_event_listener_with_options(
+    type_,
+    callback,
+    capture.unwrap_or(false),
+  )
 }
 
 ///|
@@ -210,12 +259,42 @@ extern "js" fn ffi_add_event_listener(
 
 ///|
 #cfg(target="js")
+extern "js" fn ffi_add_event_listener_with_options(
+  x : @js.Value,
+  type_ : String,
+  callback : Listener,
+  capture : Bool,
+  passive : Bool,
+  once : Bool,
+) =
+  #| (target, type, listener, capture, passive, once) => target.addEventListener(
+  #|   type,
+  #|   listener,
+  #|   { capture, passive, once },
+  #| )
+
+///|
+#cfg(target="js")
 extern "js" fn ffi_remove_event_listener(
   x : @js.Value,
   type_ : String,
   callback : Listener,
 ) =
   #| (target, type, listener) => target.removeEventListener(type, listener)
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_remove_event_listener_with_options(
+  x : @js.Value,
+  type_ : String,
+  callback : Listener,
+  capture : Bool,
+) =
+  #| (target, type, listener, capture) => target.removeEventListener(
+  #|   type,
+  #|   listener,
+  #|   { capture },
+  #| )
 
 ///|
 #cfg(target="js")
@@ -287,7 +366,9 @@ extern "js" fn ffi_to_html_dialog_element(
 extern "js" fn ffi_to_html_image_element(
   x : @js.Value,
 ) -> @js.Nullable[HTMLImageElement] =
-  #| (x) => x instanceof HTMLImageElement ? x : null
+  #| (x) => typeof HTMLImageElement !== "undefined" && x instanceof HTMLImageElement
+  #|   ? x
+  #|   : null
 
 ///|
 #cfg(target="js")

--- a/rabbita/dom/focus_event.mbt
+++ b/rabbita/dom/focus_event.mbt
@@ -24,5 +24,14 @@ pub impl @js.Cast for FocusEvent with fn from(value) {
 }
 
 ///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget
 #cfg(target="js")
-pub extern "js" fn FocusEvent::related_target(self : Self) -> EventTarget = "(e) => e.relatedTarget"
+pub fn FocusEvent::related_target(self : Self) -> EventTarget? {
+  ffi_focus_event_related_target(self).to_option()
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_focus_event_related_target(
+  event : FocusEvent,
+) -> @js.Nullable[EventTarget] = "(event) => event.relatedTarget"

--- a/rabbita/dom/html_element.mbt
+++ b/rabbita/dom/html_element.mbt
@@ -83,8 +83,13 @@ pub trait IsHtmlElement: IsElement {
   fn blur(Self) -> Unit = _
   fn click(Self) -> Unit = _
   fn focus(Self) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+  fn focus_with_options(Self, prevent_scroll? : Bool, focus_visible? : Bool) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/hidePopover
   fn hide_popover(Self) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover
   fn show_popover(Self) -> Unit = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/togglePopover
   fn toggle_popover(Self, Bool?) -> Bool = _
 }
 
@@ -496,6 +501,20 @@ impl IsHtmlElement with fn focus(s) {
 
 ///|
 #cfg(target="js")
+impl IsHtmlElement with fn focus_with_options(
+  s,
+  prevent_scroll?,
+  focus_visible?,
+) {
+  ffi_html_element_focus_with_options(
+    s.as_html_element(),
+    prevent_scroll.unwrap_or(false),
+    @js.Optional::from_option(focus_visible),
+  )
+}
+
+///|
+#cfg(target="js")
 impl IsHtmlElement with fn hide_popover(s) {
   ffi_html_element_hide_popover(s.as_html_element())
 }
@@ -742,7 +761,7 @@ extern "js" fn ffi_html_element_set_outer_text(
 #cfg(target="js")
 extern "js" fn ffi_html_element_get_popover(
   s : HTMLElement,
-) -> @js.Nullable[String] = "(s) => s.popover"
+) -> @js.Nullable[String] = "(s) => s.popover ?? null"
 
 ///|
 #cfg(target="js")
@@ -851,6 +870,18 @@ extern "js" fn ffi_html_element_click(s : HTMLElement) -> Unit = "(s) => s.click
 ///|
 #cfg(target="js")
 extern "js" fn ffi_html_element_focus(s : HTMLElement) -> Unit = "(s) => s.focus()"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_html_element_focus_with_options(
+  s : HTMLElement,
+  prevent_scroll : Bool,
+  focus_visible : @js.Optional[Bool],
+) -> Unit =
+  #| (element, preventScroll, focusVisible) => {
+  #|   if (focusVisible === undefined) element.focus({ preventScroll })
+  #|   else element.focus({ preventScroll, focusVisible })
+  #| }
 
 ///|
 #cfg(target="js")

--- a/rabbita/dom/html_input_element.mbt
+++ b/rabbita/dom/html_input_element.mbt
@@ -34,3 +34,8 @@ pub impl IsHtmlElement for HTMLInputElement
 ///|
 #cfg(target="js")
 pub extern "js" fn HTMLInputElement::value(self : Self) -> String = "(self) => self.value"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/value
+#cfg(target="js")
+pub extern "js" fn HTMLInputElement::set_value(self : Self, value : String) = "(input, value) => input.value = value"

--- a/rabbita/dom/intersection_observer.mbt
+++ b/rabbita/dom/intersection_observer.mbt
@@ -1,0 +1,59 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
+#cfg(target="js")
+#external
+type IntersectionObserver
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry
+#cfg(target="js")
+#external
+type IntersectionObserverEntry
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver
+#cfg(target="js")
+pub fn IntersectionObserver::new(
+  callback : (Array[IntersectionObserverEntry], IntersectionObserver) -> Unit,
+  threshold? : Array[Double],
+) -> Self {
+  if threshold is Some(threshold) {
+    ffi_intersection_observer_new_with_threshold(callback, threshold)
+  } else {
+    ffi_intersection_observer_new(callback)
+  }
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/observe
+#cfg(target="js")
+pub extern "js" fn IntersectionObserver::observe(
+  self : Self,
+  target : Element,
+) -> Unit = "(self, target) => self.observe(target)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/unobserve
+#cfg(target="js")
+pub extern "js" fn IntersectionObserver::unobserve(
+  self : Self,
+  target : Element,
+) -> Unit = "(self, target) => self.unobserve(target)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/disconnect
+#cfg(target="js")
+pub extern "js" fn IntersectionObserver::disconnect(self : Self) -> Unit = "(self) => self.disconnect()"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_intersection_observer_new(
+  callback : (Array[IntersectionObserverEntry], IntersectionObserver) -> Unit,
+) -> IntersectionObserver = "(callback) => new IntersectionObserver(callback)"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_intersection_observer_new_with_threshold(
+  callback : (Array[IntersectionObserverEntry], IntersectionObserver) -> Unit,
+  threshold : Array[Double],
+) -> IntersectionObserver = "(callback, threshold) => new IntersectionObserver(callback, { threshold })"

--- a/rabbita/dom/media_query_list.mbt
+++ b/rabbita/dom/media_query_list.mbt
@@ -1,0 +1,44 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
+#cfg(target="js")
+#external
+type MediaQueryList
+
+///|
+#cfg(target="js")
+pub impl IsEventTarget for MediaQueryList
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for MediaQueryList with fn into(value) {
+  value |> ffi_to_media_query_list |> list => { list.to_option() }
+}
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for MediaQueryList with fn from(value) {
+  value |> js_identity
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
+#cfg(target="js")
+pub extern "js" fn Window::match_media(
+  self : Self,
+  query : String,
+) -> MediaQueryList = "(self, query) => self.matchMedia(query)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/matches
+#cfg(target="js")
+pub extern "js" fn MediaQueryList::get_matches(self : Self) -> Bool = "(self) => self.matches"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_to_media_query_list(
+  value : @js.Value,
+) -> @js.Nullable[MediaQueryList] =
+  #| (value) => typeof MediaQueryList !== "undefined"
+  #|   && value instanceof MediaQueryList
+  #|   ? value
+  #|   : null

--- a/rabbita/dom/mouse_event.mbt
+++ b/rabbita/dom/mouse_event.mbt
@@ -20,7 +20,8 @@ pub trait IsMouseEvent: IsUIEvent {
   fn get_offset_y(Self) -> Int = _
   fn get_page_x(Self) -> Int = _
   fn get_page_y(Self) -> Int = _
-  fn get_related_target(Self) -> EventTarget = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/relatedTarget
+  fn get_related_target(Self) -> EventTarget? = _
   fn get_screen_x(Self) -> Int = _
   fn get_screen_y(Self) -> Int = _
   fn get_shift_key(Self) -> Bool = _
@@ -140,7 +141,10 @@ impl IsMouseEvent with fn get_page_y(s) {
 ///|
 #cfg(target="js")
 impl IsMouseEvent with fn get_related_target(s) {
-  s |> js_identity |> ffi_mouse_event_related_target
+  s
+  |> js_identity
+  |> ffi_mouse_event_related_target
+  |> related_target => { related_target.to_option() }
 }
 
 ///|
@@ -245,7 +249,9 @@ extern "js" fn ffi_mouse_event_page_y(e : @js.Value) -> Int = "(e) => e.pageY"
 
 ///|
 #cfg(target="js")
-extern "js" fn ffi_mouse_event_related_target(e : @js.Value) -> EventTarget = "(e) => e.relatedTarget"
+extern "js" fn ffi_mouse_event_related_target(
+  e : @js.Value,
+) -> @js.Nullable[EventTarget] = "(e) => e.relatedTarget"
 
 ///|
 #cfg(target="js")

--- a/rabbita/dom/mutation_observer.mbt
+++ b/rabbita/dom/mutation_observer.mbt
@@ -1,0 +1,88 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+#cfg(target="js")
+#external
+type MutationObserver
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord
+#cfg(target="js")
+#external
+type MutationRecord
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/MutationObserver
+#cfg(target="js")
+pub extern "js" fn MutationObserver::new(
+  callback : (Array[MutationRecord], MutationObserver) -> Unit,
+) -> Self = "(callback) => new MutationObserver(callback)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe
+#cfg(target="js")
+pub fn MutationObserver::observe(
+  self : Self,
+  target : Node,
+  child_list? : Bool,
+  attributes? : Bool,
+  character_data? : Bool,
+  subtree? : Bool,
+  attribute_old_value? : Bool,
+  character_data_old_value? : Bool,
+  attribute_filter? : Array[String],
+) -> Unit {
+  ffi_mutation_observer_observe(
+    self,
+    target,
+    @js.Optional::from_option(child_list),
+    @js.Optional::from_option(attributes),
+    @js.Optional::from_option(character_data),
+    @js.Optional::from_option(subtree),
+    @js.Optional::from_option(attribute_old_value),
+    @js.Optional::from_option(character_data_old_value),
+    @js.Optional::from_option(attribute_filter),
+  )
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect
+#cfg(target="js")
+pub extern "js" fn MutationObserver::disconnect(self : Self) -> Unit = "(self) => self.disconnect()"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord/attributeName
+#cfg(target="js")
+pub fn MutationRecord::get_attribute_name(self : Self) -> String? {
+  ffi_mutation_record_get_attribute_name(self).to_option()
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mutation_observer_observe(
+  observer : MutationObserver,
+  target : Node,
+  child_list : @js.Optional[Bool],
+  attributes : @js.Optional[Bool],
+  character_data : @js.Optional[Bool],
+  subtree : @js.Optional[Bool],
+  attribute_old_value : @js.Optional[Bool],
+  character_data_old_value : @js.Optional[Bool],
+  attribute_filter : @js.Optional[Array[String]],
+) -> Unit =
+  #| (self, target, childList, attributes, characterData, subtree, attributeOldValue, characterDataOldValue, attributeFilter) => {
+  #|   const options = {}
+  #|   if (childList !== undefined) options.childList = childList
+  #|   if (attributes !== undefined) options.attributes = attributes
+  #|   if (characterData !== undefined) options.characterData = characterData
+  #|   if (subtree !== undefined) options.subtree = subtree
+  #|   if (attributeOldValue !== undefined) options.attributeOldValue = attributeOldValue
+  #|   if (characterDataOldValue !== undefined) options.characterDataOldValue = characterDataOldValue
+  #|   if (attributeFilter !== undefined) options.attributeFilter = attributeFilter
+  #|   self.observe(target, options)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mutation_record_get_attribute_name(
+  record : MutationRecord,
+) -> @js.Nullable[String] = "(self) => self.attributeName"

--- a/rabbita/dom/node.mbt
+++ b/rabbita/dom/node.mbt
@@ -16,6 +16,12 @@ pub trait IsNode: IsEventTarget {
   fn get_next_sibling(Self) -> @js.Nullable[Node] = _
   fn get_previous_sibling(Self) -> @js.Nullable[Node] = _
   fn get_parent_node(Self) -> @js.Nullable[Node] = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement
+  fn get_parent_element(Self) -> Element? = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected
+  fn get_is_connected(Self) -> Bool = _
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Node/contains
+  fn contains(Self, Node) -> Bool = _
   fn append_child(Self, Node) -> Unit = _
   fn remove_child(Self, Node) -> Unit = _
   fn replace_child(Self, Node, Node) -> Unit = _
@@ -107,6 +113,27 @@ impl IsNode with fn get_parent_node(s) {
 
 ///|
 #cfg(target="js")
+impl IsNode with fn get_parent_element(s) {
+  s
+  |> js_identity
+  |> ffi_node_get_parent_element
+  |> parent => { parent.to_option() }
+}
+
+///|
+#cfg(target="js")
+impl IsNode with fn get_is_connected(s) {
+  s |> js_identity |> ffi_node_get_is_connected
+}
+
+///|
+#cfg(target="js")
+impl IsNode with fn contains(s, other) {
+  s |> js_identity |> ffi_node_contains(other)
+}
+
+///|
+#cfg(target="js")
 impl IsNode with fn append_child(s, child) {
   s |> js_identity |> ffi_append_child(child)
 }
@@ -180,6 +207,20 @@ extern "js" fn ffi_previous_sibling(x : @js.Value) -> @js.Nullable[Node] = "(x) 
 ///|
 #cfg(target="js")
 extern "js" fn ffi_parent_node(x : @js.Value) -> @js.Nullable[Node] = "(x) => x.parentNode"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_node_get_parent_element(
+  x : @js.Value,
+) -> @js.Nullable[Element] = "(self) => self.parentElement"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_node_get_is_connected(x : @js.Value) -> Bool = "(self) => self.isConnected"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_node_contains(x : @js.Value, other : Node) -> Bool = "(self, other) => self.contains(other)"
 
 ///|
 #cfg(target="js")

--- a/rabbita/dom/performance.mbt
+++ b/rabbita/dom/performance.mbt
@@ -1,0 +1,15 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Performance
+#cfg(target="js")
+#external
+type Performance
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/performance
+#cfg(target="js")
+pub extern "js" fn Window::get_performance(self : Self) -> Performance = "(self) => self.performance"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+#cfg(target="js")
+pub extern "js" fn Performance::now(self : Self) -> DOMHighResTimeStamp = "(self) => self.now()"

--- a/rabbita/dom/pkg.generated.mbti
+++ b/rabbita/dom/pkg.generated.mbti
@@ -29,6 +29,11 @@ pub fn window() -> Window
 // Errors
 
 // Types and methods
+type Animation
+pub fn Animation::finish(Self) -> Unit
+pub impl IsEventTarget for Animation
+pub impl @js.Cast for Animation
+
 type AnimationEvent
 pub fn AnimationEvent::get_animation_name(Self) -> String
 pub fn AnimationEvent::get_elapsed_time(Self) -> Double
@@ -55,6 +60,9 @@ pub fn BlobEvent::get_timecode(Self) -> Double
 pub fn BlobEvent::new() -> Self
 pub impl IsEvent for BlobEvent
 pub impl @js.Cast for BlobEvent
+
+type CSS
+pub fn CSS::supports(String, String) -> Bool
 
 type CSSRule
 
@@ -232,6 +240,9 @@ pub fn Document::create_document_fragment(Self) -> DocumentFragment
 pub fn Document::create_element(Self, String) -> Element
 pub fn Document::create_element_ns(Self, String, String, on_namespace_error? : (DOMException) -> Element, on_invalid_character_error? : (DOMException) -> Element) -> Element
 pub fn Document::create_text_node(Self, String) -> Element
+pub fn Document::get_active_element(Self) -> Element?
+pub fn Document::get_body(Self) -> HTMLElement?
+pub fn Document::get_document_element(Self) -> Element?
 pub fn Document::get_element_by_id(Self, String) -> @js.Nullable[Element]
 pub fn Document::get_elements_by_class_name(Self, String) -> HTMLCollection
 pub fn Document::get_elements_by_name(Self, String) -> NodeList
@@ -268,6 +279,7 @@ pub impl @js.Cast for Element
 type ElementInternals
 
 type Event
+pub fn Event::new(String, bubbles? : Bool, cancelable? : Bool, composed? : Bool) -> Self
 pub impl IsEvent for Event
 pub impl @js.Cast for Event
 
@@ -276,7 +288,7 @@ pub impl IsEventTarget for EventTarget
 pub impl @js.Cast for EventTarget
 
 type FocusEvent
-pub fn FocusEvent::related_target(Self) -> EventTarget
+pub fn FocusEvent::related_target(Self) -> EventTarget?
 pub impl IsEvent for FocusEvent
 pub impl IsUIEvent for FocusEvent
 pub impl @js.Cast for FocusEvent
@@ -360,6 +372,7 @@ pub impl IsNode for HTMLImageElement
 pub impl @js.Cast for HTMLImageElement
 
 type HTMLInputElement
+pub fn HTMLInputElement::set_value(Self, String) -> Unit
 pub fn HTMLInputElement::value(Self) -> String
 pub impl IsElement for HTMLInputElement
 pub impl IsEventTarget for HTMLInputElement
@@ -410,6 +423,14 @@ pub impl IsEvent for InputEvent
 pub impl IsUIEvent for InputEvent
 pub impl @js.Cast for InputEvent
 
+type IntersectionObserver
+pub fn IntersectionObserver::disconnect(Self) -> Unit
+pub fn IntersectionObserver::new((Array[IntersectionObserverEntry], Self) -> Unit, threshold? : Array[Double]) -> Self
+pub fn IntersectionObserver::observe(Self, Element) -> Unit
+pub fn IntersectionObserver::unobserve(Self, Element) -> Unit
+
+type IntersectionObserverEntry
+
 type KeyboardEvent
 pub fn KeyboardEvent::alt_key(Self) -> Bool
 pub fn KeyboardEvent::code(Self) -> String
@@ -428,6 +449,11 @@ type MediaError
 
 type MediaKeys
 
+type MediaQueryList
+pub fn MediaQueryList::get_matches(Self) -> Bool
+pub impl IsEventTarget for MediaQueryList
+pub impl @js.Cast for MediaQueryList
+
 type MediaStream
 
 type MessageEvent
@@ -441,6 +467,14 @@ pub impl IsEvent for MouseEvent
 pub impl IsMouseEvent for MouseEvent
 pub impl IsUIEvent for MouseEvent
 pub impl @js.Cast for MouseEvent
+
+type MutationObserver
+pub fn MutationObserver::disconnect(Self) -> Unit
+pub fn MutationObserver::new((Array[MutationRecord], Self) -> Unit) -> Self
+pub fn MutationObserver::observe(Self, Node, child_list? : Bool, attributes? : Bool, character_data? : Bool, subtree? : Bool, attribute_old_value? : Bool, character_data_old_value? : Bool, attribute_filter? : Array[String]) -> Unit
+
+type MutationRecord
+pub fn MutationRecord::get_attribute_name(Self) -> String?
 
 #external
 pub type Navigator
@@ -461,7 +495,36 @@ type Path2D
 pub fn Path2D::add_path(Self, Self, transform? : @js.Optional[DOMMatrix2DInit]) -> Unit
 pub fn Path2D::new(path? : @js.Optional[@js.Union2[Self, String]]) -> Self
 
+type Performance
+pub fn Performance::now(Self) -> Double
+
+type PointerEvent
+pub fn PointerEvent::get_altitude_angle(Self) -> Double
+pub fn PointerEvent::get_azimuth_angle(Self) -> Double
+pub fn PointerEvent::get_height(Self) -> Double
+pub fn PointerEvent::get_is_primary(Self) -> Bool
+pub fn PointerEvent::get_pointer_id(Self) -> Int
+pub fn PointerEvent::get_pointer_type(Self) -> String
+pub fn PointerEvent::get_pressure(Self) -> Double
+pub fn PointerEvent::get_tangential_pressure(Self) -> Double
+pub fn PointerEvent::get_tilt_x(Self) -> Int
+pub fn PointerEvent::get_tilt_y(Self) -> Int
+pub fn PointerEvent::get_twist(Self) -> Int
+pub fn PointerEvent::get_width(Self) -> Double
+pub impl IsEvent for PointerEvent
+pub impl IsMouseEvent for PointerEvent
+pub impl IsUIEvent for PointerEvent
+pub impl @js.Cast for PointerEvent
+
 type RemotePlayback
+
+type ResizeObserver
+pub fn ResizeObserver::disconnect(Self) -> Unit
+pub fn ResizeObserver::new((Array[ResizeObserverEntry], Self) -> Unit) -> Self
+pub fn ResizeObserver::observe(Self, Element) -> Unit
+pub fn ResizeObserver::unobserve(Self, Element) -> Unit
+
+type ResizeObserverEntry
 
 type SVGAnimatedTransformList
 
@@ -503,6 +566,19 @@ type TextTrackList
 
 type TimeRanges
 
+type ToggleEvent
+pub fn ToggleEvent::get_new_state(Self) -> String
+pub fn ToggleEvent::get_old_state(Self) -> String
+pub impl IsEvent for ToggleEvent
+pub impl @js.Cast for ToggleEvent
+
+type TransitionEvent
+pub fn TransitionEvent::get_elapsed_time(Self) -> Double
+pub fn TransitionEvent::get_property_name(Self) -> String
+pub fn TransitionEvent::get_pseudo_element(Self) -> String
+pub impl IsEvent for TransitionEvent
+pub impl @js.Cast for TransitionEvent
+
 type UIEvent
 pub impl IsEvent for UIEvent
 pub impl IsUIEvent for UIEvent
@@ -513,6 +589,14 @@ type Uint8ClampedArray
 type VideoFrame
 
 type VideoTrackList
+
+type VisualViewport
+pub fn VisualViewport::get_height(Self) -> Double
+pub fn VisualViewport::get_offset_left(Self) -> Double
+pub fn VisualViewport::get_offset_top(Self) -> Double
+pub fn VisualViewport::get_width(Self) -> Double
+pub impl IsEventTarget for VisualViewport
+pub impl @js.Cast for VisualViewport
 
 type WebGL2RenderingContext
 
@@ -549,15 +633,21 @@ type Window
 pub fn Window::alert(Self, String) -> Unit
 pub fn Window::cancel_animation_frame(Self, Double) -> Unit
 pub fn Window::clear_interval(Self, Int) -> Unit
+pub fn Window::clear_timeout(Self, Int) -> Unit
 pub fn Window::confirm(Self, String) -> Bool
 pub fn Window::current_url(Self) -> String
+pub fn Window::get_computed_style(Self, Element) -> CSSStyleDeclaration
+pub fn Window::get_performance(Self) -> Performance
+pub fn Window::get_visual_viewport(Self) -> VisualViewport?
 pub fn Window::history_go_back(Self) -> Unit
 pub fn Window::history_go_forward(Self) -> Unit
 pub fn Window::inner_height(Self) -> Int
 pub fn Window::inner_width(Self) -> Int
 pub fn Window::load_url(Self, String) -> Unit
+pub fn Window::match_media(Self, String) -> MediaQueryList
 pub fn Window::navigator(Self) -> Navigator
 pub fn Window::push_url(Self, String) -> Unit
+pub fn Window::queue_microtask(Self, () -> Unit) -> Unit
 pub fn Window::reload_url(Self) -> Unit
 pub fn Window::replace_url(Self, String) -> Unit
 pub fn Window::request_animation_frame(Self, (Double) -> Unit) -> Double
@@ -568,6 +658,7 @@ pub fn Window::scroll_to_top(Self, behavior? : String) -> Unit
 pub fn Window::scroll_x(Self) -> Int
 pub fn Window::scroll_y(Self) -> Int
 pub fn Window::set_interval(Self, () -> Unit, Int) -> Int
+pub fn Window::set_timeout(Self, () -> Unit, Int) -> Int
 pub fn Window::to_event_target(Self) -> EventTarget
 pub impl IsEventTarget for Window
 pub impl @js.Cast for Window
@@ -583,13 +674,27 @@ pub type PredefinedColorSpace = String
 pub trait IsElement : IsNode {
   fn as_element(Self) -> Element
   fn get_children(Self) -> Array[Element]
+  fn query_selector(Self, String) -> Element?
+  fn query_selector_all(Self, String) -> Array[Element]
+  fn closest(Self, String) -> Element?
+  fn matches(Self, String) -> Bool
+  fn has_attribute(Self, String) -> Bool
+  fn get_client_width(Self) -> Double
+  fn get_client_height(Self) -> Double
+  fn get_client_left(Self) -> Double
+  fn get_client_top(Self) -> Double
+  fn get_client_rects(Self) -> Array[DOMRect]
+  fn set_pointer_capture(Self, Int) -> Unit
+  fn release_pointer_capture(Self, Int) -> Unit
+  fn has_pointer_capture(Self, Int) -> Bool
   fn set_attribute(Self, String, String) -> Unit
-  fn get_attribute(Self, String) -> String
+  fn get_attribute(Self, String) -> String?
   fn remove_attribute(Self, String) -> Unit
   fn set_property(Self, String, @js.Value) -> Unit
   fn get_property(Self, String) -> @js.Optional[String]
   fn remove_property(Self, String) -> Unit
   fn scroll_into_view(Self, behavior? : String) -> Unit
+  fn scroll_into_view_with_options(Self, behavior? : String, block? : String, inline? : String, container? : String) -> Unit
   fn get_scroll_top(Self) -> Double
   fn set_scroll_top(Self, Double) -> Unit
   fn get_scroll_left(Self) -> Double
@@ -598,17 +703,23 @@ pub trait IsElement : IsNode {
   fn get_scroll_height(Self) -> Double
   fn set_inner_html(Self, String) -> Unit
   fn get_bounding_client_rect(Self) -> DOMRect
+  fn get_animations(Self) -> Array[Animation]
 }
 
 pub trait IsEvent : @js.Cast {
   fn target(Self) -> EventTarget
   fn current_target(Self) -> @js.Nullable[EventTarget]
+  fn get_default_prevented(Self) -> Bool
+  fn get_time_stamp(Self) -> Double
+  fn composed_path(Self) -> Array[EventTarget]
   fn prevent_default(Self) -> Unit
   fn stop_propagation(Self) -> Unit
+  fn stop_immediate_propagation(Self) -> Unit
   fn as_event(Self) -> Event
   fn to_ui_event(Self) -> UIEvent?
   fn to_clipboard_event(Self) -> ClipboardEvent?
   fn to_mouse_event(Self) -> MouseEvent?
+  fn to_pointer_event(Self) -> PointerEvent?
   fn to_input_event(Self) -> InputEvent?
   fn to_focus_event(Self) -> FocusEvent?
   fn to_keyboard_event(Self) -> KeyboardEvent?
@@ -626,7 +737,9 @@ pub trait IsEvent : @js.Cast {
 pub trait IsEventTarget : @js.Cast {
   fn as_event_target(Self) -> EventTarget
   fn add_event_listener(Self, String, (Event) -> Unit) -> Unit
+  fn add_event_listener_with_options(Self, String, (Event) -> Unit, capture? : Bool, passive? : Bool, once? : Bool) -> Unit
   fn remove_event_listener(Self, String, (Event) -> Unit) -> Unit
+  fn remove_event_listener_with_options(Self, String, (Event) -> Unit, capture? : Bool) -> Unit
   fn dispatch_event(Self, Event) -> Unit
   fn to_clipboard(Self) -> Clipboard?
   fn to_node(Self) -> Node?
@@ -772,6 +885,7 @@ pub trait IsHtmlElement : IsElement {
   fn blur(Self) -> Unit
   fn click(Self) -> Unit
   fn focus(Self) -> Unit
+  fn focus_with_options(Self, prevent_scroll? : Bool, focus_visible? : Bool) -> Unit
   fn hide_popover(Self) -> Unit
   fn show_popover(Self) -> Unit
   fn toggle_popover(Self, Bool?) -> Bool
@@ -792,7 +906,7 @@ pub trait IsMouseEvent : IsUIEvent {
   fn get_offset_y(Self) -> Int
   fn get_page_x(Self) -> Int
   fn get_page_y(Self) -> Int
-  fn get_related_target(Self) -> EventTarget
+  fn get_related_target(Self) -> EventTarget?
   fn get_screen_x(Self) -> Int
   fn get_screen_y(Self) -> Int
   fn get_shift_key(Self) -> Bool
@@ -812,6 +926,9 @@ pub trait IsNode : IsEventTarget {
   fn get_next_sibling(Self) -> @js.Nullable[Node]
   fn get_previous_sibling(Self) -> @js.Nullable[Node]
   fn get_parent_node(Self) -> @js.Nullable[Node]
+  fn get_parent_element(Self) -> Element?
+  fn get_is_connected(Self) -> Bool
+  fn contains(Self, Node) -> Bool
   fn append_child(Self, Node) -> Unit
   fn remove_child(Self, Node) -> Unit
   fn replace_child(Self, Node, Node) -> Unit

--- a/rabbita/dom/pointer_event.mbt
+++ b/rabbita/dom/pointer_event.mbt
@@ -1,0 +1,89 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
+#cfg(target="js")
+#external
+type PointerEvent
+
+///|
+#cfg(target="js")
+pub impl IsEvent for PointerEvent
+
+///|
+#cfg(target="js")
+pub impl IsUIEvent for PointerEvent
+
+///|
+#cfg(target="js")
+pub impl IsMouseEvent for PointerEvent
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for PointerEvent with fn into(value) {
+  value |> ffi_to_pointer_event |> result => { result.to_option() }
+}
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for PointerEvent with fn from(value) {
+  value |> js_identity
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerId
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_pointer_id(self : Self) -> Int = "(event) => event.pointerId"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/width
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_width(self : Self) -> Double = "(event) => event.width"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/height
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_height(self : Self) -> Double = "(event) => event.height"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pressure
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_pressure(self : Self) -> Double = "(event) => event.pressure"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tangentialPressure
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_tangential_pressure(self : Self) -> Double = "(event) => event.tangentialPressure"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltX
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_tilt_x(self : Self) -> Int = "(event) => event.tiltX"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltY
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_tilt_y(self : Self) -> Int = "(event) => event.tiltY"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/twist
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_twist(self : Self) -> Int = "(event) => event.twist"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/altitudeAngle
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_altitude_angle(self : Self) -> Double = "(event) => event.altitudeAngle"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/azimuthAngle
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_azimuth_angle(self : Self) -> Double = "(event) => event.azimuthAngle"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_pointer_type(self : Self) -> String = "(event) => event.pointerType"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/isPrimary
+#cfg(target="js")
+pub extern "js" fn PointerEvent::get_is_primary(self : Self) -> Bool = "(event) => event.isPrimary"

--- a/rabbita/dom/resize_observer.mbt
+++ b/rabbita/dom/resize_observer.mbt
@@ -1,0 +1,39 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+#cfg(target="js")
+#external
+type ResizeObserver
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry
+#cfg(target="js")
+#external
+type ResizeObserverEntry
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver
+#cfg(target="js")
+pub extern "js" fn ResizeObserver::new(
+  callback : (Array[ResizeObserverEntry], ResizeObserver) -> Unit,
+) -> Self = "(callback) => new ResizeObserver(callback)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe
+#cfg(target="js")
+pub extern "js" fn ResizeObserver::observe(
+  self : Self,
+  target : Element,
+) -> Unit = "(self, target) => self.observe(target)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/unobserve
+#cfg(target="js")
+pub extern "js" fn ResizeObserver::unobserve(
+  self : Self,
+  target : Element,
+) -> Unit = "(self, target) => self.unobserve(target)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect
+#cfg(target="js")
+pub extern "js" fn ResizeObserver::disconnect(self : Self) -> Unit = "(self) => self.disconnect()"

--- a/rabbita/dom/toggle_event.mbt
+++ b/rabbita/dom/toggle_event.mbt
@@ -1,0 +1,31 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent
+#cfg(target="js")
+#external
+type ToggleEvent
+
+///|
+#cfg(target="js")
+pub impl IsEvent for ToggleEvent
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for ToggleEvent with fn into(value) {
+  value |> ffi_to_toggle_event |> result => { result.to_option() }
+}
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for ToggleEvent with fn from(value) {
+  value |> js_identity
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
+#cfg(target="js")
+pub extern "js" fn ToggleEvent::get_old_state(self : Self) -> String = "(event) => event.oldState"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
+#cfg(target="js")
+pub extern "js" fn ToggleEvent::get_new_state(self : Self) -> String = "(event) => event.newState"

--- a/rabbita/dom/transition_event.mbt
+++ b/rabbita/dom/transition_event.mbt
@@ -1,0 +1,36 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent
+#cfg(target="js")
+#external
+type TransitionEvent
+
+///|
+#cfg(target="js")
+pub impl IsEvent for TransitionEvent
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for TransitionEvent with fn into(value) {
+  value |> ffi_to_transition_event |> result => { result.to_option() }
+}
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for TransitionEvent with fn from(value) {
+  value |> js_identity
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent/propertyName
+#cfg(target="js")
+pub extern "js" fn TransitionEvent::get_property_name(self : Self) -> String = "(event) => event.propertyName"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent/elapsedTime
+#cfg(target="js")
+pub extern "js" fn TransitionEvent::get_elapsed_time(self : Self) -> Double = "(event) => event.elapsedTime"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent/pseudoElement
+#cfg(target="js")
+pub extern "js" fn TransitionEvent::get_pseudo_element(self : Self) -> String = "(event) => event.pseudoElement"

--- a/rabbita/dom/visual_viewport.mbt
+++ b/rabbita/dom/visual_viewport.mbt
@@ -1,0 +1,64 @@
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport
+#cfg(target="js")
+#external
+type VisualViewport
+
+///|
+#cfg(target="js")
+pub impl IsEventTarget for VisualViewport
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for VisualViewport with fn into(value) {
+  value |> ffi_to_visual_viewport |> viewport => { viewport.to_option() }
+}
+
+///|
+#cfg(target="js")
+pub impl @js.Cast for VisualViewport with fn from(value) {
+  value |> js_identity
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/visualViewport
+#cfg(target="js")
+pub fn Window::get_visual_viewport(self : Self) -> VisualViewport? {
+  ffi_window_get_visual_viewport(self).to_option()
+}
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/width
+#cfg(target="js")
+pub extern "js" fn VisualViewport::get_width(self : Self) -> Double = "(self) => self.width"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/height
+#cfg(target="js")
+pub extern "js" fn VisualViewport::get_height(self : Self) -> Double = "(self) => self.height"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/offsetLeft
+#cfg(target="js")
+pub extern "js" fn VisualViewport::get_offset_left(self : Self) -> Double = "(self) => self.offsetLeft"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport/offsetTop
+#cfg(target="js")
+pub extern "js" fn VisualViewport::get_offset_top(self : Self) -> Double = "(self) => self.offsetTop"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_window_get_visual_viewport(
+  win : Window,
+) -> @js.Nullable[VisualViewport] = "(self) => self.visualViewport ?? null"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_to_visual_viewport(
+  value : @js.Value,
+) -> @js.Nullable[VisualViewport] =
+  #| (value) => typeof VisualViewport !== "undefined"
+  #|   && value instanceof VisualViewport
+  #|   ? value
+  #|   : null

--- a/rabbita/dom/window.mbt
+++ b/rabbita/dom/window.mbt
@@ -1,5 +1,6 @@
 ///|
 #cfg(target="js")
+#external
 type Window
 
 ///|
@@ -153,6 +154,25 @@ pub extern "js" fn Window::set_interval(
 pub extern "js" fn Window::clear_interval(self : Self, interval_id : Int) = "(self,id) => self.clearInterval(id)"
 
 ///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout
+#cfg(target="js")
+pub extern "js" fn Window::set_timeout(
+  self : Self,
+  f : () -> Unit,
+  ms : Int,
+) -> Int = "(self, f, ms) => self.setTimeout(f, ms)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/clearTimeout
+#cfg(target="js")
+pub extern "js" fn Window::clear_timeout(self : Self, timeout_id : Int) = "(self, id) => self.clearTimeout(id)"
+
+///|
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask
+#cfg(target="js")
+pub extern "js" fn Window::queue_microtask(self : Self, f : () -> Unit) = "(self, f) => self.queueMicrotask(f)"
+
+///|
 /// https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame
 #cfg(target="js")
 pub extern "js" fn Window::request_animation_frame(
@@ -188,3 +208,12 @@ pub extern "js" fn Window::confirm(self : Self, msg : String) -> Bool = "(self,m
 #cfg(target="js")
 pub extern "js" fn Window::navigator(self : Self) -> Navigator =
   #| (self) => self.navigator
+
+///|
+/// Returns the resolved CSS values for an element.
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle
+#cfg(target="js")
+pub extern "js" fn Window::get_computed_style(
+  self : Self,
+  element : Element,
+) -> CSSStyleDeclaration = "(self, element) => self.getComputedStyle(element)"

--- a/rabbita/html/README.mbt.md
+++ b/rabbita/html/README.mbt.md
@@ -101,6 +101,12 @@ HTML wrappers provide common events as optional arguments like `on_click`,
 `Msg` you define. When an event fires, the `Msg` (and any extra payload) is
 forwarded to the centralized state update function.
 
+Registering the same event more than once composes the handlers in registration
+order. When a wrapper receives both an event in `attrs` and its matching named
+event argument, the `attrs` handler runs first and the named handler runs
+second. Non-event attributes and properties keep their usual last-write-wins
+behavior.
+
 Example:
 
 ```moonbit check

--- a/rabbita/html/attrs.mbt
+++ b/rabbita/html/attrs.mbt
@@ -26,7 +26,8 @@ fn Attrs::to_props(self : Attrs) -> Props {
 }
 
 ///|
-fn Attrs::copy(self : Attrs) -> Attrs {
+/// Return an independent copy that can be extended without mutating `self`.
+pub fn Attrs::copy(self : Attrs) -> Attrs {
   Attrs(self.0.copy())
 }
 
@@ -66,13 +67,20 @@ pub fn Attrs::style(self : Attrs, key : String, value : String) -> Attrs {
 }
 
 ///|
-/// Set an event handler.
+/// Add an event handler after handlers already registered for the same event.
 fn Attrs::handler(
   self : Attrs,
   key : String,
   value : (Event, &@cmd.Scheduler) -> Unit,
 ) -> Attrs {
-  self.0.handlers[key] = value
+  if self.0.handlers.get(key) is Some(previous) {
+    self.0.handlers[key] = (event, scheduler) => {
+      previous(event, scheduler)
+      value(event, scheduler)
+    }
+  } else {
+    self.0.handlers[key] = value
+  }
   self
 }
 

--- a/rabbita/html/attrs_copy_test.mbt
+++ b/rabbita/html/attrs_copy_test.mbt
@@ -1,0 +1,35 @@
+///|
+fn vnode_attr(html : @html.Html, name : String) -> String? {
+  match html.to_virtual_dom() {
+    Elem(_, props, _, namespace_uri=None) => props.attrs.get(name)
+    _ => None
+  }
+}
+
+///|
+test "Attrs::copy isolates later mutations" {
+  let original = @html.Attrs::build().role("note")
+  let copied = original.copy().aria_label("Copied")
+
+  let original_html = @html.div(attrs=original, @html.nothing)
+  let copied_html = @html.div(attrs=copied, @html.nothing)
+
+  debug_inspect(vnode_attr(original_html, "role"), content="Some(\"note\")")
+  debug_inspect(vnode_attr(original_html, "aria-label"), content="None")
+  debug_inspect(vnode_attr(copied_html, "role"), content="Some(\"note\")")
+  debug_inspect(
+    vnode_attr(copied_html, "aria-label"),
+    content="Some(\"Copied\")",
+  )
+}
+
+///|
+test "input leaves autocomplete to the browser when omitted" {
+  let inherited = @html.input(attrs=@html.Attrs::build().autocomplete(@html.On))
+  let omitted = @html.input()
+  let explicit = @html.input(auto_complete=@html.Off)
+
+  debug_inspect(vnode_attr(inherited, "autocomplete"), content="Some(\"on\")")
+  debug_inspect(vnode_attr(omitted, "autocomplete"), content="None")
+  debug_inspect(vnode_attr(explicit, "autocomplete"), content="Some(\"off\")")
+}

--- a/rabbita/html/attrs_event.mbt
+++ b/rabbita/html/attrs_event.mbt
@@ -79,6 +79,14 @@ type InputEvent = Unit
 type DomEvent = Unit
 
 ///|
+// Browsers dispatch `scroll` as a plain Event in current Chromium, even though
+// older DOM typings exposed it as UIEvent. The wrapper only relies on the
+// shared Event surface, so preserve the public callback type without an
+// `instanceof UIEvent` assertion that would panic for valid scroll events.
+#cfg(target="js")
+extern "js" fn scroll_event_as_ui_event(event : DomEvent) -> UIEvent = "(event) => event"
+
+///|
 #cfg(target="js")
 fn Attrs::on_mouse_event(
   self : Attrs,
@@ -290,6 +298,37 @@ pub fn Attrs::on_mouseout(self : Attrs, msg : (MouseEvent) -> Cmd) -> Attrs {
 }
 
 ///|
+/// Handle a primary or auxiliary pointer starting contact with the element.
+///
+/// `PointerEvent` extends the browser's mouse-event surface, so the callback
+/// uses Rabbita's existing `MouseEvent` wrapper while preserving pointer-only
+/// fields for JavaScript FFI helpers.
+pub fn Attrs::on_pointerdown(self : Attrs, msg : (MouseEvent) -> Cmd) -> Attrs {
+  self.on_mouse_event("pointerdown", msg)
+}
+
+///|
+/// Handle movement from a captured mouse, pen, or touch pointer.
+pub fn Attrs::on_pointermove(self : Attrs, msg : (MouseEvent) -> Cmd) -> Attrs {
+  self.on_mouse_event("pointermove", msg)
+}
+
+///|
+/// Handle the end of a mouse, pen, or touch pointer interaction.
+pub fn Attrs::on_pointerup(self : Attrs, msg : (MouseEvent) -> Cmd) -> Attrs {
+  self.on_mouse_event("pointerup", msg)
+}
+
+///|
+/// Handle browser cancellation of an active pointer interaction.
+pub fn Attrs::on_pointercancel(
+  self : Attrs,
+  msg : (MouseEvent) -> Cmd,
+) -> Attrs {
+  self.on_mouse_event("pointercancel", msg)
+}
+
+///|
 pub fn Attrs::on_contextmenu(self : Attrs, msg : (MouseEvent) -> Cmd) -> Attrs {
   self.on_mouse_event("contextmenu", msg)
 }
@@ -298,7 +337,7 @@ pub fn Attrs::on_contextmenu(self : Attrs, msg : (MouseEvent) -> Cmd) -> Attrs {
 #cfg(target="js")
 pub fn Attrs::on_scroll(self : Attrs, msg : (UIEvent) -> Cmd) -> Attrs {
   self.handler("scroll", (event, scheduler) => {
-    scheduler.add(msg(event.to_ui_event().unwrap()))
+    scheduler.add(msg(scroll_event_as_ui_event(event)))
   })
 }
 

--- a/rabbita/html/attrs_event_composition_wbtest.mbt
+++ b/rabbita/html/attrs_event_composition_wbtest.mbt
@@ -1,0 +1,272 @@
+///|
+#cfg(target="js")
+struct EventCompositionScheduler {}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for EventCompositionScheduler with fn run_effect(
+  self,
+  kind,
+  effect,
+) {
+  ignore(kind)
+  effect(self)
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for EventCompositionScheduler with fn queue_message(
+  self,
+  path,
+  message,
+) {
+  ignore((self, path, message))
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for EventCompositionScheduler with fn drain_message(self) {
+  ignore(self)
+}
+
+///|
+#cfg(target="js")
+impl @cmd.Scheduler for EventCompositionScheduler with fn hooks(self) {
+  ignore(self)
+  @cmd.Hooks::{ url_request: None, url_changed: None }
+}
+
+///|
+#cfg(target="js")
+extern "js" fn with_event_composition_event(
+  event_kind : String,
+  value : String,
+  run : (@dom.Event) -> Bool,
+) -> Bool =
+  #| (eventKind, value, run) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const hadMouseEvent = own("MouseEvent")
+  #|   const previousMouseEvent = globalThis.MouseEvent
+  #|   const hadInputEvent = own("InputEvent")
+  #|   const previousInputEvent = globalThis.InputEvent
+  #|   const hadInputElement = own("HTMLInputElement")
+  #|   const previousInputElement = globalThis.HTMLInputElement
+  #|   class FakeMouseEvent {
+  #|     constructor() {
+  #|       this.defaultPrevented = false
+  #|       this.target = null
+  #|       this.currentTarget = null
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|     stopPropagation() {}
+  #|   }
+  #|   class FakeInputElement {
+  #|     constructor(inputValue) { this.value = inputValue }
+  #|   }
+  #|   class FakeInputEvent {
+  #|     constructor(inputValue) {
+  #|       this.defaultPrevented = false
+  #|       this.target = new FakeInputElement(inputValue)
+  #|       this.currentTarget = this.target
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|     stopPropagation() {}
+  #|   }
+  #|   globalThis.MouseEvent = FakeMouseEvent
+  #|   globalThis.InputEvent = FakeInputEvent
+  #|   globalThis.HTMLInputElement = FakeInputElement
+  #|   const event = eventKind === "mouse"
+  #|     ? new FakeMouseEvent()
+  #|     : eventKind === "input"
+  #|       ? new FakeInputEvent(value)
+  #|       : {
+  #|           defaultPrevented: false,
+  #|           target: null,
+  #|           currentTarget: null,
+  #|           preventDefault() { this.defaultPrevented = true },
+  #|           stopPropagation() {},
+  #|         }
+  #|   try {
+  #|     return run(event)
+  #|   } finally {
+  #|     if (hadMouseEvent) globalThis.MouseEvent = previousMouseEvent
+  #|     else delete globalThis.MouseEvent
+  #|     if (hadInputEvent) globalThis.InputEvent = previousInputEvent
+  #|     else delete globalThis.InputEvent
+  #|     if (hadInputElement) globalThis.HTMLInputElement = previousInputElement
+  #|     else delete globalThis.HTMLInputElement
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn event_composition_default_prevented(event : @dom.Event) -> Bool = "event => event.defaultPrevented"
+
+///|
+#cfg(target="js")
+fn event_composition_command(trace : Array[String], label : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => trace.push(label))
+}
+
+///|
+#cfg(target="js")
+fn event_composition_props(html : Html) -> @runtime.Props raise {
+  match html.to_virtual_dom() {
+    Elem(_, props, _, namespace_uri=None) => props
+    _ => fail("expected an HTML element")
+  }
+}
+
+///|
+#cfg(target="js")
+fn dispatch_composed_event(
+  props : @runtime.Props,
+  event_name : String,
+  event_kind : String,
+  value : String,
+) -> Bool raise {
+  guard props.handlers.get(event_name) is Some(handler) else {
+    fail("expected handler for event: \{event_name}")
+  }
+  let scheduler = EventCompositionScheduler::{  }
+  with_event_composition_event(event_kind, value, event => {
+    handler(event, scheduler)
+    event_composition_default_prevented(event)
+  })
+}
+
+///|
+#cfg(target="js")
+test "event families compose through one handler per event name" {
+  let attrs = Attrs::build()
+    .on_click(_ => @cmd.none)
+    .on_click(_ => @cmd.none)
+    .on_keydown(_ => @cmd.none)
+    .on_keydown(_ => @cmd.none)
+    .on_focus(_ => @cmd.none)
+    .on_focus(_ => @cmd.none)
+    .on_pointerdown(_ => @cmd.none)
+    .on_pointerdown(_ => @cmd.none)
+    .on_scroll(_ => @cmd.none)
+    .on_scroll(_ => @cmd.none)
+    .on_input(_ => @cmd.none)
+    .on_input(_ => @cmd.none)
+    .on_change(_ => @cmd.none)
+    .on_change(_ => @cmd.none)
+    .on_submit(_ => @cmd.none)
+    .on_submit(_ => @cmd.none)
+    .on_reset(_ => @cmd.none)
+    .on_reset(_ => @cmd.none)
+    .on_dragstart(_ => @cmd.none)
+    .on_dragstart(_ => @cmd.none)
+    .on_copy(_ => @cmd.none)
+    .on_copy(_ => @cmd.none)
+    .on_compositionstart(_ => @cmd.none)
+    .on_compositionstart(_ => @cmd.none)
+    .on_wheel(_ => @cmd.none)
+    .on_wheel(_ => @cmd.none)
+  assert_eq(attrs.0.handlers.length(), 13)
+}
+
+///|
+#cfg(target="js")
+test "same event handlers compose once in registration order" {
+  let trace : Array[String] = []
+  let attrs = Attrs::build()
+    .on_click(_ => event_composition_command(trace, "A"))
+    .on_click(_ => event_composition_command(trace, "B"))
+    .on_click(_ => event_composition_command(trace, "C"))
+  assert_eq(attrs.0.handlers.length(), 1)
+  assert_true(attrs.0.handlers.contains("click"))
+  ignore(dispatch_composed_event(attrs.0, "click", "mouse", ""))
+  assert_eq(trace.join(","), "A,B,C")
+}
+
+///|
+#cfg(target="js")
+test "Attrs copy isolates later handler composition" {
+  let trace : Array[String] = []
+  let original = Attrs::build().on_click(_ => {
+    event_composition_command(trace, "original")
+  })
+  let copied = original
+    .copy()
+    .on_click(_ => event_composition_command(trace, "copied"))
+  ignore(dispatch_composed_event(original.0, "click", "mouse", ""))
+  assert_eq(trace.join(","), "original")
+  trace.clear()
+  ignore(dispatch_composed_event(copied.0, "click", "mouse", ""))
+  assert_eq(trace.join(","), "original,copied")
+  trace.clear()
+  ignore(dispatch_composed_event(original.0, "click", "mouse", ""))
+  assert_eq(trace.join(","), "original")
+}
+
+///|
+#cfg(target="js")
+test "button named callback appends without mutating caller attrs" {
+  let trace : Array[String] = []
+  let caller_attrs = Attrs::build().on_click(_ => {
+    event_composition_command(trace, "caller")
+  })
+  let html = button(
+    attrs=caller_attrs,
+    on_click=event_composition_command(trace, "internal"),
+    nothing,
+  )
+  ignore(
+    dispatch_composed_event(event_composition_props(html), "click", "mouse", ""),
+  )
+  assert_eq(trace.join(","), "caller,internal")
+  trace.clear()
+  ignore(dispatch_composed_event(caller_attrs.0, "click", "mouse", ""))
+  assert_eq(trace.join(","), "caller")
+}
+
+///|
+#cfg(target="js")
+test "input and change named callbacks append to attrs handlers" {
+  let trace : Array[String] = []
+  let caller_attrs = Attrs::build()
+    .on_input(_ => event_composition_command(trace, "input-caller"))
+    .on_change(_ => event_composition_command(trace, "change-caller"))
+  let html = input(
+    attrs=caller_attrs,
+    on_input=@cmd.Emit(value => {
+      event_composition_command(trace, "input-internal:\{value}")
+    }),
+    on_change=@cmd.Emit(value => {
+      event_composition_command(trace, "change-internal:\{value}")
+    }),
+  )
+  let props = event_composition_props(html)
+  ignore(dispatch_composed_event(props, "input", "input", "typed"))
+  assert_eq(trace.join(","), "input-caller,input-internal:typed")
+  trace.clear()
+  ignore(dispatch_composed_event(props, "change", "input", "changed"))
+  assert_eq(trace.join(","), "change-caller,change-internal:changed")
+}
+
+///|
+#cfg(target="js")
+test "form submit preserves caller order and prevention" {
+  let trace : Array[String] = []
+  let form_attrs = Attrs::build().on_submit(event => {
+    trace.push("submit-caller:\{event_composition_default_prevented(event)}")
+    @cmd.none
+  })
+  let form_html = form(
+    attrs=form_attrs,
+    on_submit=event_composition_command(trace, "submit-internal"),
+    nothing,
+  )
+  assert_true(
+    dispatch_composed_event(
+      event_composition_props(form_html),
+      "submit",
+      "generic",
+      "",
+    ),
+  )
+  assert_eq(trace.join(","), "submit-caller:false,submit-internal")
+}

--- a/rabbita/html/attrs_pointer_wbtest.mbt
+++ b/rabbita/html/attrs_pointer_wbtest.mbt
@@ -1,0 +1,33 @@
+///|
+#cfg(target="js")
+test "pointer event helpers install generic runtime handlers" {
+  let attrs = Attrs::build()
+    .on_pointerdown(_ => @cmd.none)
+    .on_pointerdown(_ => @cmd.none)
+    .on_pointermove(_ => @cmd.none)
+    .on_pointermove(_ => @cmd.none)
+    .on_pointerup(_ => @cmd.none)
+    .on_pointerup(_ => @cmd.none)
+    .on_pointercancel(_ => @cmd.none)
+    .on_pointercancel(_ => @cmd.none)
+  assert_true(attrs.0.handlers.contains("pointerdown"))
+  assert_true(attrs.0.handlers.contains("pointermove"))
+  assert_true(attrs.0.handlers.contains("pointerup"))
+  assert_true(attrs.0.handlers.contains("pointercancel"))
+}
+
+///|
+#cfg(not(target="js"))
+test "pointer event helpers remain SSR safe" {
+  let attrs = Attrs::build()
+    .on_pointerdown(_ => @cmd.none)
+    .on_pointerdown(_ => @cmd.none)
+    .on_pointermove(_ => @cmd.none)
+    .on_pointermove(_ => @cmd.none)
+    .on_pointerup(_ => @cmd.none)
+    .on_pointerup(_ => @cmd.none)
+    .on_pointercancel(_ => @cmd.none)
+    .on_pointercancel(_ => @cmd.none)
+  let html = div(attrs~, nothing)
+  assert_true(html.to_virtual_dom() is Elem(_, _, _, namespace_uri=None))
+}

--- a/rabbita/html/html.mbt
+++ b/rabbita/html/html.mbt
@@ -1464,10 +1464,6 @@ pub fn input(
     Url => "url"
     Week => "week"
   }
-  let auto_complete = match auto_complete {
-    Some(On) => "on"
-    _ => "off"
-  }
   let attrs = resolve_attrs(attrs)
   push_title(title, attrs)
   push_hidden(hidden, attrs)
@@ -1476,7 +1472,9 @@ pub fn input(
   push_list(list, attrs)
   push_inputmode(inputmode, attrs)
   ignore(attrs.attribute("type", input_type))
-  ignore(attrs.attribute("autocomplete", auto_complete))
+  if auto_complete is Some(value) {
+    ignore(attrs.autocomplete(value))
+  }
   push_name(name, attrs)
   push_value_prop_string(value, attrs)
   push_checked(checked, attrs)

--- a/rabbita/html/pkg.generated.mbti
+++ b/rabbita/html/pkg.generated.mbti
@@ -346,6 +346,7 @@ pub fn Attrs::content(Self, String) -> Self
 pub fn Attrs::contenteditable(Self, String) -> Self
 pub fn Attrs::controls(Self, Bool) -> Self
 pub fn Attrs::coords(Self, String) -> Self
+pub fn Attrs::copy(Self) -> Self
 pub fn Attrs::crossorigin(Self, String) -> Self
 pub fn Attrs::csp(Self, String) -> Self
 pub fn Attrs::data(Self, String) -> Self
@@ -438,6 +439,10 @@ pub fn Attrs::on_mouseout(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_mouseover(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_mouseup(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_paste(Self, (@dom.ClipboardEvent) -> @cmd.Cmd) -> Self
+pub fn Attrs::on_pointercancel(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
+pub fn Attrs::on_pointerdown(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
+pub fn Attrs::on_pointermove(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
+pub fn Attrs::on_pointerup(Self, (@dom.MouseEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_reset(Self, (@dom.Event) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_scroll(Self, (@dom.UIEvent) -> @cmd.Cmd) -> Self
 pub fn Attrs::on_submit(Self, (@dom.Event) -> @cmd.Cmd) -> Self

--- a/rabbita/internal/duplix/duplix.mbt
+++ b/rabbita/internal/duplix/duplix.mbt
@@ -96,6 +96,9 @@ impl[T : Eq] ErasedNode for Node[T] with fn dirty_flag(self) {
 }
 
 ///|
+extend Node with ErasedNode::{dirty_flag}
+
+///|
 impl[T : Eq] ErasedNode for Node[T] with fn recompute(self) {
   current_scope.protect(self.scope, () => {
     match self.value {

--- a/rabbita/internal/runtime/ssr.mbt
+++ b/rabbita/internal/runtime/ssr.mbt
@@ -73,6 +73,7 @@ fn write_variant_text(buf : StringBuilder, value : @variant.Variant) -> Unit {
 ///|
 fn write_property_attrs(
   buf : StringBuilder,
+  tag : String,
   attrs : Map[String, String],
   props : Map[String, @variant.Variant],
 ) -> Unit {
@@ -80,6 +81,7 @@ fn write_property_attrs(
     if name == "textContent" ||
       name == "innerHTML" ||
       name == "style" ||
+      (tag == "textarea" && name == "value") ||
       attrs.contains(name) {
       continue
     }
@@ -138,7 +140,7 @@ fn vnode_to_string(buf : StringBuilder, vnode : VNode) -> Unit {
         write_attr(buf, name, value)
       }
       write_styles_attr(buf, attrs, styles)
-      write_property_attrs(buf, attrs, props)
+      write_property_attrs(buf, tag, attrs, props)
       if is_html_void_element(tag) {
         buf.write_char('>')
       } else {
@@ -149,7 +151,11 @@ fn vnode_to_string(buf : StringBuilder, vnode : VNode) -> Unit {
         if props.get("textContent") is Some(text_content) {
           write_variant_text(buf, text_content)
         }
-        children_to_string(buf, children)
+        if tag == "textarea" && props.get("value") is Some(String(value)) {
+          write_escaped_text(buf, value)
+        } else {
+          children_to_string(buf, children)
+        }
 
         buf.write_string("</")
         buf.write_string(tag)

--- a/rabbita/internal/runtime/ssr_wbtest.mbt
+++ b/rabbita/internal/runtime/ssr_wbtest.mbt
@@ -21,3 +21,18 @@ test "ssr keeps end tags for non-void empty elements" {
     "<iframe src=\"frame.html\"></iframe>",
   )
 }
+
+///|
+test "ssr writes textarea value as escaped text content" {
+  let props = Props::new(
+    Map([]),
+    { "value": @variant.String("one < two & three") },
+    Map([]),
+    Map([]),
+  )
+  let vnode = VNode::elem("textarea", props, Array([]))
+  assert_eq(
+    render_vnode_for_test(vnode),
+    "<textarea>one &lt; two &amp; three</textarea>",
+  )
+}

--- a/rabbita/internal/runtime/vdom_handler_slots_wbtest.mbt
+++ b/rabbita/internal/runtime/vdom_handler_slots_wbtest.mbt
@@ -1,0 +1,68 @@
+///|
+#cfg(target="js")
+extern "js" fn vdom_handler_slot_test_element() -> @dom.Element =
+  #| () => {
+  #|   let createdHTMLElement = null
+  #|   if (typeof globalThis.HTMLElement === "undefined") {
+  #|     createdHTMLElement = class HTMLElement {}
+  #|     globalThis.HTMLElement = createdHTMLElement
+  #|   }
+  #|   const element = Object.create(globalThis.HTMLElement.prototype)
+  #|   Object.defineProperty(element, "style", {
+  #|     configurable: true,
+  #|     value: {
+  #|       removeProperty: () => "",
+  #|       setProperty: () => {},
+  #|     },
+  #|   })
+  #|   element.__vdomHandlerSlotCreatedHTMLElement = createdHTMLElement
+  #|   return element
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn vdom_handler_slot_test_cleanup(element : @dom.Element) -> Unit =
+  #| element => {
+  #|   const created = element.__vdomHandlerSlotCreatedHTMLElement
+  #|   if (created && globalThis.HTMLElement === created) {
+  #|     delete globalThis.HTMLElement
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn vdom_handler_slot_test_event() -> @dom.Event = "() => ({})"
+
+///|
+#cfg(target="js")
+test "vdom replaces a render's composed handler without accumulating stale handlers" {
+  let trace : Array[String] = []
+  let old_render_handler : (Event, &Scheduler) -> Unit = (_, _) => {
+    trace.push("A")
+    trace.push("B")
+  }
+  let new_render_handler : (Event, &Scheduler) -> Unit = (_, _) => {
+    trace.push("C")
+    trace.push("D")
+  }
+  let old = Props::new(Map([]), Map([]), Map([]), {
+    "click": old_render_handler,
+  })
+  let slot = @ref.new(old_render_handler)
+  old.slots["click"] = slot
+  let new = Props::new(Map([]), Map([]), Map([]), {
+    "click": new_render_handler,
+  })
+  let sandbox = Sandbox::new()
+  (slot.val)(vdom_handler_slot_test_event(), sandbox)
+  assert_eq(trace.join(","), "A,B")
+  let element = vdom_handler_slot_test_element()
+  diff_props(old, new, sandbox, element)
+  vdom_handler_slot_test_cleanup(element)
+  guard new.slots.get("click") is Some(updated_slot) else {
+    fail("expected the existing click handler slot to be retained")
+  }
+  assert_true(physical_equal(slot, updated_slot))
+  (updated_slot.val)(vdom_handler_slot_test_event(), sandbox)
+  assert_eq(trace.join(","), "A,B,C,D")
+}

--- a/rabbita/moon.mod
+++ b/rabbita/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/rabbita"
 
-version = "0.13.0"
+version = "0.13.1"
 
 readme = "README.md"
 

--- a/rui/LICENSE
+++ b/rui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rabbita UI contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rui/README.mbt.md
+++ b/rui/README.mbt.md
@@ -1,257 +1,37 @@
-# RUI
+# RUI (Experimental)
+
+> RUI is experimental. Its API and component behavior may change before a
+> stable release.
 
 RUI (`Yoorkin/rui`) is a native component library for
-[Rabbita](https://github.com/moonbit-community/rabbita). It brings the
-shadcn/ui **Vega** visual language and compound component conventions to
-MoonBit while keeping rendering, state, and interaction inside Rabbita.
+[Rabbita](https://github.com/moonbit-community/rabbita), inspired by the
+shadcn/ui Vega visual language.
 
-Components are ready to use as black boxes by default. Use the public API for
-ordinary customization, or copy a component's source when you need to change
-its structure or state model. RUI follows familiar shadcn/ui organization, but
-it is not a drop-in port of the React implementation.
+[Browse the component showcase](https://moonbit-community.github.io/rabbita/components/)
 
-## Highlights
+## Design
 
-- No Tailwind, PostCSS, code generator, or build plugin.
-- No CSS file to import.
-- Vega-style light and dark themes with overridable CSS custom properties.
-- Interactive components own their state through Rabbita incremental values.
-- Native HTML, ARIA, Dialog, and Popover semantics where the browser already
-  provides the correct behavior.
-- JavaScript interaction and native-target initial HTML for SSR.
-- Consistent `data-slot` attributes for testing and application-level styling.
-- MIT-licensed component source that can be copied for deep customization.
+- Black-box components with public APIs for common customization.
+- No Tailwind, external CSS import, code generator, or extra build step.
+- Shared inline base styles, with `theme` providing tokens and the static rules
+  needed for hover, focus, and motion.
+- Interactive state is owned by Rabbita incremental components.
+- Native HTML and ARIA behavior is used where the browser provides it.
+- JavaScript provides browser interaction; native builds expose initial state
+  for SSR and snapshot rendering.
 
-## Installation
+RUI includes components for forms, data display, navigation, disclosure,
+overlays, menus, and feedback. Exact APIs and copyable examples are available
+in the [showcase](https://moonbit-community.github.io/rabbita/components/) and
+the generated `pkg.generated.mbti` interface.
 
-Add Rabbita and RUI to your application's `moon.mod`:
+## Customization
 
-```mbt nocheck
-import {
-  "moonbit-community/rabbita@0.13.1",
-  "Yoorkin/rui@0.1.0",
-}
-```
+Use `--rui-*` theme tokens, component `style` parameters, and `attrs` for normal
+customization. Copy the relevant `.mbt` source when you need to change a
+component's DOM structure, state model, or interaction policy.
 
-Import the packages used by your view from `moon.pkg`:
+## License
 
-```mbt nocheck
-import {
-  "moonbit-community/rabbita",
-  "moonbit-community/rabbita/html",
-  "Yoorkin/rui",
-}
-```
-
-RUI does not require initialization or a CSS import. Component base recipes are
-inline. Wrap the rendered HTML root in `theme` once to provide the selected
-theme tokens, hover states, focus rings, and animations to the subtree:
-
-```mbt nocheck
-@rui.theme(
-  @rui.card([
-    @rui.card_header([
-      @rui.card_title("Account"),
-      @rui.card_description("Manage your sign-in information."),
-    ]),
-    @rui.card_content([
-      @rui.input(placeholder="name@example.com"),
-      @rui.button("Save changes"),
-    ]),
-  ]),
-)
-```
-
-## State model
-
-Presentation components such as `button`, `card`, `input`, `separator`, and
-`table` return `@html.Html` directly.
-
-Interactive components return `@rabbita.Val[@html.Html]`. They keep their state
-inside the component: `default_*` parameters provide initial values, while
-`on_*_change` callbacks observe state updates without transferring state
-ownership to the caller.
-
-An interactive component can be used as the complete view or embedded in
-surrounding HTML with `Val::view`:
-
-```mbt nocheck
-fn notification_settings() -> @rabbita.Val[@html.Html] {
-  let notifications = @rui.switch(
-    default_checked=true,
-    aria_label="Receive notifications",
-  )
-  notifications.view(control =>
-    @rui.theme(
-      @rui.card([
-        @rui.card_header(@rui.card_title("Notifications")),
-        @rui.card_content(
-          @rui.label([
-            control,
-            @html.text("Receive product notifications"),
-          ]),
-        ),
-      ]),
-    )
-  )
-}
-```
-
-`theme` returns `@html.Html`, while interactive components return
-`@rabbita.Val[@html.Html]`. Compose an interactive value first, then apply
-`theme` inside its `view` callback, as in the example above.
-
-Use `Val::view2` through `Val::view9` when a view combines several independent
-interactive components.
-
-Stateful compound components often receive an opaque scope. The scope connects
-their parts to one internal state owner without exposing implementation details:
-
-```mbt nocheck
-@rui.radio_group(
-  default_value="pro",
-  name="plan",
-  aria_label="Plan",
-  scope => [
-    @rui.radio_group_item(scope~, value="free", aria_label="Free"),
-    @rui.radio_group_item(scope~, value="pro", aria_label="Pro"),
-  ],
-)
-```
-
-Select and Combobox include ready-to-use renderers and also accept scoped render
-functions. Components such as Radio Group, menus, Dialog, and Sidebar expose
-opaque builder scopes so their parts share one internal state owner. Popover,
-Hover Card, and Tooltip accept their trigger and content directly instead.
-
-## Themes and customization
-
-Component recipes use `--rui-*` custom properties and include neutral fallback
-values. `theme` supplies the selected light or dark token set together with the
-CSS selectors needed for hover, focus-visible, open, checked, and selected
-states.
-
-Override tokens on `theme` to customize an entire subtree:
-
-```mbt nocheck
-@rui.theme(
-  mode=@rui.Dark,
-  style=[
-    "--rui-primary:oklch(0.62 0.19 265)",
-    "--rui-primary-foreground:white",
-    "--rui-radius:0.75rem",
-  ],
-  @rui.button("Continue"),
-)
-```
-
-Visual components also accept a `style` array. User styles are appended after
-the built-in recipe, so later declarations override matching properties:
-
-```mbt nocheck
-@rui.button(
-  style=["background:rebeccapurple", "border-radius:2px"],
-  "Custom button",
-)
-```
-
-Use `attrs` for additional HTML, ARIA, event, and `data-*` attributes. Components
-copy caller-provided attributes before adding their own values. Avoid managing
-the same CSS property through both the component's `style` parameter and
-`Attrs::style`, because they belong to different VDOM update paths.
-
-The Vega font stack starts with Inter, but RUI does not download a font. It
-falls back to the host application's system sans-serif stack when Inter is not
-available.
-
-## Components
-
-The live [component catalog](https://moonbit-community.github.io/rabbita/components/)
-shows each component, its variants, and copyable MoonBit examples. The generated
-`pkg.generated.mbti` file is the source of truth for exact public signatures.
-
-| Category | Components |
-|---|---|
-| Foundations | Aspect Ratio, Avatar, Badge, Button, Button Group, Direction, Kbd, Label, Separator, Skeleton, Spinner, Toggle, Toggle Group |
-| Forms | Calendar, Checkbox, Combobox, Date Picker, Field, Form, Input, Input Group, Input OTP, Native Select, Radio Group, Select, Slider, Switch, Textarea |
-| Data and content | Alert, Attachment, Bubble, Card, Chart, Data Table, Empty, Item, Marker, Message, Message Scroller, Progress, Resizable, Scroll Area, Table, Typography |
-| Navigation and disclosure | Accordion, Breadcrumb, Carousel, Collapsible, Navigation Menu, Pagination, Sidebar, Tabs |
-| Overlays and menus | Alert Dialog, Command, Context Menu, Dialog, Drawer, Dropdown Menu, Hover Card, Menubar, Popover, Sheet, Tooltip |
-| Feedback | Sonner, Toast, Toaster |
-
-Compound APIs mirror familiar shadcn/ui part names. For example, Card exposes
-Header, Title, Description, Action, Content, and Footer; menu components expose
-Group, Item, CheckboxItem, RadioGroup, RadioItem, Label, Separator, Shortcut,
-and Sub; Sidebar exposes Provider, Trigger, Rail, Header, Footer, Content,
-Group, and menu parts.
-
-Higher-level components are self-contained. Data Table does not require TanStack
-Table, Date Picker does not require React DayPicker, Carousel does not require
-Embla, and Sonner/Toaster do not create a global JavaScript singleton.
-
-## Interaction and accessibility
-
-RUI uses native browser behavior where possible and fills in the state and
-keyboard behavior required by compound widgets:
-
-- Buttons, inputs, textareas, native selects, and radios preserve native form
-  and keyboard semantics.
-- Dialog, Alert Dialog, Sheet, Drawer, and Command Dialog use the browser's
-  top-layer dialog behavior for Escape handling, focus boundaries, and focus
-  restoration.
-- Popover, Hover Card, Tooltip, and menu surfaces use native floating/top-layer
-  primitives with Rabbita-owned open state and, for menus, active-item state.
-- Menu, Command, Combobox, and Select support their applicable ARIA roles,
-  arrow keys, Home/End, Enter, Escape, roving focus, or active-option behavior.
-- Tabs support arrow-key and Home/End navigation. Calendar supports a single
-  tab stop, arrow keys, Home/End, PageUp/PageDown, and cross-month focus
-  movement.
-- Disabled, read-only, invalid, mixed, pressed, checked, and selected states are
-  reflected through the applicable native, ARIA, and `data-*` attributes.
-- Motion respects `prefers-reduced-motion`.
-
-## Rendering targets
-
-The JavaScript target provides browser events and interactive state updates.
-On the native target, interactive components expose their initial state as a
-constant Rabbita value for SSR and snapshot rendering; they do not emulate
-browser interaction inside the server process.
-
-## Showcase
-
-Browse the hosted [Components pages](https://moonbit-community.github.io/rabbita/components/)
-for interactive variants and copyable MoonBit examples. Each example calls the
-same public RUI API that applications use and matches the rendered result.
-
-## Current limitations
-
-- A single `theme` wrapper is required for pseudo-classes, media queries, and
-  keyframe animations. These rules cannot be expressed in an HTML `style`
-  attribute, so `theme` emits one static internal stylesheet; it does not use a
-  runtime registration system.
-- Modern browser support for native Dialog and Popover primitives is expected.
-- Drawer uses native dialog behavior and does not reproduce Vaul drag velocity
-  or snap points.
-- Chart provides themed container, tooltip, and legend surfaces. Supply your
-  own SVG, Canvas, or charting engine for the actual visualization.
-
-## Deep customization
-
-Start with theme tokens, component `style`, `attrs`, and compound builders. If
-you need a different DOM structure, sizing system, state machine, or interaction
-policy, copy the relevant `.mbt` source into your application and maintain it
-locally.
-
-There is no vendor synchronization, style registration, generator, or
-additional build convention to keep in sync.
-
-## Upstream and license
-
-RUI follows the current [shadcn/ui component documentation](https://ui.shadcn.com/docs/components)
-and [shadcn/ui source](https://github.com/shadcn-ui/ui) for the Vega visual
-language and compound API conventions.
-
-RUI is implemented for Rabbita and is not affiliated with shadcn/ui. The module
-is available under the [MIT License](./LICENSE). See
-[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) for upstream copyright and
-attribution notices.
+RUI is available under the [MIT License](./LICENSE). See
+[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) for upstream attribution.

--- a/rui/README.mbt.md
+++ b/rui/README.mbt.md
@@ -1,0 +1,257 @@
+# RUI
+
+RUI (`Yoorkin/rui`) is a native component library for
+[Rabbita](https://github.com/moonbit-community/rabbita). It brings the
+shadcn/ui **Vega** visual language and compound component conventions to
+MoonBit while keeping rendering, state, and interaction inside Rabbita.
+
+Components are ready to use as black boxes by default. Use the public API for
+ordinary customization, or copy a component's source when you need to change
+its structure or state model. RUI follows familiar shadcn/ui organization, but
+it is not a drop-in port of the React implementation.
+
+## Highlights
+
+- No Tailwind, PostCSS, code generator, or build plugin.
+- No CSS file to import.
+- Vega-style light and dark themes with overridable CSS custom properties.
+- Interactive components own their state through Rabbita incremental values.
+- Native HTML, ARIA, Dialog, and Popover semantics where the browser already
+  provides the correct behavior.
+- JavaScript interaction and native-target initial HTML for SSR.
+- Consistent `data-slot` attributes for testing and application-level styling.
+- MIT-licensed component source that can be copied for deep customization.
+
+## Installation
+
+Add Rabbita and RUI to your application's `moon.mod`:
+
+```mbt nocheck
+import {
+  "moonbit-community/rabbita@0.13.1",
+  "Yoorkin/rui@0.1.0",
+}
+```
+
+Import the packages used by your view from `moon.pkg`:
+
+```mbt nocheck
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+  "Yoorkin/rui",
+}
+```
+
+RUI does not require initialization or a CSS import. Component base recipes are
+inline. Wrap the rendered HTML root in `theme` once to provide the selected
+theme tokens, hover states, focus rings, and animations to the subtree:
+
+```mbt nocheck
+@rui.theme(
+  @rui.card([
+    @rui.card_header([
+      @rui.card_title("Account"),
+      @rui.card_description("Manage your sign-in information."),
+    ]),
+    @rui.card_content([
+      @rui.input(placeholder="name@example.com"),
+      @rui.button("Save changes"),
+    ]),
+  ]),
+)
+```
+
+## State model
+
+Presentation components such as `button`, `card`, `input`, `separator`, and
+`table` return `@html.Html` directly.
+
+Interactive components return `@rabbita.Val[@html.Html]`. They keep their state
+inside the component: `default_*` parameters provide initial values, while
+`on_*_change` callbacks observe state updates without transferring state
+ownership to the caller.
+
+An interactive component can be used as the complete view or embedded in
+surrounding HTML with `Val::view`:
+
+```mbt nocheck
+fn notification_settings() -> @rabbita.Val[@html.Html] {
+  let notifications = @rui.switch(
+    default_checked=true,
+    aria_label="Receive notifications",
+  )
+  notifications.view(control =>
+    @rui.theme(
+      @rui.card([
+        @rui.card_header(@rui.card_title("Notifications")),
+        @rui.card_content(
+          @rui.label([
+            control,
+            @html.text("Receive product notifications"),
+          ]),
+        ),
+      ]),
+    )
+  )
+}
+```
+
+`theme` returns `@html.Html`, while interactive components return
+`@rabbita.Val[@html.Html]`. Compose an interactive value first, then apply
+`theme` inside its `view` callback, as in the example above.
+
+Use `Val::view2` through `Val::view9` when a view combines several independent
+interactive components.
+
+Stateful compound components often receive an opaque scope. The scope connects
+their parts to one internal state owner without exposing implementation details:
+
+```mbt nocheck
+@rui.radio_group(
+  default_value="pro",
+  name="plan",
+  aria_label="Plan",
+  scope => [
+    @rui.radio_group_item(scope~, value="free", aria_label="Free"),
+    @rui.radio_group_item(scope~, value="pro", aria_label="Pro"),
+  ],
+)
+```
+
+Select and Combobox include ready-to-use renderers and also accept scoped render
+functions. Components such as Radio Group, menus, Dialog, and Sidebar expose
+opaque builder scopes so their parts share one internal state owner. Popover,
+Hover Card, and Tooltip accept their trigger and content directly instead.
+
+## Themes and customization
+
+Component recipes use `--rui-*` custom properties and include neutral fallback
+values. `theme` supplies the selected light or dark token set together with the
+CSS selectors needed for hover, focus-visible, open, checked, and selected
+states.
+
+Override tokens on `theme` to customize an entire subtree:
+
+```mbt nocheck
+@rui.theme(
+  mode=@rui.Dark,
+  style=[
+    "--rui-primary:oklch(0.62 0.19 265)",
+    "--rui-primary-foreground:white",
+    "--rui-radius:0.75rem",
+  ],
+  @rui.button("Continue"),
+)
+```
+
+Visual components also accept a `style` array. User styles are appended after
+the built-in recipe, so later declarations override matching properties:
+
+```mbt nocheck
+@rui.button(
+  style=["background:rebeccapurple", "border-radius:2px"],
+  "Custom button",
+)
+```
+
+Use `attrs` for additional HTML, ARIA, event, and `data-*` attributes. Components
+copy caller-provided attributes before adding their own values. Avoid managing
+the same CSS property through both the component's `style` parameter and
+`Attrs::style`, because they belong to different VDOM update paths.
+
+The Vega font stack starts with Inter, but RUI does not download a font. It
+falls back to the host application's system sans-serif stack when Inter is not
+available.
+
+## Components
+
+The live [component catalog](https://moonbit-community.github.io/rabbita/components/)
+shows each component, its variants, and copyable MoonBit examples. The generated
+`pkg.generated.mbti` file is the source of truth for exact public signatures.
+
+| Category | Components |
+|---|---|
+| Foundations | Aspect Ratio, Avatar, Badge, Button, Button Group, Direction, Kbd, Label, Separator, Skeleton, Spinner, Toggle, Toggle Group |
+| Forms | Calendar, Checkbox, Combobox, Date Picker, Field, Form, Input, Input Group, Input OTP, Native Select, Radio Group, Select, Slider, Switch, Textarea |
+| Data and content | Alert, Attachment, Bubble, Card, Chart, Data Table, Empty, Item, Marker, Message, Message Scroller, Progress, Resizable, Scroll Area, Table, Typography |
+| Navigation and disclosure | Accordion, Breadcrumb, Carousel, Collapsible, Navigation Menu, Pagination, Sidebar, Tabs |
+| Overlays and menus | Alert Dialog, Command, Context Menu, Dialog, Drawer, Dropdown Menu, Hover Card, Menubar, Popover, Sheet, Tooltip |
+| Feedback | Sonner, Toast, Toaster |
+
+Compound APIs mirror familiar shadcn/ui part names. For example, Card exposes
+Header, Title, Description, Action, Content, and Footer; menu components expose
+Group, Item, CheckboxItem, RadioGroup, RadioItem, Label, Separator, Shortcut,
+and Sub; Sidebar exposes Provider, Trigger, Rail, Header, Footer, Content,
+Group, and menu parts.
+
+Higher-level components are self-contained. Data Table does not require TanStack
+Table, Date Picker does not require React DayPicker, Carousel does not require
+Embla, and Sonner/Toaster do not create a global JavaScript singleton.
+
+## Interaction and accessibility
+
+RUI uses native browser behavior where possible and fills in the state and
+keyboard behavior required by compound widgets:
+
+- Buttons, inputs, textareas, native selects, and radios preserve native form
+  and keyboard semantics.
+- Dialog, Alert Dialog, Sheet, Drawer, and Command Dialog use the browser's
+  top-layer dialog behavior for Escape handling, focus boundaries, and focus
+  restoration.
+- Popover, Hover Card, Tooltip, and menu surfaces use native floating/top-layer
+  primitives with Rabbita-owned open state and, for menus, active-item state.
+- Menu, Command, Combobox, and Select support their applicable ARIA roles,
+  arrow keys, Home/End, Enter, Escape, roving focus, or active-option behavior.
+- Tabs support arrow-key and Home/End navigation. Calendar supports a single
+  tab stop, arrow keys, Home/End, PageUp/PageDown, and cross-month focus
+  movement.
+- Disabled, read-only, invalid, mixed, pressed, checked, and selected states are
+  reflected through the applicable native, ARIA, and `data-*` attributes.
+- Motion respects `prefers-reduced-motion`.
+
+## Rendering targets
+
+The JavaScript target provides browser events and interactive state updates.
+On the native target, interactive components expose their initial state as a
+constant Rabbita value for SSR and snapshot rendering; they do not emulate
+browser interaction inside the server process.
+
+## Showcase
+
+Browse the hosted [Components pages](https://moonbit-community.github.io/rabbita/components/)
+for interactive variants and copyable MoonBit examples. Each example calls the
+same public RUI API that applications use and matches the rendered result.
+
+## Current limitations
+
+- A single `theme` wrapper is required for pseudo-classes, media queries, and
+  keyframe animations. These rules cannot be expressed in an HTML `style`
+  attribute, so `theme` emits one static internal stylesheet; it does not use a
+  runtime registration system.
+- Modern browser support for native Dialog and Popover primitives is expected.
+- Drawer uses native dialog behavior and does not reproduce Vaul drag velocity
+  or snap points.
+- Chart provides themed container, tooltip, and legend surfaces. Supply your
+  own SVG, Canvas, or charting engine for the actual visualization.
+
+## Deep customization
+
+Start with theme tokens, component `style`, `attrs`, and compound builders. If
+you need a different DOM structure, sizing system, state machine, or interaction
+policy, copy the relevant `.mbt` source into your application and maintain it
+locally.
+
+There is no vendor synchronization, style registration, generator, or
+additional build convention to keep in sync.
+
+## Upstream and license
+
+RUI follows the current [shadcn/ui component documentation](https://ui.shadcn.com/docs/components)
+and [shadcn/ui source](https://github.com/shadcn-ui/ui) for the Vega visual
+language and compound API conventions.
+
+RUI is implemented for Rabbita and is not affiliated with shadcn/ui. The module
+is available under the [MIT License](./LICENSE). See
+[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) for upstream copyright and
+attribution notices.

--- a/rui/README.md
+++ b/rui/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/rui/THIRD_PARTY_NOTICES.md
+++ b/rui/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,54 @@
+# Third-party notices
+
+Rabbita UI translates visual recipes and public component conventions from
+shadcn/ui's Vega style. Calendar focus behavior additionally follows React
+DayPicker, which shadcn/ui wraps. The MoonBit implementation is original and
+uses Rabbita-native HTML, ARIA, browser primitives, and incremental state.
+
+## shadcn/ui
+
+MIT License
+
+Copyright (c) 2023 shadcn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## React DayPicker
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rui/accordion.mbt
+++ b/rui/accordion.mbt
@@ -1,0 +1,652 @@
+///|
+pub(all) enum AccordionType {
+  Single
+  Multiple
+} derive(Debug, Eq)
+
+///|
+/// One entry for the self-contained accordion component.
+///
+/// Use the compound `accordion_*` functions directly when the trigger needs
+/// richer content than this entry's text label.
+struct AccordionEntry {
+  value : String
+  label : String
+  content : @html.Html
+  disabled : Bool
+}
+
+///|
+const AccordionRootStyle : String = "display:block;width:100%;min-width:0;color:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const AccordionItemStyle : String = "display:block;width:100%;min-width:0;border-bottom:1px solid var(--rui-border,oklch(0.922 0 0))"
+
+///|
+const AccordionTriggerStyle : String = "display:flex;width:100%;min-height:3rem;align-items:center;justify-content:space-between;gap:0.75rem;border:1px solid var(--rui-accordion-border,var(--rui-accordion-base-border,transparent));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);margin:0;padding:0.75rem 0;background:var(--rui-accordion-bg,var(--rui-accordion-base-bg,transparent));color:var(--rui-accordion-fg,var(--rui-accordion-base-fg,inherit));box-shadow:var(--rui-accordion-shadow,var(--rui-accordion-base-shadow,none));font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:start;list-style:none;cursor:pointer;user-select:none;outline-offset:2px"
+
+///|
+const AccordionTriggerOpenStyle : String = "--rui-accordion-base-fg:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const AccordionTriggerLabelStyle : String = "display:block;min-width:0;flex:1"
+
+///|
+const AccordionIndicatorBoxStyle : String = "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));pointer-events:none"
+
+///|
+const AccordionIndicatorStyle : String = "display:block;width:0.4375rem;height:0.4375rem;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform-origin:center;transition:transform 150ms ease"
+
+///|
+const AccordionIndicatorClosedStyle : String = "transform:translateY(-0.125rem) rotate(45deg)"
+
+///|
+const AccordionIndicatorOpenStyle : String = "transform:translateY(0.125rem) rotate(225deg)"
+
+///|
+const AccordionContentOuterStyle : String = "display:grid;min-width:0;grid-template-rows:var(--rui-accordion-content-rows,0fr);opacity:var(--rui-accordion-content-opacity,0);visibility:var(--rui-accordion-content-visibility,hidden);transition:grid-template-rows 200ms cubic-bezier(0.22,1,0.36,1),opacity 150ms ease,visibility 0s linear var(--rui-accordion-content-visibility-delay,200ms)"
+
+///|
+const AccordionContentOpenStyle : String = "--rui-accordion-content-rows:1fr;--rui-accordion-content-opacity:1;--rui-accordion-content-visibility:visible;--rui-accordion-content-visibility-delay:0s"
+
+///|
+const AccordionContentClosedStyle : String = "--rui-accordion-content-rows:0fr;--rui-accordion-content-opacity:0;--rui-accordion-content-visibility:hidden;--rui-accordion-content-visibility-delay:200ms"
+
+///|
+const AccordionContentClipStyle : String = "min-width:0;min-height:0;overflow:hidden"
+
+///|
+const AccordionContentStyle : String = "min-width:0;padding:0 0 1rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.5;overflow-wrap:anywhere"
+
+///|
+fn accordion_type_value(type_ : AccordionType) -> String {
+  match type_ {
+    Single => "single"
+    Multiple => "multiple"
+  }
+}
+
+///|
+fn accordion_state(open : Bool) -> String {
+  if open {
+    "open"
+  } else {
+    "closed"
+  }
+}
+
+///|
+fn accordion_state_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  open : Bool,
+) -> @html.Attrs {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("state", accordion_state(open))
+  if open {
+    ignore(element_attrs.data_set("open", ""))
+  } else {
+    ignore(element_attrs.data_set("closed", ""))
+  }
+  element_attrs
+}
+
+///|
+#cfg(target="js")
+fn accordion_bind_value_change(
+  attrs : @html.Attrs,
+  value : String,
+  emit : @cmd.Emit[String],
+) -> Unit {
+  ignore(
+    attrs.on_click(event => {
+      event.prevent_default()
+      emit(value)
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn accordion_bind_value_change(
+  attrs : @html.Attrs,
+  value : String,
+  emit : @cmd.Emit[String],
+) -> Unit {
+  ignore((attrs, value, emit))
+}
+
+///|
+#cfg(target="js")
+fn accordion_move_focus(event : @dom.KeyboardEvent) -> Bool {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.shift_key() {
+    return false
+  }
+  guard ui_roving_context(
+      event, "[data-slot=\"accordion-trigger\"]", "[data-slot=\"accordion\"]", "[data-slot=\"accordion-trigger\"]",
+    )
+    is Some(context) else {
+    return false
+  }
+  if context.root.get_attribute("aria-disabled").unwrap_or("") == "true" {
+    return false
+  }
+  guard ui_roving_target(context, event.key(), "vertical", false)
+    is Some(target) else {
+    return false
+  }
+  ui_focus_element(target)
+  true
+}
+
+///|
+#cfg(target="js")
+fn accordion_bind_keyboard(attrs : @html.Attrs) -> Unit {
+  ignore(
+    attrs.on_keydown(event => {
+      if accordion_move_focus(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn accordion_bind_keyboard(attrs : @html.Attrs) -> Unit {
+  ignore(attrs)
+}
+
+///|
+fn accordion_indicator(open : Bool) -> @html.Html {
+  let state = accordion_state(open)
+  @html.span(
+    style=[UiBoxSizing, AccordionIndicatorBoxStyle],
+    attrs=@html.Attrs::build()
+      .aria_hidden("true")
+      .data_set("slot", "accordion-indicator")
+      .data_set("state", state),
+    @html.span(
+      style=[
+        UiBoxSizing,
+        AccordionIndicatorStyle,
+        if open {
+          AccordionIndicatorOpenStyle
+        } else {
+          AccordionIndicatorClosedStyle
+        },
+      ],
+      attrs=@html.Attrs::build().data_set("state", state),
+      @html.nothing,
+    ),
+  )
+}
+
+///|
+fn accordion_entry_enabled(
+  items : Array[AccordionEntry],
+  value : String,
+) -> Bool {
+  for item in items {
+    if item.value == value {
+      return !item.disabled
+    }
+  }
+  false
+}
+
+///|
+fn accordion_initial_values(
+  items : Array[AccordionEntry],
+  type_ : AccordionType,
+  default_value : String?,
+  default_values : Array[String],
+) -> Array[String] {
+  match type_ {
+    Single =>
+      if default_value is Some(value) && accordion_entry_enabled(items, value) {
+        [value]
+      } else {
+        []
+      }
+    Multiple => {
+      let values : Array[String] = []
+      for value in default_values {
+        if accordion_entry_enabled(items, value) && !values.contains(value) {
+          values.push(value)
+        }
+      }
+      values
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn accordion_next_values(
+  current : Array[String],
+  value : String,
+  type_ : AccordionType,
+  collapsible : Bool,
+) -> Array[String] {
+  match type_ {
+    Single =>
+      if current.contains(value) {
+        if collapsible {
+          []
+        } else {
+          current
+        }
+      } else {
+        [value]
+      }
+    Multiple =>
+      if current.contains(value) {
+        current.filter(item => item != value)
+      } else {
+        let next = current.copy()
+        next.push(value)
+        next
+      }
+  }
+}
+
+///|
+/// Construct one black-box accordion entry.
+pub fn accordion_entry(
+  value~ : String,
+  label~ : String,
+  content~ : @html.Html,
+  disabled? : Bool = false,
+) -> AccordionEntry {
+  { value, label, content, disabled }
+}
+
+///|
+/// Render the root for a composed accordion.
+pub fn[C : @html.IsChildren] accordion_root(
+  type_? : AccordionType = Single,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "accordion")
+    .data_set("type", accordion_type_value(type_))
+    .data_set("orientation", "vertical")
+    .aria_disabled(ui_bool(disabled))
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  }
+  accordion_bind_keyboard(element_attrs)
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        AccordionRootStyle,
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render one accordion item container.
+pub fn[C : @html.IsChildren] accordion_item(
+  value~ : String,
+  open? : Bool = false,
+  disabled? : Bool = false,
+  name? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = accordion_state_attrs(attrs, "accordion-item", open)
+    .data_set("value", value)
+    .aria_disabled(ui_bool(disabled))
+  if name is Some(name) {
+    ignore(element_attrs.data_set("group", name))
+  }
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  }
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, AccordionItemStyle, ui_disabled_visual_style(disabled)],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render one native button accordion trigger.
+pub fn[C : @html.IsChildren] accordion_trigger(
+  value~ : String,
+  open? : Bool = false,
+  disabled? : Bool = false,
+  controls? : String,
+  show_indicator? : Bool = true,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = accordion_state_attrs(attrs, "accordion-trigger", open)
+    .data_set("value", value)
+    .aria_expanded(ui_bool(open))
+    .aria_disabled(ui_bool(disabled))
+  if controls is Some(controls) {
+    ignore(element_attrs.aria_controls(controls))
+  }
+  if disabled {
+    ignore(element_attrs.data_set("disabled", "").tabindex(-1))
+  }
+  if !disabled && on_value_change is Some(emit) {
+    accordion_bind_value_change(element_attrs, value, emit)
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        AccordionTriggerStyle,
+        if open {
+          AccordionTriggerOpenStyle
+        } else {
+          ""
+        },
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    [
+      @html.span(
+        style=[UiBoxSizing, AccordionTriggerLabelStyle],
+        attrs=@html.Attrs::build().data_set("slot", "accordion-trigger-label"),
+        children,
+      ),
+      if show_indicator {
+        accordion_indicator(open)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+/// Render one accordion panel.
+pub fn[C : @html.IsChildren] accordion_content(
+  value~ : String,
+  open? : Bool = false,
+  force_mount? : Bool = false,
+  labelledby? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = accordion_state_attrs(attrs, "accordion-content", open)
+    .data_set("value", value)
+    .data_set("force-mount", ui_bool(force_mount))
+    .role("region")
+    .aria_hidden(ui_bool(!open))
+    .inert(!open)
+  if labelledby is Some(labelledby) {
+    ignore(element_attrs.aria_labelledby(labelledby))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        AccordionContentOuterStyle,
+        if open {
+          AccordionContentOpenStyle
+        } else {
+          AccordionContentClosedStyle
+        },
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    @html.div(
+      style=[UiBoxSizing, AccordionContentClipStyle],
+      attrs=@html.Attrs::build().data_set("slot", "accordion-content-clip"),
+      @html.div(
+        style=[UiBoxSizing, AccordionContentStyle],
+        attrs=@html.Attrs::build().data_set("slot", "accordion-content-body"),
+        children,
+      ),
+    ),
+  )
+}
+
+///|
+/// Render the current accordion state for the public incremental component.
+fn render_accordion(
+  items~ : Array[AccordionEntry],
+  values~ : Array[String],
+  type_? : AccordionType = Single,
+  collapsible? : Bool = true,
+  disabled? : Bool = false,
+  show_indicator? : Bool = true,
+  force_mount? : Bool = false,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  item_style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+) -> @html.Html {
+  let item_nodes : Array[@html.Html] = []
+  for index, item in items {
+    let open = values.contains(item.value)
+    let item_disabled = disabled || item.disabled
+    let trigger_id = id.map(id => "\{id}-trigger-\{index}")
+    let content_id = id.map(id => "\{id}-content-\{index}")
+    let group_name = if type_ is Single {
+      id.map(id => "\{id}-group")
+    } else {
+      None
+    }
+    let trigger_html = {
+      let controls = content_id
+      let id = trigger_id
+      accordion_trigger(
+        value=item.value,
+        open~,
+        disabled=item_disabled,
+        controls?,
+        show_indicator~,
+        on_value_change?,
+        id?,
+        style=trigger_style,
+        item.label,
+      )
+    }
+    let content_html = {
+      let labelledby = trigger_id
+      let id = content_id
+      accordion_content(
+        value=item.value,
+        open~,
+        force_mount~,
+        labelledby?,
+        id?,
+        style=content_style,
+        item.content,
+      )
+    }
+    let item_html = {
+      let name = group_name
+      accordion_item(
+        value=item.value,
+        open~,
+        disabled=item_disabled,
+        name?,
+        style=item_style,
+        [trigger_html, content_html],
+      )
+    }
+    item_nodes.push(item_html)
+  }
+  let root_attrs = ui_attrs(attrs).data_set("collapsible", ui_bool(collapsible))
+  accordion_root(
+    type_~,
+    disabled~,
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=root_attrs,
+    style~,
+    item_nodes,
+  )
+}
+
+///|
+/// Build a self-contained accordion with component-local incremental state.
+#cfg(target="js")
+pub fn accordion(
+  items~ : Array[AccordionEntry],
+  type_? : AccordionType = Single,
+  collapsible? : Bool = true,
+  disabled? : Bool = false,
+  default_value? : String,
+  default_values? : Array[String] = [],
+  show_indicator? : Bool = true,
+  force_mount? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  item_style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = accordion_initial_values(
+    items, type_, default_value, default_values,
+  )
+  let (values, set_values) = @rabbita.create_variable(initial)
+  let on_value_change = set_values.map(value => {
+    current => accordion_next_values(current, value, type_, collapsible)
+  })
+  values.view(values => {
+    render_accordion(
+      items~,
+      values~,
+      type_~,
+      collapsible~,
+      disabled~,
+      show_indicator~,
+      force_mount~,
+      on_value_change~,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      style~,
+      item_style~,
+      trigger_style~,
+      content_style~,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: render the requested initial selection as a constant
+/// incremental value.
+#cfg(not(target="js"))
+pub fn accordion(
+  items~ : Array[AccordionEntry],
+  type_? : AccordionType = Single,
+  collapsible? : Bool = true,
+  disabled? : Bool = false,
+  default_value? : String,
+  default_values? : Array[String] = [],
+  show_indicator? : Bool = true,
+  force_mount? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  item_style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let values = accordion_initial_values(
+    items, type_, default_value, default_values,
+  )
+  @rabbita.Val::constant(
+    render_accordion(
+      items~,
+      values~,
+      type_~,
+      collapsible~,
+      disabled~,
+      show_indicator~,
+      force_mount~,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      style~,
+      item_style~,
+      trigger_style~,
+      content_style~,
+    ),
+  )
+}

--- a/rui/alert.mbt
+++ b/rui/alert.mbt
@@ -1,0 +1,127 @@
+///|
+pub(all) enum AlertVariant {
+  Default
+  Destructive
+} derive(Debug, Eq)
+
+///|
+const AlertBaseStyle : String = "position:relative;display:grid;grid-template-columns:var(--rui-alert-columns,0 minmax(0,1fr) auto);grid-template-rows:auto auto;width:100%;min-width:0;align-items:start;column-gap:var(--rui-alert-column-gap,0);row-gap:0.125rem;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem);padding:0.75rem 1rem;text-align:start;font-size:0.875rem;line-height:1.25rem;--rui-icon-size:1rem"
+
+///|
+const AlertDefaultStyle : String = "--rui-alert-description-color:var(--rui-muted-foreground,oklch(0.556 0 0));background:var(--rui-card,oklch(1 0 0));color:var(--rui-card-foreground,oklch(0.145 0 0))"
+
+///|
+const AlertDestructiveStyle : String = "--rui-alert-description-color:color-mix(in oklab,var(--rui-destructive,oklch(0.577 0.245 27.325)) 90%,transparent);background:var(--rui-card,oklch(1 0 0));color:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+
+///|
+const AlertTitleStyle : String = "grid-column:2;grid-row:1;min-width:0;min-height:1rem;overflow:hidden;font-weight:500;letter-spacing:-0.025em;text-overflow:ellipsis;white-space:nowrap"
+
+///|
+const AlertDescriptionStyle : String = "grid-column:2;grid-row:2;display:grid;min-width:0;justify-items:start;gap:0.25rem;color:var(--rui-alert-description-color,var(--rui-muted-foreground,oklch(0.556 0 0)));font-size:0.875rem;line-height:1.25rem;text-wrap:balance"
+
+///|
+const AlertActionStyle : String = "grid-column:3;grid-row:1 / span 2;align-self:start;justify-self:end;margin-inline-start:1rem;transform:translate(var(--rui-alert-action-offset-inline,0.25rem),-0.125rem)"
+
+///|
+fn alert_variant_style(variant : AlertVariant) -> String {
+  match variant {
+    Default => AlertDefaultStyle
+    Destructive => AlertDestructiveStyle
+  }
+}
+
+///|
+fn alert_part_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+/// Render a semantic live alert using the Vega default or destructive recipe.
+///
+/// Title, description, and action parts occupy stable grid tracks. This keeps
+/// optional actions from covering text without relying on stylesheet `:has()`.
+pub fn[C : @html.IsChildren] alert(
+  variant? : AlertVariant = Default,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = alert_part_attrs(attrs, "alert").role("alert")
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        AlertBaseStyle,
+        alert_variant_style(variant),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, AlertTitleStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=alert_part_attrs(attrs, "alert-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, AlertDescriptionStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=alert_part_attrs(attrs, "alert-description"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_action(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, AlertActionStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=alert_part_attrs(attrs, "alert-action"),
+    children,
+  )
+}

--- a/rui/alert_dialog.mbt
+++ b/rui/alert_dialog.mbt
@@ -1,0 +1,365 @@
+///|
+/// Explicit scope passed by [`alert_dialog`] to its compound parts.
+struct AlertDialogScope(DialogScope)
+
+///|
+const AlertDialogContentStyle : String = "width:min(100%,32rem)"
+
+///|
+const AlertDialogMediaStyle : String = "display:inline-flex;width:4rem;height:4rem;flex-shrink:0;align-items:center;justify-content:center;margin-bottom:0.5rem;border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-muted,oklch(0.97 0 0));color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+
+///|
+/// Create a stateful alert dialog.
+///
+/// Unlike [`dialog_content`], [`alert_dialog_content`] does not dismiss on an
+/// overlay click and does not render an implicit close icon. A deliberate
+/// action or cancel control is therefore always visible in normal use.
+pub fn alert_dialog(
+  id~ : String,
+  default_open? : Bool = false,
+  close_on_escape? : Bool = true,
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  children : (AlertDialogScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  dialog(
+    id~,
+    default_open~,
+    modal=true,
+    close_on_escape~,
+    on_open_change?,
+    on_close?,
+    scope => children(AlertDialogScope(scope)),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_dialog_trigger(
+  scope : AlertDialogScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let dialog_scope = scope.0
+  let trigger_attrs = dialog_state_attrs(
+      attrs,
+      "alert-dialog-trigger",
+      dialog_scope.open,
+    )
+    .aria_haspopup("dialog")
+    .aria_controls(dialog_scope.id)
+    .aria_expanded(ui_bool(dialog_scope.open))
+  dialog_control_button(
+    slot="alert-dialog-trigger",
+    command=dialog_scope.open_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(trigger_attrs),
+    style~,
+    children,
+  )
+}
+
+///|
+/// Pass native alert-dialog content through without adding a DOM node.
+pub fn alert_dialog_portal(children : Array[@html.Html]) -> @html.Html {
+  @html.fragment(children)
+}
+
+///|
+/// Render the non-dismissible backdrop for an alert-dialog scope.
+pub fn alert_dialog_overlay(
+  scope : AlertDialogScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  dialog_overlay_part(
+    scope.0,
+    slot="alert-dialog-overlay",
+    close_on_overlay=false,
+    id~,
+    class~,
+    title~,
+    hidden~,
+    attrs~,
+    style~,
+  )
+}
+
+///|
+/// Render a native `role="alertdialog"` with a non-dismissible backdrop.
+pub fn[C : @html.IsChildren] alert_dialog_content(
+  scope : AlertDialogScope,
+  described? : Bool = true,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  native_attrs? : @html.Attrs,
+  native_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let dialog_scope = scope.0
+  let native_element_attrs = dialog_state_attrs(
+      native_attrs,
+      "alert-dialog-native",
+      dialog_scope.open,
+    )
+    .role("alertdialog")
+    .aria_modal("true")
+    .data_set("modal", "true")
+    .data_set("close-on-outside", "false")
+    .data_set("close-on-escape", ui_bool(dialog_scope.close_on_escape))
+  if aria_label is Some(label) {
+    ignore(native_element_attrs.aria_label(label))
+  } else {
+    ignore(native_element_attrs.aria_labelledby(dialog_scope.title_id()))
+  }
+  if described {
+    ignore(native_element_attrs.aria_describedby(dialog_scope.description_id()))
+  }
+  let content_attrs = dialog_state_attrs(
+    attrs,
+    "alert-dialog-content",
+    dialog_scope.open,
+  )
+  let positioner_attrs = dialog_state_attrs(
+    None,
+    "alert-dialog-positioner",
+    dialog_scope.open,
+  )
+  let content = @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        DialogContentStyle,
+        AlertDialogContentStyle,
+        dialog_content_motion_style(dialog_scope.open),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=content_attrs,
+    children,
+  )
+  let open = dialog_scope.native_open
+  let on_close = dialog_scope.on_close
+  let on_cancel = dialog_scope.on_cancel
+  let closedby = if dialog_scope.close_on_escape {
+    "closerequest"
+  } else {
+    "none"
+  }
+  alert_dialog_portal([
+    @html.dialog(
+      style=ui_styles([UiBoxSizing, DialogNativeStyle], native_style),
+      id=dialog_scope.id,
+      open?,
+      closedby~,
+      on_close?,
+      on_cancel?,
+      attrs=native_element_attrs,
+      [
+        alert_dialog_overlay(
+          scope,
+          attrs=ui_attrs(overlay_attrs),
+          style=overlay_style,
+        ),
+        @html.div(
+          style=[UiBoxSizing, DialogPositionerStyle],
+          attrs=positioner_attrs,
+          content,
+        ),
+      ],
+    ),
+  ])
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_dialog_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DialogHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "alert-dialog-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_dialog_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DialogFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "alert-dialog-footer"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_dialog_title(
+  scope : AlertDialogScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.0.title_id())
+  @html.h2(
+    style=ui_styles([UiBoxSizing, DialogTitleStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "alert-dialog-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] alert_dialog_description(
+  scope : AlertDialogScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.0.description_id())
+  @html.p(
+    style=ui_styles([UiBoxSizing, DialogDescriptionStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "alert-dialog-description"),
+    children,
+  )
+}
+
+///|
+/// Render the shadcn alert-dialog media tile for an icon or illustration.
+pub fn[C : @html.IsChildren] alert_dialog_media(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, AlertDialogMediaStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "alert-dialog-media"),
+    children,
+  )
+}
+
+///|
+/// Render the primary alert-dialog action and close after its caller handler.
+pub fn[C : @html.IsChildren] alert_dialog_action(
+  scope : AlertDialogScope,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  dialog_control_button(
+    slot="alert-dialog-action",
+    command=scope.0.close_command,
+    variant=Default,
+    size=Default,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs~,
+    style~,
+    children,
+  )
+}
+
+///|
+/// Render the secondary alert-dialog cancel control.
+pub fn[C : @html.IsChildren] alert_dialog_cancel(
+  scope : AlertDialogScope,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let cancel_attrs = ui_attrs(attrs).autofocus(!disabled)
+  dialog_control_button(
+    slot="alert-dialog-cancel",
+    command=scope.0.close_command,
+    variant=Outline,
+    size=Default,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(cancel_attrs),
+    style~,
+    children,
+  )
+}

--- a/rui/aspect_ratio.mbt
+++ b/rui/aspect_ratio.mbt
@@ -1,0 +1,27 @@
+///|
+const AspectRatioStyle : String = "position:relative;width:100%;overflow:hidden"
+
+///|
+/// Keep content at a stable width-to-height ratio without external CSS.
+pub fn[C : @html.IsChildren] aspect_ratio(
+  ratio? : Double = 1.0,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let safe_ratio = if ratio > 0.0 { ratio } else { 1.0 }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "aspect-ratio"),
+    style=ui_styles(
+      [UiBoxSizing, AspectRatioStyle, "aspect-ratio:\{safe_ratio}"],
+      style,
+    ),
+    children,
+  )
+}

--- a/rui/attachment.mbt
+++ b/rui/attachment.mbt
@@ -1,0 +1,433 @@
+///|
+pub(all) enum AttachmentState {
+  AttachmentIdle
+  AttachmentUploading
+  AttachmentProcessing
+  AttachmentError
+  AttachmentDone
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AttachmentSize {
+  AttachmentDefaultSize
+  AttachmentSm
+  AttachmentXs
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AttachmentOrientation {
+  AttachmentHorizontal
+  AttachmentVertical
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AttachmentMediaVariant {
+  AttachmentIcon
+  AttachmentImage
+} derive(Debug, Eq)
+
+///|
+const AttachmentTitleShimmerStyle : String = "--rui-attachment-title-shimmer-spread:calc(3ch + 40px);--rui-attachment-title-shimmer-base:currentColor;--rui-attachment-title-shimmer-highlight:light-dark(oklch(from currentColor l c h / calc(alpha * 0.2)),oklch(from currentColor max(0.8,calc(l + 0.4)) c h / calc(alpha + 0.4)));--rui-attachment-title-bg:linear-gradient(calc(90deg + var(--rui-attachment-title-shimmer-angle,20deg)),var(--rui-attachment-title-shimmer-base) calc(50% - var(--rui-attachment-title-shimmer-spread)),color-mix(in oklch,var(--rui-attachment-title-shimmer-highlight),var(--rui-attachment-title-shimmer-base) 50%) calc(50% - var(--rui-attachment-title-shimmer-spread) * 0.5),var(--rui-attachment-title-shimmer-highlight) 50%,color-mix(in oklch,var(--rui-attachment-title-shimmer-highlight),var(--rui-attachment-title-shimmer-base) 50%) calc(50% + var(--rui-attachment-title-shimmer-spread) * 0.5),var(--rui-attachment-title-shimmer-base) calc(50% + var(--rui-attachment-title-shimmer-spread)));--rui-attachment-title-bg-size:calc(200% + var(--rui-attachment-title-shimmer-spread) * 2);--rui-attachment-title-bg-position:0 0;--rui-attachment-title-text-fill:transparent;--rui-attachment-title-animation:rui-shimmer 2s linear infinite"
+
+///|
+fn attachment_state_value(state : AttachmentState) -> String {
+  match state {
+    AttachmentIdle => "idle"
+    AttachmentUploading => "uploading"
+    AttachmentProcessing => "processing"
+    AttachmentError => "error"
+    AttachmentDone => "done"
+  }
+}
+
+///|
+fn attachment_size_value(size : AttachmentSize) -> String {
+  match size {
+    AttachmentDefaultSize => "default"
+    AttachmentSm => "sm"
+    AttachmentXs => "xs"
+  }
+}
+
+///|
+fn attachment_orientation_value(orientation : AttachmentOrientation) -> String {
+  match orientation {
+    AttachmentHorizontal => "horizontal"
+    AttachmentVertical => "vertical"
+  }
+}
+
+///|
+fn attachment_size_style(size : AttachmentSize) -> String {
+  match size {
+    AttachmentDefaultSize =>
+      "--rui-attachment-media-size:2.5rem;--rui-attachment-icon-size:1rem;--rui-attachment-spinner-size:1rem;--rui-attachment-content-padding-block:0.5rem;--rui-attachment-content-padding-inline-root:0.625rem;--rui-attachment-media-padding:0.5rem;gap:0.5rem;font-size:0.875rem"
+    AttachmentSm =>
+      "--rui-attachment-media-size:2rem;--rui-attachment-icon-size:1rem;--rui-attachment-spinner-size:1rem;--rui-attachment-content-padding-block:0.375rem;--rui-attachment-content-padding-inline-root:0.5rem;--rui-attachment-media-padding:0.375rem;gap:0.625rem;font-size:0.75rem"
+    AttachmentXs =>
+      "--rui-attachment-media-size:1.75rem;--rui-attachment-icon-size:0.875rem;--rui-attachment-spinner-size:0.875rem;--rui-attachment-content-padding-block:0.25rem;--rui-attachment-content-padding-inline-root:0.375rem;--rui-attachment-media-padding:0.25rem;gap:0.375rem;border-radius:0.5rem;font-size:0.75rem"
+  }
+}
+
+///|
+fn attachment_state_style(state : AttachmentState) -> String {
+  match state {
+    AttachmentIdle => "border-style:dashed"
+    AttachmentError =>
+      "--rui-attachment-base-border:color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 30%,transparent);--rui-attachment-media-bg:var(--rui-destructive-subtle,oklch(0.577 0.245 27.325 / 0.1));--rui-attachment-media-fg:var(--rui-destructive,oklch(0.577 0.245 27.325));--rui-attachment-description-fg:color-mix(in oklab,var(--rui-destructive,oklch(0.577 0.245 27.325)) 80%,transparent);--rui-attachment-image-opacity:0.6"
+    AttachmentUploading | AttachmentProcessing =>
+      "--rui-attachment-image-opacity:0.6;" + AttachmentTitleShimmerStyle
+    AttachmentDone => "--rui-attachment-image-opacity:1"
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment(
+  state? : AttachmentState = AttachmentDone,
+  size? : AttachmentSize = AttachmentDefaultSize,
+  orientation? : AttachmentOrientation = AttachmentHorizontal,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let state_value = attachment_state_value(state)
+  let size_value = attachment_size_value(size)
+  let orientation_value = attachment_orientation_value(orientation)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "attachment")
+      .data_set("state", state_value)
+      .data_set("size", size_value)
+      .data_set("orientation", orientation_value),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        "position:relative;display:flex;width:fit-content;max-width:100%;min-width:0;flex-shrink:0;flex-wrap:wrap;align-items:center;scroll-snap-align:start;border:1px solid var(--rui-attachment-border,var(--rui-attachment-base-border,var(--rui-border,oklch(0.922 0 0))));border-radius:0.75rem;background:var(--rui-attachment-bg,var(--rui-attachment-base-bg,var(--rui-card,var(--rui-background,white))));padding-block:var(--rui-attachment-padding-block,0);padding-inline:var(--rui-attachment-padding-inline,0);color:var(--rui-attachment-fg,var(--rui-attachment-base-fg,var(--rui-card-foreground,var(--rui-foreground,oklch(0.145 0 0)))));box-shadow:var(--rui-attachment-shadow,var(--rui-attachment-base-shadow,none));--rui-attachment-media-bg:var(--rui-muted,oklch(0.97 0 0));--rui-attachment-media-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-attachment-description-fg:var(--rui-muted-foreground,oklch(0.556 0 0));--rui-attachment-image-opacity:1;--rui-attachment-title-fg:inherit;--rui-attachment-title-bg:none;--rui-attachment-title-bg-size:auto;--rui-attachment-title-bg-position:0 0;--rui-attachment-title-text-fill:currentColor;--rui-attachment-title-animation:none;--rui-attachment-content-width:auto;--rui-attachment-content-padding-inline:0;--rui-attachment-actions-position:relative;--rui-attachment-actions-top:auto;--rui-attachment-actions-inline-end:auto;--rui-attachment-actions-gap:0.25rem",
+        attachment_size_style(size),
+        if orientation is AttachmentVertical {
+          if size is AttachmentXs {
+            "width:6rem;flex-direction:column;align-items:stretch;--rui-attachment-media-width:100%;--rui-attachment-icon-size:0.875rem;--rui-attachment-spinner-size:1.5rem;--rui-attachment-content-width:7.5rem;--rui-attachment-content-padding-inline:0.25rem;--rui-attachment-actions-position:absolute;--rui-attachment-actions-top:0.75rem;--rui-attachment-actions-inline-end:0.75rem;--rui-attachment-actions-gap:0.25rem"
+          } else {
+            "width:6rem;flex-direction:column;align-items:stretch;--rui-attachment-media-width:100%;--rui-attachment-icon-size:1.5rem;--rui-attachment-spinner-size:1.5rem;--rui-attachment-content-width:7.5rem;--rui-attachment-content-padding-inline:0.25rem;--rui-attachment-actions-position:absolute;--rui-attachment-actions-top:0.75rem;--rui-attachment-actions-inline-end:0.75rem;--rui-attachment-actions-gap:0.25rem"
+          }
+        } else {
+          "min-width:10rem;--rui-attachment-media-width:var(--rui-attachment-media-size,2.5rem)"
+        },
+        attachment_state_style(state),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "attachment-group"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;min-width:0;gap:0.75rem;overflow-x:auto;overscroll-behavior-inline:contain;padding-block:0.25rem;padding-inline:0.25rem;scroll-padding-inline:0.25rem;scroll-snap-type:x mandatory",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_media(
+  variant? : AttachmentMediaVariant = AttachmentIcon,
+  error? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let variant_value = if variant is AttachmentImage { "image" } else { "icon" }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "attachment-media")
+      .data_set("variant", variant_value),
+    style=ui_styles(
+      [
+        "position:relative;display:flex;aspect-ratio:1;width:var(--rui-attachment-media-width,var(--rui-attachment-media-size,2.5rem));flex-shrink:0;align-items:center;justify-content:center;overflow:hidden;border-radius:0.5rem;background:var(--rui-attachment-media-bg,var(--rui-muted,oklch(0.97 0 0)));color:var(--rui-attachment-media-fg,var(--rui-foreground,oklch(0.145 0 0)));--rui-icon-size:var(--rui-attachment-icon-size,1rem)",
+        if variant is AttachmentImage {
+          "opacity:var(--rui-attachment-image-opacity,0.6)"
+        } else {
+          ""
+        },
+        if error {
+          "--rui-attachment-media-bg:var(--rui-destructive-subtle,oklch(0.577 0.245 27.325 / 0.1));--rui-attachment-media-fg:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "attachment-content"),
+    style=ui_styles(
+      [
+        "width:var(--rui-attachment-content-width,auto);max-width:100%;min-width:0;flex:1;padding-inline:var(--rui-attachment-content-padding-inline,0);line-height:1.25",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "attachment-title"),
+    style=ui_styles(
+      [
+        "display:block;max-width:100%;min-width:0;overflow:hidden;background-image:var(--rui-attachment-title-bg,none);background-position:var(--rui-attachment-title-bg-position,0 0);background-size:var(--rui-attachment-title-bg-size,auto);background-repeat:no-repeat;background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:var(--rui-attachment-title-text-fill,currentColor);color:var(--rui-attachment-title-fg,inherit);font-weight:500;text-overflow:ellipsis;white-space:nowrap;animation:var(--rui-attachment-title-animation,none)",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "attachment-description"),
+    style=ui_styles(
+      [
+        "display:block;max-width:100%;min-width:0;overflow:hidden;margin-top:0.125rem;color:var(--rui-attachment-description-fg,var(--rui-muted-foreground,oklch(0.556 0 0)));font-size:0.75rem;line-height:1rem;text-overflow:ellipsis;white-space:nowrap",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_actions(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "attachment-actions"),
+    style=ui_styles(
+      [
+        "position:var(--rui-attachment-actions-position,relative);top:var(--rui-attachment-actions-top,auto);inset-inline-end:var(--rui-attachment-actions-inline-end,auto);z-index:20;display:flex;flex-shrink:0;align-items:center;gap:var(--rui-attachment-actions-gap,0.25rem)",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_action(
+  variant? : ButtonVariant = Ghost,
+  size? : ButtonSize = IconXs,
+  disabled? : Bool = false,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let action_attrs = ui_attrs(attrs).data_set("slot", "attachment-action")
+  if aria_label is Some(label) {
+    ignore(action_attrs.aria_label(label))
+  }
+  button(
+    variant~,
+    size~,
+    disabled~,
+    slot="attachment-action",
+    on_click?,
+    id?,
+    class?,
+    title?,
+    attrs=action_attrs,
+    style~,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] attachment_trigger(
+  disabled? : Bool = false,
+  on_click? : @cmd.Cmd,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let trigger_attrs = ui_attrs(attrs).data_set("slot", "attachment-trigger")
+  if aria_label is Some(label) {
+    ignore(trigger_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(trigger_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  @html.button(
+    type_="button",
+    disabled~,
+    on_click?,
+    id?,
+    class?,
+    title?,
+    attrs=trigger_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:absolute;inset:0;z-index:10;border:0;border-radius:inherit;background:transparent;color:transparent;box-shadow:var(--rui-attachment-trigger-shadow,none);cursor:pointer;outline:none;outline-offset:2px",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn attachment_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn attachment_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+/// Render the Vega attachment trigger's `asChild` path as a native anchor.
+pub fn[C : @html.IsChildren] attachment_trigger_link(
+  href~ : String,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let trigger_attrs = ui_attrs(attrs).data_set("slot", "attachment-trigger")
+  if aria_label is Some(label) {
+    ignore(trigger_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(
+      trigger_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(trigger_attrs.on_click(_ => command))
+  }
+  attachment_bind_disabled_link(trigger_attrs, disabled)
+  @html.a(
+    href~,
+    target~,
+    rel?,
+    download?,
+    id?,
+    class?,
+    title?,
+    attrs=trigger_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:absolute;inset:0;z-index:10;border:0;border-radius:inherit;background:transparent;color:transparent;box-shadow:var(--rui-attachment-trigger-shadow,none);cursor:pointer;outline:none;outline-offset:2px;text-decoration:none",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    children,
+    escape~,
+  )
+}

--- a/rui/avatar.mbt
+++ b/rui/avatar.mbt
@@ -1,0 +1,390 @@
+///|
+pub(all) enum AvatarSize {
+  Default
+  Sm
+  Lg
+} derive(Debug, Eq)
+
+///|
+pub(all) enum AvatarImageStatus {
+  AvatarLoading
+  AvatarLoaded
+  AvatarError
+} derive(Debug, Eq)
+
+///|
+#cfg(target="js")
+fn bind_avatar_image(id : String, notify : (Int) -> Unit) -> Unit {
+  guard ui_element_by_id(id) is Some(element) else { return }
+  guard element.to_html_image_element() is Some(image) else { return }
+  image.add_event_listener("load", _ => notify(1))
+  image.add_event_listener("error", _ => notify(2))
+  if image.get_complete() {
+    notify(if image.get_natural_width() > 0.0 { 1 } else { 2 })
+  }
+}
+
+///|
+#cfg(target="js")
+fn bind_avatar_image_cmd(
+  id : String,
+  emit : @cmd.Emit[AvatarImageStatus],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        bind_avatar_image(id, status => {
+          scheduler.add(
+            emit(if status == 1 { AvatarLoaded } else { AvatarError }),
+          )
+        })
+      },
+      purpose="avatar-image-bind",
+    )
+  })
+}
+
+///|
+const AvatarBaseStyle : String = "position:relative;isolation:isolate;display:inline-flex;width:var(--rui-avatar-size,2rem);height:var(--rui-avatar-size,2rem);flex-shrink:0;overflow:hidden;margin-inline-start:var(--rui-avatar-overlap,0);border-radius:9999px;box-shadow:var(--rui-avatar-ring,0 0 0 0 transparent);vertical-align:middle;user-select:none"
+
+///|
+const AvatarDefaultSizeStyle : String = "--rui-avatar-size:2rem;--rui-avatar-fallback-font-size:0.875rem;--rui-avatar-badge-size:0.625rem;--rui-avatar-badge-icon-size:0.5rem;--rui-avatar-group-count-icon-size:1rem"
+
+///|
+const AvatarSmSizeStyle : String = "--rui-avatar-size:1.5rem;--rui-avatar-fallback-font-size:0.75rem;--rui-avatar-badge-size:0.5rem;--rui-avatar-badge-icon-size:0;--rui-avatar-group-count-icon-size:0.75rem"
+
+///|
+const AvatarLgSizeStyle : String = "--rui-avatar-size:2.5rem;--rui-avatar-fallback-font-size:0.875rem;--rui-avatar-badge-size:0.75rem;--rui-avatar-badge-icon-size:0.5rem;--rui-avatar-group-count-icon-size:1.25rem"
+
+///|
+const AvatarImageStyle : String = "position:absolute;inset:0;z-index:1;width:100%;height:100%;border-radius:9999px;color:transparent;font-size:0;object-fit:cover"
+
+///|
+const AvatarFallbackStyle : String = "display:flex;width:100%;height:100%;align-items:center;justify-content:center;border-radius:9999px;background:var(--rui-muted,oklch(0.97 0 0));color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:var(--rui-avatar-fallback-font-size,0.875rem);line-height:1;font-weight:500"
+
+///|
+const AvatarBadgeStyle : String = "position:absolute;inset-inline-end:0;bottom:0;z-index:2;display:inline-flex;width:var(--rui-avatar-badge-size,0.625rem);height:var(--rui-avatar-badge-size,0.625rem);align-items:center;justify-content:center;border-radius:9999px;background:var(--rui-primary,oklch(0.205 0 0));color:var(--rui-primary-foreground,oklch(0.985 0 0));font-size:var(--rui-avatar-badge-icon-size,0.5rem);line-height:1;box-shadow:0 0 0 2px var(--rui-background,oklch(1 0 0));user-select:none"
+
+///|
+const AvatarGroupStyle : String = "--rui-avatar-overlap:-0.5rem;--rui-avatar-ring:0 0 0 2px var(--rui-background,oklch(1 0 0));display:flex;align-items:center;padding-inline-start:0.5rem"
+
+///|
+const AvatarGroupCountStyle : String = "position:relative;display:flex;width:var(--rui-avatar-size,2rem);height:var(--rui-avatar-size,2rem);flex-shrink:0;align-items:center;justify-content:center;margin-inline-start:var(--rui-avatar-overlap,-0.5rem);border-radius:9999px;background:var(--rui-muted,oklch(0.97 0 0));color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:var(--rui-avatar-fallback-font-size,0.875rem);line-height:1;font-weight:500;box-shadow:var(--rui-avatar-ring,0 0 0 2px var(--rui-background,oklch(1 0 0)));--rui-icon-size:var(--rui-avatar-group-count-icon-size,1rem)"
+
+///|
+fn avatar_size_style(size : AvatarSize) -> String {
+  match size {
+    Default => AvatarDefaultSizeStyle
+    Sm => AvatarSmSizeStyle
+    Lg => AvatarLgSizeStyle
+  }
+}
+
+///|
+fn avatar_size_value(size : AvatarSize) -> String {
+  match size {
+    Default => "default"
+    Sm => "sm"
+    Lg => "lg"
+  }
+}
+
+///|
+fn avatar_part_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+/// Render the composable Vega avatar root as a native `span` element.
+///
+/// Size is shared with fallback and badge parts through inherited inline custom
+/// properties. The root does not own image-loading state; omit `avatar_image`
+/// while showing a fallback, or control that choice in the parent TEA model.
+pub fn[C : @html.IsChildren] avatar(
+  size? : AvatarSize = Default,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = avatar_part_attrs(attrs, "avatar").data_set(
+    "size",
+    avatar_size_value(size),
+  )
+  @html.span(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        AvatarBaseStyle,
+        avatar_size_style(size),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the avatar image as a native `img` layered above the fallback.
+pub fn avatar_image(
+  src? : String,
+  alt? : String,
+  width? : Int,
+  height? : Int,
+  srcset? : String,
+  sizes? : String,
+  loading? : String,
+  decoding? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.img(
+    style=ui_styles([UiBoxSizing, AvatarImageStyle], style),
+    id?,
+    class?,
+    hidden?,
+    src?,
+    alt?,
+    title?,
+    width?,
+    height?,
+    srcset?,
+    sizes?,
+    loading?,
+    decoding?,
+    attrs=avatar_part_attrs(attrs, "avatar-image"),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] avatar_fallback(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles([UiBoxSizing, AvatarFallbackStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=avatar_part_attrs(attrs, "avatar-fallback"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] avatar_badge(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles([UiBoxSizing, AvatarBadgeStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=avatar_part_attrs(attrs, "avatar-badge"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] avatar_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, AvatarGroupStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=avatar_part_attrs(attrs, "avatar-group"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] avatar_group_count(
+  size? : AvatarSize = Default,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = avatar_part_attrs(attrs, "avatar-group-count").data_set(
+    "size",
+    avatar_size_value(size),
+  )
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, avatar_size_style(size), AvatarGroupCountStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] render_avatar_with_fallback(
+  status : AvatarImageStatus,
+  id : String,
+  src : String,
+  alt : String?,
+  size : AvatarSize,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  image_attrs : @html.Attrs?,
+  image_style : Array[String],
+  fallback_attrs : @html.Attrs?,
+  fallback_style : Array[String],
+  fallback : C,
+) -> @html.Html {
+  let status_value = match status {
+    AvatarLoading => "loading"
+    AvatarLoaded => "loaded"
+    AvatarError => "error"
+  }
+  let root_attrs = ui_attrs(attrs).data_set("image-state", status_value)
+  avatar(size~, id~, class?, title?, attrs=root_attrs, style~, [
+    avatar_fallback(
+      hidden=status is AvatarLoaded,
+      attrs?=fallback_attrs,
+      style=fallback_style,
+      fallback,
+    ),
+    avatar_image(
+      id=id + "-image",
+      src~,
+      alt?,
+      hidden=!(status is AvatarLoaded),
+      attrs?=image_attrs,
+      style=image_style,
+    ),
+  ])
+}
+
+///|
+/// Build a black-box avatar that owns image loading and failure state.
+///
+/// The fallback remains visible until the browser reports a successfully
+/// decoded image resource. Use the pure `avatar`, `avatar_image`, and
+/// `avatar_fallback` parts when the application already owns that state.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] avatar_with_fallback(
+  id~ : String,
+  src~ : String,
+  alt? : String,
+  size? : AvatarSize = Default,
+  on_status_change? : @cmd.Emit[AvatarImageStatus],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  image_attrs? : @html.Attrs,
+  image_style? : Array[String] = [],
+  fallback_attrs? : @html.Attrs,
+  fallback_style? : Array[String] = [],
+  fallback : C,
+) -> @rabbita.Val[@html.Html] {
+  let initial = if src == "" { AvatarError } else { AvatarLoading }
+  let (status, _) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        if src == "" {
+          @cmd.none
+        } else {
+          bind_avatar_image_cmd(id + "-image", emit)
+        },
+      )
+    },
+    update=(_, next, _) => {
+      (
+        next,
+        if on_status_change is Some(notify) {
+          notify(next)
+        } else {
+          @cmd.none
+        },
+      )
+    },
+  )
+  status.view(status => {
+    render_avatar_with_fallback(
+      status, id, src, alt, size, class, title, attrs, style, image_attrs, image_style,
+      fallback_attrs, fallback_style, fallback,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] avatar_with_fallback(
+  id~ : String,
+  src~ : String,
+  alt? : String,
+  size? : AvatarSize = Default,
+  on_status_change? : @cmd.Emit[AvatarImageStatus],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  image_attrs? : @html.Attrs,
+  image_style? : Array[String] = [],
+  fallback_attrs? : @html.Attrs,
+  fallback_style? : Array[String] = [],
+  fallback : C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_status_change)
+  let status = if src == "" { AvatarError } else { AvatarLoading }
+  @rabbita.Val::constant(
+    render_avatar_with_fallback(
+      status, id, src, alt, size, class, title, attrs, style, image_attrs, image_style,
+      fallback_attrs, fallback_style, fallback,
+    ),
+  )
+}

--- a/rui/badge.mbt
+++ b/rui/badge.mbt
@@ -1,0 +1,166 @@
+///|
+pub(all) enum BadgeVariant {
+  Default
+  Secondary
+  Destructive
+  Outline
+  Ghost
+  Link
+} derive(Debug, Eq)
+
+///|
+const BadgeBaseStyle : String = "display:inline-flex;width:fit-content;height:1.25rem;flex-shrink:0;align-items:center;justify-content:center;gap:0.25rem;overflow:hidden;border:1px solid var(--rui-badge-border,var(--rui-badge-base-border,transparent));border-radius:9999px;padding:0.125rem 0.5rem;background:var(--rui-badge-bg,var(--rui-badge-base-bg,transparent));color:var(--rui-badge-fg,var(--rui-badge-base-fg,currentColor));box-shadow:var(--rui-badge-shadow,none);font-size:0.75rem;line-height:1rem;font-weight:500;white-space:nowrap;vertical-align:middle;outline:none;--rui-icon-size:0.75rem"
+
+///|
+const BadgeDefaultStyle : String = "--rui-badge-base-bg:var(--rui-primary,oklch(0.205 0 0));--rui-badge-base-fg:var(--rui-primary-foreground,oklch(0.985 0 0));--rui-badge-base-border:transparent"
+
+///|
+const BadgeSecondaryStyle : String = "--rui-badge-base-bg:var(--rui-secondary,oklch(0.97 0 0));--rui-badge-base-fg:var(--rui-secondary-foreground,oklch(0.205 0 0));--rui-badge-base-border:transparent"
+
+///|
+const BadgeDestructiveStyle : String = "--rui-badge-base-bg:var(--rui-destructive-surface,var(--rui-destructive,oklch(0.577 0.245 27.325)));--rui-badge-base-fg:white;--rui-badge-base-border:transparent"
+
+///|
+const BadgeOutlineStyle : String = "--rui-badge-base-bg:transparent;--rui-badge-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-badge-base-border:var(--rui-border,oklch(0.922 0 0))"
+
+///|
+const BadgeGhostStyle : String = "--rui-badge-base-bg:transparent;--rui-badge-base-fg:var(--rui-muted-foreground,oklch(0.556 0 0));--rui-badge-base-border:transparent"
+
+///|
+const BadgeLinkStyle : String = "--rui-badge-base-bg:transparent;--rui-badge-base-fg:var(--rui-primary,oklch(0.205 0 0));--rui-badge-base-border:transparent;text-underline-offset:4px"
+
+///|
+fn badge_variant_style(variant : BadgeVariant) -> String {
+  match variant {
+    Default => BadgeDefaultStyle
+    Secondary => BadgeSecondaryStyle
+    Destructive => BadgeDestructiveStyle
+    Outline => BadgeOutlineStyle
+    Ghost => BadgeGhostStyle
+    Link => BadgeLinkStyle
+  }
+}
+
+///|
+fn badge_variant_value(variant : BadgeVariant) -> String {
+  match variant {
+    Default => "default"
+    Secondary => "secondary"
+    Destructive => "destructive"
+    Outline => "outline"
+    Ghost => "ghost"
+    Link => "link"
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] badge(
+  variant? : BadgeVariant = Default,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "badge")
+    .data_set("variant", badge_variant_value(variant))
+  @html.span(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        BadgeBaseStyle,
+        badge_variant_style(variant),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn badge_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn badge_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+/// Render the `asChild` anchor path from the Vega badge recipe as a native link.
+pub fn[C : @html.IsChildren] badge_link(
+  href~ : String,
+  variant? : BadgeVariant = Default,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "badge")
+    .data_set("variant", badge_variant_value(variant))
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  badge_bind_disabled_link(element_attrs, disabled)
+  @html.a(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        BadgeBaseStyle,
+        badge_variant_style(variant),
+        "text-decoration:none;cursor:pointer",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    href~,
+    target~,
+    rel?,
+    download?,
+    attrs=element_attrs,
+    children,
+    escape~,
+  )
+}

--- a/rui/breadcrumb.mbt
+++ b/rui/breadcrumb.mbt
@@ -1,0 +1,225 @@
+///|
+const BreadcrumbRootStyle : String = "display:block"
+
+///|
+const BreadcrumbListStyle : String = "display:flex;flex-wrap:wrap;align-items:center;gap:clamp(0.375rem,1vw,0.625rem);margin:0;padding:0;list-style:none;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem;overflow-wrap:anywhere"
+
+///|
+const BreadcrumbItemStyle : String = "display:inline-flex;align-items:center;gap:0.375rem;min-width:0"
+
+///|
+const BreadcrumbLinkStyle : String = "min-width:0;border-radius:0.25rem;color:var(--rui-link-fg,var(--rui-link-base-fg,inherit));text-decoration:none;overflow-wrap:anywhere;outline-offset:2px;transition:color 150ms ease"
+
+///|
+const BreadcrumbPageStyle : String = "color:var(--rui-foreground,oklch(0.145 0 0));font-weight:400"
+
+///|
+const BreadcrumbSeparatorStyle : String = "display:inline-flex;align-items:center;justify-content:center;color:inherit"
+
+///|
+const BreadcrumbChevronBoxStyle : String = "display:inline-flex;width:0.875rem;height:0.875rem;flex-shrink:0;align-items:center;justify-content:center"
+
+///|
+const BreadcrumbChevronStyle : String = "display:block;width:0.4375rem;height:0.4375rem;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:rotate(-45deg);transform-origin:center"
+
+///|
+const BreadcrumbEllipsisStyle : String = "display:inline-flex;width:1.25rem;height:1.25rem;align-items:center;justify-content:center;color:inherit"
+
+///|
+const BreadcrumbDotsStyle : String = "display:block;width:0.1875rem;height:0.1875rem;border-radius:9999px;background:currentColor;box-shadow:-0.3125rem 0 currentColor,0.3125rem 0 currentColor"
+
+///|
+const BreadcrumbScreenReaderOnlyStyle : String = "position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0"
+
+///|
+fn breadcrumb_part_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+/// Render the semantic navigation root for a breadcrumb trail.
+pub fn[C : @html.IsChildren] breadcrumb(
+  aria_label? : String = "breadcrumb",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = breadcrumb_part_attrs(attrs, "breadcrumb").aria_label(
+    aria_label,
+  )
+  @html.nav(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, BreadcrumbRootStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the ordered list that contains breadcrumb items.
+pub fn[C : @html.IsChildren] breadcrumb_list(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.ol(
+    style=ui_styles([UiBoxSizing, BreadcrumbListStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=breadcrumb_part_attrs(attrs, "breadcrumb-list"),
+    children,
+  )
+}
+
+///|
+/// Render one semantic list item in a breadcrumb trail.
+pub fn[C : @html.IsChildren] breadcrumb_item(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.li(
+    style=ui_styles([UiBoxSizing, BreadcrumbItemStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=breadcrumb_part_attrs(attrs, "breadcrumb-item"),
+    children,
+  )
+}
+
+///|
+/// Render a native anchor for a navigable breadcrumb item.
+pub fn[C : @html.IsChildren] breadcrumb_link(
+  href~ : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.a(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTransition, BreadcrumbLinkStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    href~,
+    target~,
+    rel?,
+    download?,
+    attrs=breadcrumb_part_attrs(attrs, "breadcrumb-link"),
+    children,
+    escape~,
+  )
+}
+
+///|
+/// Render the non-navigable current page in a breadcrumb trail.
+pub fn[C : @html.IsChildren] breadcrumb_page(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = breadcrumb_part_attrs(attrs, "breadcrumb-page")
+    .role("link")
+    .aria_disabled("true")
+    .aria_current("page")
+    .data_set("state", "current")
+  @html.span(
+    style=ui_styles([UiBoxSizing, BreadcrumbPageStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render a presentational breadcrumb separator.
+///
+/// Without `children`, a dependency-free CSS chevron is rendered. Pass a
+/// single `Html` value to replace it with a custom separator.
+pub fn breadcrumb_separator(
+  children? : @html.Html,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let content = children.unwrap_or(
+    @html.span(
+      style=[UiBoxSizing, BreadcrumbChevronBoxStyle],
+      attrs=@html.Attrs::build().data_set("icon", "inline-end"),
+      @html.span(style=[UiBoxSizing, BreadcrumbChevronStyle], @html.nothing),
+    ),
+  )
+  let element_attrs = breadcrumb_part_attrs(attrs, "breadcrumb-separator")
+    .role("presentation")
+    .aria_hidden("true")
+  @html.li(
+    style=ui_styles([UiBoxSizing, BreadcrumbSeparatorStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    content,
+  )
+}
+
+///|
+/// Render the collapsed-range marker used by long breadcrumb trails.
+pub fn breadcrumb_ellipsis(
+  label? : String = "More",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = breadcrumb_part_attrs(attrs, "breadcrumb-ellipsis")
+    .role("presentation")
+    .aria_hidden("true")
+  @html.span(
+    style=ui_styles([UiBoxSizing, BreadcrumbEllipsisStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    [
+      @html.span(
+        style=[UiBoxSizing, BreadcrumbDotsStyle],
+        attrs=@html.Attrs::build().data_set("icon", "ellipsis"),
+        @html.nothing,
+      ),
+      @html.span(style=[BreadcrumbScreenReaderOnlyStyle], label),
+    ],
+  )
+}

--- a/rui/bubble.mbt
+++ b/rui/bubble.mbt
@@ -1,0 +1,298 @@
+///|
+pub(all) enum BubbleVariant {
+  BubbleDefault
+  BubbleSecondary
+  BubbleMuted
+  BubbleTinted
+  BubbleOutline
+  BubbleGhost
+  BubbleDestructive
+} derive(Debug, Eq)
+
+///|
+pub(all) enum BubbleReactionSide {
+  ReactionTop
+  ReactionBottom
+} derive(Debug, Eq)
+
+///|
+fn bubble_variant_value(variant : BubbleVariant) -> String {
+  match variant {
+    BubbleDefault => "default"
+    BubbleSecondary => "secondary"
+    BubbleMuted => "muted"
+    BubbleTinted => "tinted"
+    BubbleOutline => "outline"
+    BubbleGhost => "ghost"
+    BubbleDestructive => "destructive"
+  }
+}
+
+///|
+fn bubble_variant_style(variant : BubbleVariant) -> String {
+  match variant {
+    BubbleDefault =>
+      "--rui-bubble-bg:var(--rui-primary,oklch(0.205 0 0));--rui-bubble-fg:var(--rui-primary-foreground,oklch(0.985 0 0));--rui-bubble-border:transparent;--rui-bubble-radius:0.75rem;--rui-bubble-padding:0.5rem 0.75rem"
+    BubbleSecondary =>
+      "--rui-bubble-bg:var(--rui-secondary,oklch(0.97 0 0));--rui-bubble-fg:var(--rui-secondary-foreground,oklch(0.205 0 0));--rui-bubble-border:transparent;--rui-bubble-radius:0.75rem;--rui-bubble-padding:0.5rem 0.75rem"
+    BubbleMuted =>
+      "--rui-bubble-bg:var(--rui-muted,oklch(0.97 0 0));--rui-bubble-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-bubble-border:transparent;--rui-bubble-radius:0.75rem;--rui-bubble-padding:0.5rem 0.75rem"
+    BubbleTinted =>
+      "--rui-bubble-bg:light-dark(oklch(from var(--rui-primary,oklch(0.205 0 0)) 0.93 calc(c * 0.4) h),oklch(from var(--rui-primary,oklch(0.922 0 0)) 0.3 calc(c * 0.4) h));--rui-bubble-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-bubble-border:transparent;--rui-bubble-radius:0.75rem;--rui-bubble-padding:0.5rem 0.75rem"
+    BubbleOutline =>
+      "--rui-bubble-bg:var(--rui-background,white);--rui-bubble-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-bubble-border:var(--rui-border,oklch(0.922 0 0));--rui-bubble-radius:0.75rem;--rui-bubble-padding:0.5rem 0.75rem"
+    BubbleGhost =>
+      "--rui-bubble-bg:transparent;--rui-bubble-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-bubble-border:transparent;--rui-bubble-radius:0;--rui-bubble-padding:0"
+    BubbleDestructive =>
+      "--rui-bubble-bg:var(--rui-destructive-subtle,oklch(0.577 0.245 27.325 / 0.1));--rui-bubble-fg:var(--rui-destructive,oklch(0.577 0.245 27.325));--rui-bubble-border:transparent;--rui-bubble-radius:0.75rem;--rui-bubble-padding:0.5rem 0.75rem"
+  }
+}
+
+///|
+const BubbleContentBaseStyle : String = "width:fit-content;max-width:100%;min-width:0;align-self:var(--rui-bubble-content-align,flex-start);overflow:hidden;border:1px solid var(--rui-bubble-border,transparent);border-radius:var(--rui-bubble-radius,0.75rem);padding:var(--rui-bubble-padding,0.5rem 0.75rem);background:var(--rui-bubble-bg,var(--rui-primary,oklch(0.205 0 0)));color:var(--rui-bubble-fg,var(--rui-primary-foreground,oklch(0.985 0 0)));box-shadow:var(--rui-bubble-shadow,none);font-size:0.875rem;line-height:1.625;overflow-wrap:break-word;word-break:normal;outline:none"
+
+///|
+pub fn[C : @html.IsChildren] bubble_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "bubble-group"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;min-width:0;align-self:var(--rui-message-content-align,flex-start);flex-direction:column;gap:0.5rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] bubble(
+  variant? : BubbleVariant = BubbleDefault,
+  align? : ContentAlignment = AlignStart,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let align_value = content_alignment_value(align)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "bubble")
+      .data_set("variant", bubble_variant_value(variant))
+      .data_set("align", align_value),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:relative;display:flex;width:fit-content;max-width:80%;min-width:0;align-self:var(--rui-message-content-align,flex-start);flex-direction:column;gap:0.25rem;--rui-bubble-content-align:flex-start",
+        bubble_variant_style(variant),
+        if variant is BubbleGhost {
+          "max-width:100%"
+        } else {
+          ""
+        },
+        if align is AlignEnd {
+          "align-self:flex-end;--rui-bubble-content-align:flex-end"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] bubble_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "bubble-content"),
+    style=ui_styles([UiBoxSizing, UiTransition, BubbleContentBaseStyle], style),
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn bubble_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn bubble_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+/// Render an interactive bubble-content anchor without a Slot/runtime wrapper.
+pub fn[C : @html.IsChildren] bubble_content_link(
+  href~ : String,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("slot", "bubble-content")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  bubble_bind_disabled_link(element_attrs, disabled)
+  @html.a(
+    href~,
+    target~,
+    rel?,
+    download?,
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiTransition,
+        BubbleContentBaseStyle,
+        "text-decoration:none;cursor:pointer",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    children,
+    escape~,
+  )
+}
+
+///|
+/// Render the button branch of Vega's interactive bubble-content recipe.
+pub fn[C : @html.IsChildren] bubble_content_button(
+  disabled? : Bool = false,
+  type_? : String = "button",
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("slot", "bubble-content")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  @html.button(
+    type_~,
+    disabled~,
+    on_click?,
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        BubbleContentBaseStyle,
+        "margin:0;text-align:start;cursor:pointer;appearance:none;-webkit-appearance:none",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] bubble_reactions(
+  side? : BubbleReactionSide = ReactionBottom,
+  align? : ContentAlignment = AlignEnd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let side_value = if side is ReactionTop { "top" } else { "bottom" }
+  let align_value = content_alignment_value(align)
+  let placement = match (side, align) {
+    (ReactionTop, AlignStart) =>
+      "top:0;inset-inline-start:0.75rem;transform:translateY(-75%)"
+    (ReactionTop, AlignEnd) =>
+      "top:0;inset-inline-end:0.75rem;transform:translateY(-75%)"
+    (ReactionBottom, AlignStart) =>
+      "bottom:0;inset-inline-start:0.75rem;transform:translateY(75%)"
+    (ReactionBottom, AlignEnd) =>
+      "bottom:0;inset-inline-end:0.75rem;transform:translateY(75%)"
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "bubble-reactions")
+      .data_set("side", side_value)
+      .data_set("align", align_value),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:absolute;z-index:10;display:flex;width:fit-content;flex-shrink:0;align-items:center;justify-content:center;gap:0.25rem;border-radius:9999px;background:var(--rui-muted,oklch(0.97 0 0));padding:0.125rem 0.375rem;font-size:0.875rem;box-shadow:0 0 0 3px var(--rui-card,var(--rui-background,white))",
+        placement,
+      ],
+      style,
+    ),
+    children,
+  )
+}

--- a/rui/button.mbt
+++ b/rui/button.mbt
@@ -1,0 +1,174 @@
+///|
+pub(all) enum ButtonVariant {
+  Default
+  Outline
+  Secondary
+  Ghost
+  Destructive
+  Link
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ButtonSize {
+  Default
+  Xs
+  Sm
+  Lg
+  Icon
+  IconXs
+  IconSm
+  IconLg
+} derive(Debug, Eq)
+
+///|
+const ButtonBaseStyle : String = "display:inline-flex;flex-shrink:0;align-items:center;justify-content:center;gap:var(--rui-button-gap,0.5rem);--rui-button-base-bg:transparent;--rui-button-base-fg:currentColor;--rui-button-base-border:transparent;--rui-button-base-shadow:none;--rui-button-padding-inline:1rem;--rui-button-icon-size:1rem;border-style:solid;border-color:var(--rui-button-border,var(--rui-button-base-border,transparent));border-top-width:var(--rui-control-border-top-width,var(--rui-control-border-width,1px));border-right-width:var(--rui-control-border-right-width,var(--rui-control-border-width,1px));border-bottom-width:var(--rui-control-border-bottom-width,var(--rui-control-border-width,1px));border-left-width:var(--rui-control-border-left-width,var(--rui-control-border-width,1px));border-top-left-radius:var(--rui-control-radius-top-left,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));border-top-right-radius:var(--rui-control-radius-top-right,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));border-bottom-right-radius:var(--rui-control-radius-bottom-right,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));border-bottom-left-radius:var(--rui-control-radius-bottom-left,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));margin:0;padding-block:0;padding-inline:var(--rui-button-padding-inline);background:var(--rui-button-bg,var(--rui-button-base-bg,transparent));background-clip:padding-box;color:var(--rui-button-fg,var(--rui-button-base-fg,currentColor));box-shadow:var(--rui-button-shadow,var(--rui-button-base-shadow,none));font-size:0.875rem;line-height:1.25rem;font-weight:500;white-space:nowrap;cursor:pointer;user-select:none;appearance:none;-webkit-appearance:none;outline:none;vertical-align:middle"
+
+///|
+const ButtonDefaultStyle : String = "--rui-button-base-bg:var(--rui-primary,oklch(0.205 0 0));--rui-button-base-fg:var(--rui-primary-foreground,oklch(0.985 0 0));--rui-button-base-border:transparent;--rui-button-base-shadow:none"
+
+///|
+const ButtonOutlineStyle : String = "--rui-button-base-bg:var(--rui-outline-background,var(--rui-background,oklch(1 0 0)));--rui-button-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-button-base-border:var(--rui-outline-border,var(--rui-input,oklch(0.922 0 0)));--rui-button-base-shadow:0 1px 2px rgb(0 0 0 / 0.05)"
+
+///|
+const ButtonSecondaryStyle : String = "--rui-button-base-bg:var(--rui-secondary,oklch(0.97 0 0));--rui-button-base-fg:var(--rui-secondary-foreground,oklch(0.205 0 0));--rui-button-base-border:transparent;--rui-button-base-shadow:none"
+
+///|
+const ButtonGhostStyle : String = "--rui-button-base-bg:transparent;--rui-button-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-button-base-border:transparent;--rui-button-base-shadow:none"
+
+///|
+const ButtonDestructiveStyle : String = "--rui-button-base-bg:var(--rui-destructive-surface,var(--rui-destructive,oklch(0.577 0.245 27.325)));--rui-button-base-fg:white;--rui-button-base-border:transparent;--rui-button-base-shadow:none"
+
+///|
+const ButtonLinkStyle : String = "height:auto;--rui-button-base-bg:transparent;--rui-button-base-fg:var(--rui-primary,oklch(0.205 0 0));--rui-button-base-border:transparent;--rui-button-base-shadow:none;text-underline-offset:4px"
+
+///|
+const ButtonSizeDefaultStyle : String = "height:2.25rem;--rui-button-padding-inline:1rem;--rui-button-padding-inline-with-icon:0.75rem"
+
+///|
+const ButtonSizeXsStyle : String = "height:1.5rem;--rui-button-gap:0.25rem;--rui-button-padding-inline:0.5rem;--rui-button-padding-inline-with-icon:0.375rem;--rui-button-icon-size:0.75rem;font-size:0.75rem;line-height:1rem"
+
+///|
+const ButtonSizeSmStyle : String = "height:2rem;--rui-button-gap:0.375rem;--rui-button-padding-inline:0.75rem;--rui-button-padding-inline-with-icon:0.625rem"
+
+///|
+const ButtonSizeLgStyle : String = "height:2.5rem;--rui-button-padding-inline:1.5rem;--rui-button-padding-inline-with-icon:1rem"
+
+///|
+const ButtonSizeIconStyle : String = "width:2.25rem;height:2.25rem;--rui-button-padding-inline:0"
+
+///|
+const ButtonSizeIconXsStyle : String = "width:1.5rem;height:1.5rem;--rui-button-padding-inline:0;--rui-button-icon-size:0.75rem"
+
+///|
+const ButtonSizeIconSmStyle : String = "width:2rem;height:2rem;--rui-button-padding-inline:0"
+
+///|
+const ButtonSizeIconLgStyle : String = "width:2.5rem;height:2.5rem;--rui-button-padding-inline:0"
+
+///|
+fn button_variant_value(variant : ButtonVariant) -> String {
+  match variant {
+    Default => "default"
+    Outline => "outline"
+    Secondary => "secondary"
+    Ghost => "ghost"
+    Destructive => "destructive"
+    Link => "link"
+  }
+}
+
+///|
+fn button_size_value(size : ButtonSize) -> String {
+  match size {
+    Default => "default"
+    Xs => "xs"
+    Sm => "sm"
+    Lg => "lg"
+    Icon => "icon"
+    IconXs => "icon-xs"
+    IconSm => "icon-sm"
+    IconLg => "icon-lg"
+  }
+}
+
+///|
+fn button_variant_style(variant : ButtonVariant) -> String {
+  match variant {
+    Default => ButtonDefaultStyle
+    Outline => ButtonOutlineStyle
+    Secondary => ButtonSecondaryStyle
+    Ghost => ButtonGhostStyle
+    Destructive => ButtonDestructiveStyle
+    Link => ButtonLinkStyle
+  }
+}
+
+///|
+fn button_size_style(size : ButtonSize) -> String {
+  match size {
+    Default => ButtonSizeDefaultStyle
+    Xs => ButtonSizeXsStyle
+    Sm => ButtonSizeSmStyle
+    Lg => ButtonSizeLgStyle
+    Icon => ButtonSizeIconStyle
+    IconXs => ButtonSizeIconXsStyle
+    IconSm => ButtonSizeIconSmStyle
+    IconLg => ButtonSizeIconLgStyle
+  }
+}
+
+///|
+/// Render a native button with shadcn/ui Vega variants and sizes.
+///
+/// User styles are appended last and therefore override the built-in recipe.
+pub fn[C : @html.IsChildren] button(
+  variant? : ButtonVariant = Default,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  type_? : String = "button",
+  id? : String,
+  class? : String,
+  title? : String,
+  name? : String,
+  value? : String,
+  autofocus? : Bool,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "button",
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_~,
+    disabled~,
+    name?,
+    value?,
+    autofocus?,
+    on_click?,
+    attrs=element_attrs,
+    children,
+  )
+}

--- a/rui/button_group.mbt
+++ b/rui/button_group.mbt
@@ -1,0 +1,114 @@
+///|
+const ButtonGroupBaseStyle : String = "display:flex;width:fit-content;max-width:100%;align-items:stretch;gap:0;overflow:visible"
+
+///|
+const ButtonGroupVerticalStyle : String = "flex-direction:column"
+
+///|
+const ButtonGroupHorizontalStyle : String = "flex-direction:row"
+
+///|
+const ButtonGroupTextStyle : String = "display:flex;align-items:center;gap:0.5rem;border-style:solid;border-color:var(--rui-border,oklch(0.922 0 0));border-top-width:var(--rui-control-border-top-width,var(--rui-control-border-width,1px));border-right-width:var(--rui-control-border-right-width,var(--rui-control-border-width,1px));border-bottom-width:var(--rui-control-border-bottom-width,var(--rui-control-border-width,1px));border-left-width:var(--rui-control-border-left-width,var(--rui-control-border-width,1px));border-top-left-radius:var(--rui-control-radius-top-left,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));border-top-right-radius:var(--rui-control-radius-top-right,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));border-bottom-right-radius:var(--rui-control-radius-bottom-right,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));border-bottom-left-radius:var(--rui-control-radius-bottom-left,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)));background:var(--rui-muted,oklch(0.97 0 0));padding-inline:0.625rem;color:var(--rui-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem;font-weight:500;box-shadow:0 1px 2px rgb(0 0 0 / 0.05)"
+
+///|
+fn button_group_orientation_style(orientation : SeparatorOrientation) -> String {
+  match orientation {
+    Horizontal => ButtonGroupHorizontalStyle
+    Vertical => ButtonGroupVerticalStyle
+  }
+}
+
+///|
+/// Group Buttons, Toggles, inputs, or text into one contiguous Vega control.
+///
+/// The interaction sheet merges adjacent borders and corner radii. Keeping
+/// those rules on the children preserves each control's own variant surface.
+pub fn[C : @html.IsChildren] button_group(
+  orientation? : SeparatorOrientation = Horizontal,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let orientation_value = separator_orientation_value(orientation)
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "button-group")
+    .data_set("orientation", orientation_value)
+    .role("group")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        ButtonGroupBaseStyle,
+        button_group_orientation_style(orientation),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] button_group_text(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, UiFontSans, ButtonGroupTextStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "button-group-text"),
+    children,
+  )
+}
+
+///|
+pub fn button_group_separator(
+  orientation? : SeparatorOrientation = Vertical,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let orientation_value = separator_orientation_value(orientation)
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "button-group-separator")
+    .data_set("orientation", orientation_value)
+    .aria_hidden("true")
+  let orientation_style = match orientation {
+    Horizontal => "width:100%;height:1px"
+    Vertical => "width:1px;min-height:100%;align-self:stretch"
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:relative;flex-shrink:0;align-self:stretch;background:var(--rui-input,oklch(0.922 0 0))",
+        orientation_style,
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    @html.nothing,
+  )
+}

--- a/rui/calendar.mbt
+++ b/rui/calendar.mbt
@@ -1,0 +1,1326 @@
+///|
+/// A normalized proleptic-Gregorian date used by `calendar`.
+///
+/// Construction is intentionally opaque so every value stays inside the
+/// supported year range and always names a real day.
+struct CalendarDate {
+  year : Int
+  month : Int
+  day : Int
+} derive(Debug, Eq)
+
+///|
+priv struct CalendarModel {
+  visible : CalendarDate
+  selected : CalendarDate?
+  focused : CalendarDate
+} derive(Eq)
+
+///|
+priv enum CalendarSelectionMode {
+  CalendarSingleSelection
+  CalendarRangeSelection
+  CalendarMultipleSelection
+}
+
+///|
+#cfg(target="js")
+priv enum CalendarMsg {
+  CalendarNavigate(Int)
+  CalendarChoose(CalendarDate)
+  CalendarSetFocused(CalendarDate)
+  CalendarMoveFocus(CalendarDate)
+}
+
+///|
+const CalendarRootStyle : String = "display:block;width:15.5rem;max-width:100%;border-radius:var(--rui-radius,0.625rem);background:var(--rui-background,oklch(1 0 0));padding:0.75rem;color:var(--rui-foreground,oklch(0.145 0 0));--rui-calendar-cell-radius:calc(var(--rui-radius,0.625rem) - 0.125rem)"
+
+///|
+const CalendarHeaderStyle : String = "position:relative;display:flex;height:2rem;width:100%;align-items:center;justify-content:center;margin-bottom:1rem"
+
+///|
+const CalendarCaptionStyle : String = "display:flex;height:2rem;align-items:center;justify-content:center;padding-inline:2rem;font-size:0.875rem;line-height:1.25rem;font-weight:500;user-select:none"
+
+///|
+const CalendarNavStyle : String = "position:absolute;inset:0;display:flex;align-items:center;justify-content:space-between;gap:0.25rem;pointer-events:none"
+
+///|
+const CalendarNavButtonStyle : String = "display:inline-flex;width:2rem;height:2rem;align-items:center;justify-content:center;--rui-calendar-base-bg:transparent;--rui-calendar-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-calendar-base-border:transparent;--rui-calendar-base-shadow:none;border:1px solid transparent;border-color:var(--rui-calendar-border,var(--rui-calendar-base-border,transparent));border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);margin:0;padding:0;background:var(--rui-calendar-bg,var(--rui-calendar-base-bg,transparent));color:var(--rui-calendar-fg,var(--rui-calendar-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-calendar-shadow,var(--rui-calendar-base-shadow,none));cursor:pointer;appearance:none;-webkit-appearance:none;pointer-events:auto;outline-offset:2px"
+
+///|
+const CalendarGridStyle : String = "width:100%;border-collapse:separate;border-spacing:0 0.5rem;table-layout:fixed;margin-block:-0.5rem"
+
+///|
+const CalendarWeekdayStyle : String = "width:2rem;height:2rem;padding:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.8rem;line-height:1rem;font-weight:400;text-align:center;vertical-align:middle;user-select:none"
+
+///|
+const CalendarCellStyle : String = "position:relative;width:2rem;height:2rem;padding:0;text-align:center;vertical-align:middle"
+
+///|
+const CalendarCellRangeStartStyle : String = "background:linear-gradient(var(--rui-calendar-range-start-direction,to right),transparent 50%,var(--rui-accent,oklch(0.97 0 0)) 50%)"
+
+///|
+const CalendarCellRangeMiddleStyle : String = "background:var(--rui-accent,oklch(0.97 0 0))"
+
+///|
+const CalendarCellRangeEndStyle : String = "background:linear-gradient(var(--rui-calendar-range-end-direction,to right),var(--rui-accent,oklch(0.97 0 0)) 50%,transparent 50%)"
+
+///|
+const CalendarCellRangeRowStartStyle : String = "border-start-start-radius:var(--rui-calendar-cell-radius);border-end-start-radius:var(--rui-calendar-cell-radius)"
+
+///|
+const CalendarCellRangeRowEndStyle : String = "border-start-end-radius:var(--rui-calendar-cell-radius);border-end-end-radius:var(--rui-calendar-cell-radius)"
+
+///|
+const CalendarDayStyle : String = "display:inline-flex;width:2rem;height:2rem;align-items:center;justify-content:center;--rui-calendar-base-bg:transparent;--rui-calendar-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-calendar-base-border:transparent;--rui-calendar-base-shadow:none;border:1px solid transparent;border-color:var(--rui-calendar-border,var(--rui-calendar-base-border,transparent));border-radius:var(--rui-calendar-cell-radius,calc(var(--rui-radius,0.625rem) - 0.125rem));margin:0;padding:0;background:var(--rui-calendar-bg,var(--rui-calendar-base-bg,transparent));color:var(--rui-calendar-fg,var(--rui-calendar-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-calendar-shadow,var(--rui-calendar-base-shadow,none));font-size:0.875rem;line-height:1rem;font-weight:400;text-align:center;cursor:pointer;user-select:none;appearance:none;-webkit-appearance:none;outline-offset:2px"
+
+///|
+const CalendarDaySelectedStyle : String = "--rui-calendar-base-border:var(--rui-primary,oklch(0.205 0 0));--rui-calendar-base-bg:var(--rui-primary,oklch(0.205 0 0));--rui-calendar-base-fg:var(--rui-primary-foreground,oklch(0.985 0 0))"
+
+///|
+const CalendarDayRangeMiddleStyle : String = "--rui-calendar-base-border:var(--rui-accent,oklch(0.97 0 0));--rui-calendar-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-calendar-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0));border-radius:0"
+
+///|
+const CalendarDayTodayStyle : String = "--rui-calendar-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-calendar-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0));font-weight:500"
+
+///|
+const CalendarDayOutsideStyle : String = "--rui-calendar-base-fg:var(--rui-muted-foreground,oklch(0.556 0 0));opacity:0.55"
+
+///|
+const CalendarOutsidePlaceholderStyle : String = "display:block;width:2rem;height:2rem;visibility:hidden"
+
+///|
+fn calendar_clamp(value : Int, minimum : Int, maximum : Int) -> Int {
+  if value < minimum {
+    minimum
+  } else if value > maximum {
+    maximum
+  } else {
+    value
+  }
+}
+
+///|
+fn calendar_is_leap_year(year : Int) -> Bool {
+  year % 400 == 0 || (year % 4 == 0 && year % 100 != 0)
+}
+
+///|
+fn calendar_days_in_month(year : Int, month : Int) -> Int {
+  match month {
+    2 => if calendar_is_leap_year(year) { 29 } else { 28 }
+    4 | 6 | 9 | 11 => 30
+    _ => 31
+  }
+}
+
+///|
+fn calendar_first_of_month(date : CalendarDate) -> CalendarDate {
+  { year: date.year, month: date.month, day: 1 }
+}
+
+///|
+/// Construct a valid date. Years are clamped to `1..9999`, months to
+/// `1..12`, and the day to the selected month's valid range.
+pub fn calendar_date(year~ : Int, month~ : Int, day~ : Int) -> CalendarDate {
+  let year = calendar_clamp(year, 1, 9999)
+  let month = calendar_clamp(month, 1, 12)
+  let day = calendar_clamp(day, 1, calendar_days_in_month(year, month))
+  { year, month, day }
+}
+
+///|
+pub fn CalendarDate::year(self : CalendarDate) -> Int {
+  self.year
+}
+
+///|
+pub fn CalendarDate::month(self : CalendarDate) -> Int {
+  self.month
+}
+
+///|
+pub fn CalendarDate::day(self : CalendarDate) -> Int {
+  self.day
+}
+
+///|
+fn calendar_pad_two(value : Int) -> String {
+  if value < 10 {
+    "0\{value}"
+  } else {
+    value.to_string()
+  }
+}
+
+///|
+fn calendar_pad_year(value : Int) -> String {
+  if value < 10 {
+    "000\{value}"
+  } else if value < 100 {
+    "00\{value}"
+  } else if value < 1000 {
+    "0\{value}"
+  } else {
+    value.to_string()
+  }
+}
+
+///|
+/// Return the stable `YYYY-MM-DD` representation used by data attributes.
+pub fn CalendarDate::to_iso_string(self : CalendarDate) -> String {
+  let year = calendar_pad_year(self.year)
+  let month = calendar_pad_two(self.month)
+  let day = calendar_pad_two(self.day)
+  "\{year}-\{month}-\{day}"
+}
+
+///|
+fn calendar_month_name(month : Int) -> String {
+  match month {
+    1 => "January"
+    2 => "February"
+    3 => "March"
+    4 => "April"
+    5 => "May"
+    6 => "June"
+    7 => "July"
+    8 => "August"
+    9 => "September"
+    10 => "October"
+    11 => "November"
+    _ => "December"
+  }
+}
+
+///|
+fn calendar_weekday_short(weekday : Int) -> String {
+  match weekday {
+    0 => "Su"
+    1 => "Mo"
+    2 => "Tu"
+    3 => "We"
+    4 => "Th"
+    5 => "Fr"
+    _ => "Sa"
+  }
+}
+
+///|
+fn calendar_weekday_long(weekday : Int) -> String {
+  match weekday {
+    0 => "Sunday"
+    1 => "Monday"
+    2 => "Tuesday"
+    3 => "Wednesday"
+    4 => "Thursday"
+    5 => "Friday"
+    _ => "Saturday"
+  }
+}
+
+///|
+fn calendar_positive_mod(value : Int, divisor : Int) -> Int {
+  let remainder = value % divisor
+  if remainder < 0 {
+    remainder + divisor
+  } else {
+    remainder
+  }
+}
+
+///|
+fn calendar_weekday(date : CalendarDate) -> Int {
+  let month_offset = match date.month {
+    1 => 0
+    2 => 3
+    3 => 2
+    4 => 5
+    5 => 0
+    6 => 3
+    7 => 5
+    8 => 1
+    9 => 4
+    10 => 6
+    11 => 2
+    _ => 4
+  }
+  let year = if date.month < 3 { date.year - 1 } else { date.year }
+  calendar_positive_mod(
+    year + year / 4 - year / 100 + year / 400 + month_offset + date.day,
+    7,
+  )
+}
+
+///|
+fn calendar_shift_month(date : CalendarDate, delta : Int) -> CalendarDate {
+  if delta < 0 {
+    if date.month == 1 {
+      calendar_date(year=date.year - 1, month=12, day=1)
+    } else {
+      calendar_date(year=date.year, month=date.month - 1, day=1)
+    }
+  } else if date.month == 12 {
+    calendar_date(year=date.year + 1, month=1, day=1)
+  } else {
+    calendar_date(year=date.year, month=date.month + 1, day=1)
+  }
+}
+
+///|
+fn calendar_same_month(left : CalendarDate, right : CalendarDate) -> Bool {
+  left.year == right.year && left.month == right.month
+}
+
+///|
+fn calendar_compare_dates(left : CalendarDate, right : CalendarDate) -> Int {
+  if left.year != right.year {
+    left.year.compare(right.year)
+  } else if left.month != right.month {
+    left.month.compare(right.month)
+  } else {
+    left.day.compare(right.day)
+  }
+}
+
+///|
+fn calendar_previous_day(date : CalendarDate) -> CalendarDate {
+  if date.day > 1 {
+    calendar_date(year=date.year, month=date.month, day=date.day - 1)
+  } else if date.year == 1 && date.month == 1 {
+    date
+  } else {
+    let previous = calendar_shift_month(date, -1)
+    calendar_date(
+      year=previous.year,
+      month=previous.month,
+      day=calendar_days_in_month(previous.year, previous.month),
+    )
+  }
+}
+
+///|
+fn calendar_next_day(date : CalendarDate) -> CalendarDate {
+  let last = calendar_days_in_month(date.year, date.month)
+  if date.day < last {
+    calendar_date(year=date.year, month=date.month, day=date.day + 1)
+  } else if date.year == 9999 && date.month == 12 {
+    date
+  } else {
+    calendar_shift_month(date, 1)
+  }
+}
+
+///|
+fn calendar_shift_days(date : CalendarDate, delta : Int) -> CalendarDate {
+  let mut next = date
+  let mut remaining = if delta < 0 { -delta } else { delta }
+  while remaining > 0 {
+    next = if delta < 0 {
+      calendar_previous_day(next)
+    } else {
+      calendar_next_day(next)
+    }
+    remaining = remaining - 1
+  }
+  next
+}
+
+///|
+fn calendar_shift_month_preserving_day(
+  date : CalendarDate,
+  delta : Int,
+) -> CalendarDate {
+  let shifted = calendar_shift_month(date, delta)
+  calendar_date(year=shifted.year, month=shifted.month, day=date.day)
+}
+
+///|
+fn calendar_shift_year(date : CalendarDate, delta : Int) -> CalendarDate {
+  calendar_date(year=date.year + delta, month=date.month, day=date.day)
+}
+
+///|
+fn calendar_cell_date(month : CalendarDate, cell : Int) -> (CalendarDate, Bool) {
+  let first_weekday = calendar_weekday(calendar_first_of_month(month))
+  let current_days = calendar_days_in_month(month.year, month.month)
+  let day = cell - first_weekday + 1
+  if day < 1 {
+    let previous = calendar_shift_month(month, -1)
+    let previous_days = calendar_days_in_month(previous.year, previous.month)
+    (
+      calendar_date(
+        year=previous.year,
+        month=previous.month,
+        day=previous_days + day,
+      ),
+      true,
+    )
+  } else if day > current_days {
+    let next = calendar_shift_month(month, 1)
+    (
+      calendar_date(year=next.year, month=next.month, day=day - current_days),
+      true,
+    )
+  } else {
+    (calendar_date(year=month.year, month=month.month, day~), false)
+  }
+}
+
+///|
+fn calendar_date_label(date : CalendarDate) -> String {
+  let month = calendar_month_name(date.month)
+  "\{month} \{date.day}, \{date.year}"
+}
+
+///|
+fn calendar_initial_model(
+  default_month : CalendarDate?,
+  default_selected : CalendarDate?,
+  today : CalendarDate?,
+) -> CalendarModel {
+  let visible = if default_month is Some(date) {
+    calendar_first_of_month(date)
+  } else if default_selected is Some(date) {
+    calendar_first_of_month(date)
+  } else if today is Some(date) {
+    calendar_first_of_month(date)
+  } else {
+    calendar_date(year=1970, month=1, day=1)
+  }
+  let focused = calendar_focus_target(visible, default_selected, today)
+  { visible, selected: default_selected, focused }
+}
+
+///|
+fn calendar_focus_target(
+  visible : CalendarDate,
+  selected : CalendarDate?,
+  today : CalendarDate?,
+) -> CalendarDate {
+  if selected is Some(date) && calendar_same_month(date, visible) {
+    date
+  } else if today is Some(date) && calendar_same_month(date, visible) {
+    date
+  } else {
+    calendar_first_of_month(visible)
+  }
+}
+
+///|
+#cfg(target="js")
+fn[T] calendar_emit_command(emit : @cmd.Emit[T]?, value : T) -> @cmd.Cmd {
+  if emit is Some(emit) {
+    emit(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn calendar_event_is_rtl(event : @dom.KeyboardEvent) -> Bool {
+  if event.target().to_element() is Some(target) {
+    ui_element_is_rtl(target)
+  } else {
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+fn focus_calendar_day(root_id : String, iso_date : String) -> Unit {
+  let calendar_selector = "[data-slot=\"calendar\"]"
+  let day_selector = "[data-slot=\"calendar-day-button\"]"
+  fn is_calendar(root : @dom.Element) -> Bool {
+    root.get_attribute("data-slot").unwrap_or("") == "calendar" &&
+    root.get_is_connected()
+  }
+
+  fn days_in(root : @dom.Element) -> Array[@dom.Element] {
+    root.query_selector_all(day_selector)
+  }
+
+  fn target_in(root : @dom.Element) -> @dom.Element? {
+    for day in days_in(root) {
+      if day.get_attribute("data-day").unwrap_or("") == iso_date &&
+        ui_element_is_enabled(day) {
+        return Some(day)
+      }
+    }
+    None
+  }
+
+  fn focus_in(root : @dom.Element) -> Bool {
+    let days = days_in(root)
+    guard target_in(root) is Some(target) else { return false }
+    for day in days {
+      ui_set_element_tab_index(
+        day,
+        if day.is_same_node(target.as_node()) {
+          0
+        } else {
+          -1
+        },
+      )
+    }
+    ui_focus_element(target)
+    true
+  }
+
+  if root_id != "" {
+    if ui_element_by_id(root_id) is Some(root) && is_calendar(root) {
+      ignore(focus_in(root))
+    }
+    return
+  }
+  let document = @dom.document()
+  if document.get_active_element() is Some(active) &&
+    active.closest(calendar_selector) is Some(root) &&
+    is_calendar(root) &&
+    focus_in(root) {
+    return
+  }
+  let matching : Array[@dom.Element] = []
+  let roots = document.query_selector_all(calendar_selector)
+  for index in 0..<roots.get_length().to_int() {
+    if roots.item(index.to_double()).to_option() is Some(node) &&
+      node.to_element() is Some(root) &&
+      is_calendar(root) &&
+      target_in(root) is Some(_) {
+      matching.push(root)
+    }
+  }
+  if matching.length() == 1 {
+    ignore(focus_in(matching[0]))
+  }
+}
+
+///|
+#cfg(target="js")
+fn calendar_focus_day_cmd(root_id : String?, date : CalendarDate) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    focus_calendar_day(root_id.unwrap_or(""), date.to_iso_string())
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn calendar_focus_day_cmd(root_id : String?, date : CalendarDate) -> @cmd.Cmd {
+  ignore((root_id, date))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn calendar_key_target(
+  date : CalendarDate,
+  event : @dom.KeyboardEvent,
+) -> CalendarDate? {
+  let key = event.key()
+  let shift = event.shift_key()
+  let rtl = calendar_event_is_rtl(event)
+  match key {
+    "ArrowLeft" =>
+      Some(
+        if shift {
+          calendar_shift_month_preserving_day(date, if rtl { 1 } else { -1 })
+        } else {
+          calendar_shift_days(date, if rtl { 1 } else { -1 })
+        },
+      )
+    "ArrowRight" =>
+      Some(
+        if shift {
+          calendar_shift_month_preserving_day(date, if rtl { -1 } else { 1 })
+        } else {
+          calendar_shift_days(date, if rtl { -1 } else { 1 })
+        },
+      )
+    "ArrowUp" =>
+      Some(
+        if shift {
+          calendar_shift_year(date, -1)
+        } else {
+          calendar_shift_days(date, -7)
+        },
+      )
+    "ArrowDown" =>
+      Some(
+        if shift {
+          calendar_shift_year(date, 1)
+        } else {
+          calendar_shift_days(date, 7)
+        },
+      )
+    "PageUp" =>
+      Some(
+        if shift {
+          calendar_shift_year(date, -1)
+        } else {
+          calendar_shift_month_preserving_day(date, -1)
+        },
+      )
+    "PageDown" =>
+      Some(
+        if shift {
+          calendar_shift_year(date, 1)
+        } else {
+          calendar_shift_month_preserving_day(date, 1)
+        },
+      )
+    "Home" => Some(calendar_shift_days(date, -calendar_weekday(date)))
+    "End" => Some(calendar_shift_days(date, 6 - calendar_weekday(date)))
+    _ => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn calendar_bind_day_interaction(
+  attrs : @html.Attrs,
+  root_id : String?,
+  date : CalendarDate,
+  focused : Bool,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+) -> Unit {
+  ignore(attrs.tabindex(if focused { 0 } else { -1 }))
+  if on_focus_change is Some(emit) {
+    ignore(attrs.on_focus(_ => emit(date)))
+  }
+  ignore(
+    attrs.on_keydown(event => {
+      if calendar_key_target(date, event) is Some(next) {
+        event.prevent_default()
+        event.stop_propagation()
+        if on_focus_move is Some(emit) {
+          @cmd.batch([emit(next), calendar_focus_day_cmd(root_id, next)])
+        } else {
+          calendar_focus_day_cmd(root_id, next)
+        }
+      } else {
+        @cmd.none
+      }
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn calendar_bind_day_interaction(
+  attrs : @html.Attrs,
+  root_id : String?,
+  date : CalendarDate,
+  focused : Bool,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+) -> Unit {
+  ignore((root_id, date, on_focus_change, on_focus_move))
+  ignore(attrs.tabindex(if focused { 0 } else { -1 }))
+}
+
+///|
+fn calendar_nav_button(
+  direction : String,
+  label : String,
+  disabled : Bool,
+  command : @cmd.Cmd?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "calendar-\{direction}")
+    .data_set("direction", direction)
+    .aria_label(label)
+    .aria_disabled(ui_bool(disabled))
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  } else if command is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  let chevron = if direction == "previous" {
+    ui_chevron_left_icon()
+  } else {
+    ui_chevron_right_icon()
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        CalendarNavButtonStyle,
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    chevron,
+  )
+}
+
+///|
+fn calendar_day_button_impl(
+  root_id : String?,
+  date~ : CalendarDate,
+  selected? : Bool = false,
+  multiple? : Bool = false,
+  range_start? : Bool = false,
+  range_end? : Bool = false,
+  range_middle? : Bool = false,
+  today? : Bool = false,
+  outside? : Bool = false,
+  disabled? : Bool = false,
+  focused? : Bool = false,
+  on_select? : @cmd.Emit[CalendarDate],
+  on_focus_change? : @cmd.Emit[CalendarDate],
+  on_focus_move? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let iso_date = date.to_iso_string()
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "calendar-day-button")
+    .data_set("day", iso_date)
+    .data_set("selected", ui_bool(selected))
+    .data_set("outside", ui_bool(outside))
+    .aria_label(calendar_date_label(date))
+    .aria_selected(ui_bool(selected))
+    .aria_disabled(ui_bool(disabled))
+  if selected && !range_start && !range_end && !range_middle {
+    if multiple {
+      ignore(element_attrs.data_set("selected-multiple", ""))
+    } else {
+      ignore(element_attrs.data_set("selected-single", "true"))
+    }
+  }
+  if range_start {
+    ignore(element_attrs.data_set("range-start", ""))
+  }
+  if range_end {
+    ignore(element_attrs.data_set("range-end", ""))
+  }
+  if range_middle {
+    ignore(element_attrs.data_set("range-middle", ""))
+  }
+  if today {
+    ignore(element_attrs.data_set("today", "").aria_current("date"))
+  }
+  if focused && !disabled {
+    ignore(element_attrs.data_set("focused", ""))
+  }
+  if outside {
+    ignore(element_attrs.data_set("outside-day", ""))
+  }
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  } else if on_select is Some(emit) {
+    ignore(element_attrs.on_click(_ => emit(date)))
+  }
+  calendar_bind_day_interaction(
+    element_attrs,
+    root_id,
+    date,
+    focused && !disabled,
+    if disabled {
+      None
+    } else {
+      on_focus_change
+    },
+    if disabled {
+      None
+    } else {
+      on_focus_move
+    },
+  )
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        CalendarDayStyle,
+        if outside {
+          CalendarDayOutsideStyle
+        } else {
+          ""
+        },
+        if today && !selected {
+          CalendarDayTodayStyle
+        } else {
+          ""
+        },
+        if selected {
+          if range_middle {
+            CalendarDayRangeMiddleStyle
+          } else {
+            CalendarDaySelectedStyle
+          }
+        } else {
+          ""
+        },
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    date.day.to_string(),
+  )
+}
+
+///|
+/// Render the native day button used by the Calendar state renderer.
+///
+/// Dates remain native buttons while the component supplies the roving tab
+/// stop and DayPicker-compatible arrow, Home/End, and PageUp/PageDown movement.
+pub fn calendar_day_button(
+  date~ : CalendarDate,
+  selected? : Bool = false,
+  today? : Bool = false,
+  outside? : Bool = false,
+  disabled? : Bool = false,
+  focused? : Bool = false,
+  on_select? : @cmd.Emit[CalendarDate],
+  on_focus_change? : @cmd.Emit[CalendarDate],
+  on_focus_move? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  calendar_day_button_impl(
+    None,
+    date~,
+    selected~,
+    multiple=false,
+    range_start=false,
+    range_end=false,
+    range_middle=false,
+    today~,
+    outside~,
+    disabled~,
+    focused~,
+    on_select?,
+    on_focus_change?,
+    on_focus_move?,
+    id?,
+    class?,
+    title?,
+    attrs?,
+    style~,
+  )
+}
+
+///|
+fn calendar_weekday_header(weekday : Int, style : Array[String]) -> @html.Html {
+  @html.th(
+    style=ui_styles([UiBoxSizing, CalendarWeekdayStyle], style),
+    abbr=calendar_weekday_long(weekday),
+    scope=Col,
+    attrs=@html.Attrs::build()
+      .data_set("slot", "calendar-weekday")
+      .data_set("weekday", weekday.to_string()),
+    calendar_weekday_short(weekday),
+  )
+}
+
+///|
+fn calendar_day_cell(
+  root_id : String?,
+  month : CalendarDate,
+  cell : Int,
+  selection_mode : CalendarSelectionMode,
+  selected_date : CalendarDate?,
+  selected_dates : Array[CalendarDate]?,
+  range_start : CalendarDate?,
+  range_end : CalendarDate?,
+  today_date : CalendarDate?,
+  focused_date : CalendarDate,
+  show_outside_days : Bool,
+  hide_outside_before : Bool,
+  hide_outside_after : Bool,
+  disabled : Bool,
+  on_select : @cmd.Emit[CalendarDate]?,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+  day_attrs : @html.Attrs?,
+  cell_style : Array[String],
+  day_style : Array[String],
+) -> @html.Html {
+  let (date, outside) = calendar_cell_date(month, cell)
+  let outside_before = outside && calendar_compare_dates(date, month) < 0
+  let outside_visible = show_outside_days &&
+    !(outside_before && hide_outside_before) &&
+    !(!outside_before && outside && hide_outside_after)
+  let date_visible = !outside || outside_visible
+  let is_range_start = date_visible && range_start == Some(date)
+  let is_range_end = date_visible && range_end == Some(date)
+  let is_range_middle = date_visible &&
+    (if range_start is Some(start) && range_end is Some(end) {
+      calendar_compare_dates(date, start) > 0 &&
+      calendar_compare_dates(date, end) < 0
+    } else {
+      false
+    })
+  let is_multiple_selected = if selected_dates is Some(dates) {
+    calendar_contains_date(dates, date)
+  } else {
+    false
+  }
+  let is_selected = date_visible &&
+    (
+      selected_date == Some(date) ||
+      is_multiple_selected ||
+      is_range_start ||
+      is_range_end ||
+      is_range_middle
+    )
+  let is_today = today_date == Some(date)
+  let is_focused = focused_date == date
+  let cell_attrs = @html.Attrs::build()
+    .data_set("slot", "calendar-day")
+    .data_set("outside", ui_bool(outside))
+    .data_set("selected", ui_bool(is_selected))
+  if is_range_start {
+    ignore(cell_attrs.data_set("range-start", ""))
+  }
+  if is_range_end {
+    ignore(cell_attrs.data_set("range-end", ""))
+  }
+  if is_range_middle {
+    ignore(cell_attrs.data_set("range-middle", ""))
+  }
+  let range_cell_style = if is_range_middle {
+    if cell % 7 == 0 {
+      CalendarCellRangeMiddleStyle + ";" + CalendarCellRangeRowStartStyle
+    } else if cell % 7 == 6 {
+      CalendarCellRangeMiddleStyle + ";" + CalendarCellRangeRowEndStyle
+    } else {
+      CalendarCellRangeMiddleStyle
+    }
+  } else if is_range_start && !is_range_end && range_end is Some(_) {
+    CalendarCellRangeStartStyle
+  } else if is_range_end && !is_range_start {
+    CalendarCellRangeEndStyle
+  } else {
+    ""
+  }
+  @html.td(
+    style=ui_styles(
+      [UiBoxSizing, CalendarCellStyle, range_cell_style],
+      cell_style,
+    ),
+    attrs=cell_attrs,
+    if outside && !outside_visible {
+      @html.span(
+        style=[UiBoxSizing, CalendarOutsidePlaceholderStyle],
+        attrs=@html.Attrs::build().aria_hidden("true"),
+        @html.nothing,
+      )
+    } else {
+      let attrs = day_attrs
+      calendar_day_button_impl(
+        root_id,
+        date~,
+        selected=is_selected,
+        multiple=selection_mode is CalendarMultipleSelection,
+        range_start=is_range_start,
+        range_end=is_range_end,
+        range_middle=is_range_middle,
+        today=is_today,
+        outside~,
+        disabled~,
+        focused=is_focused,
+        on_select?,
+        on_focus_change?,
+        on_focus_move?,
+        attrs?,
+        style=day_style,
+      )
+    },
+  )
+}
+
+///|
+/// Render one fully composed Calendar state for the incremental wrapper.
+///
+/// The table and button semantics work without a client runtime. `attrs` and
+/// every part-level attribute set are cloned before component data is added.
+fn render_calendar(
+  month~ : CalendarDate,
+  selection_mode? : CalendarSelectionMode = CalendarSingleSelection,
+  selected? : CalendarDate,
+  selected_dates? : Array[CalendarDate],
+  range_start? : CalendarDate,
+  range_end? : CalendarDate,
+  today? : CalendarDate,
+  focused? : CalendarDate,
+  show_outside_days? : Bool = true,
+  hide_outside_before? : Bool = false,
+  hide_outside_after? : Bool = false,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_previous? : @cmd.Cmd,
+  on_next? : @cmd.Cmd,
+  on_select? : @cmd.Emit[CalendarDate],
+  on_focus_change? : @cmd.Emit[CalendarDate],
+  on_focus_move? : @cmd.Emit[CalendarDate],
+  show_previous? : Bool = true,
+  show_next? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @html.Html {
+  let month = calendar_first_of_month(month)
+  let focused = focused.unwrap_or(calendar_focus_target(month, selected, today))
+  let caption = "\{calendar_month_name(month.month)} \{month.year}"
+  let caption_id = id.map(id => "\{id}-caption")
+  let previous_disabled = disabled || (month.year == 1 && month.month == 1)
+  let next_disabled = disabled || (month.year == 9999 && month.month == 12)
+  let root_attrs = ui_attrs(attrs)
+    .data_set("slot", "calendar")
+    .data_set("mode", calendar_selection_mode_name(selection_mode))
+    .data_set("month", month.to_iso_string())
+    .role("group")
+    .aria_label(aria_label)
+    .aria_disabled(ui_bool(disabled))
+  if range_start is Some(start) {
+    ignore(root_attrs.data_set("range-start", start.to_iso_string()))
+  }
+  if range_end is Some(end) {
+    ignore(root_attrs.data_set("range-end", end.to_iso_string()))
+  }
+  if selected_dates is Some(dates) {
+    ignore(root_attrs.data_set("selected-count", dates.length().to_string()))
+  }
+  if disabled {
+    ignore(root_attrs.data_set("disabled", ""))
+  }
+  let table_attrs = ui_attrs(grid_attrs)
+    .data_set("slot", "calendar-grid")
+    .role("grid")
+  if selection_mode is CalendarRangeSelection ||
+    selection_mode is CalendarMultipleSelection {
+    ignore(table_attrs.aria_multiselectable("true"))
+  }
+  if caption_id is Some(caption_id) {
+    ignore(table_attrs.aria_labelledby(caption_id))
+  } else {
+    ignore(table_attrs.aria_label(caption))
+  }
+  let weekdays = Array::makei(7, weekday => {
+    calendar_weekday_header(weekday, weekday_style)
+  })
+  let weeks = Array::makei(6, week => {
+    let days = Array::makei(7, weekday => {
+      calendar_day_cell(
+        id,
+        month,
+        week * 7 + weekday,
+        selection_mode,
+        selected,
+        selected_dates,
+        range_start,
+        range_end,
+        today,
+        focused,
+        show_outside_days,
+        hide_outside_before,
+        hide_outside_after,
+        disabled,
+        on_select,
+        on_focus_change,
+        on_focus_move,
+        day_attrs,
+        cell_style,
+        day_style,
+      )
+    })
+    @html.tr(
+      attrs=@html.Attrs::build()
+        .data_set("slot", "calendar-week")
+        .data_set("week", week.to_string()),
+      days,
+    )
+  })
+  let caption_node = {
+    let id = caption_id
+    @html.span(
+      style=ui_styles([UiBoxSizing, CalendarCaptionStyle], caption_style),
+      id?,
+      attrs=@html.Attrs::build().data_set("slot", "calendar-caption"),
+      caption,
+    )
+  }
+  let nav_items : Array[@html.Html] = []
+  if show_previous {
+    nav_items.push(
+      calendar_nav_button(
+        "previous", "Go to previous month", previous_disabled, on_previous, previous_attrs,
+        previous_style,
+      ),
+    )
+  }
+  if show_next {
+    nav_items.push(
+      calendar_nav_button(
+        "next", "Go to next month", next_disabled, on_next, next_attrs, next_style,
+      ),
+    )
+  }
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, CalendarRootStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=root_attrs,
+    [
+      @html.div(
+        style=ui_styles([UiBoxSizing, CalendarHeaderStyle], header_style),
+        attrs=@html.Attrs::build().data_set("slot", "calendar-header"),
+        [
+          caption_node,
+          @html.div(
+            style=ui_styles([UiBoxSizing, CalendarNavStyle], nav_style),
+            attrs=@html.Attrs::build()
+              .data_set("slot", "calendar-nav")
+              .aria_label("Month navigation"),
+            nav_items,
+          ),
+        ],
+      ),
+      @html.table(
+        style=ui_styles([UiBoxSizing, CalendarGridStyle], grid_style),
+        attrs=table_attrs,
+        [@html.thead(@html.tr(weekdays)), @html.tbody(weeks)],
+      ),
+    ],
+  )
+}
+
+///|
+#cfg(target="js")
+fn calendar_update(
+  root_id : String?,
+  on_select : @cmd.Emit[CalendarDate]?,
+  on_month_change : @cmd.Emit[CalendarDate]?,
+  today : CalendarDate?,
+  msg : CalendarMsg,
+  model : CalendarModel,
+) -> (CalendarModel, @cmd.Cmd) {
+  match msg {
+    CalendarNavigate(delta) => {
+      let visible = calendar_shift_month(model.visible, delta)
+      let focused = calendar_focus_target(visible, model.selected, today)
+      (
+        { ..model, visible, focused },
+        calendar_emit_command(on_month_change, visible),
+      )
+    }
+    CalendarChoose(date) => {
+      let visible = calendar_first_of_month(date)
+      let commands : Array[@cmd.Cmd] = [calendar_emit_command(on_select, date)]
+      if visible != model.visible {
+        commands.push(calendar_emit_command(on_month_change, visible))
+      }
+      ({ visible, selected: Some(date), focused: date }, @cmd.batch(commands))
+    }
+    CalendarSetFocused(date) => ({ ..model, focused: date }, @cmd.none)
+    CalendarMoveFocus(date) => {
+      let visible = calendar_first_of_month(date)
+      let commands : Array[@cmd.Cmd] = [calendar_focus_day_cmd(root_id, date)]
+      if visible != model.visible {
+        commands.push(calendar_emit_command(on_month_change, visible))
+      }
+      ({ ..model, visible, focused: date }, @cmd.batch(commands))
+    }
+  }
+}
+
+///|
+/// Stateful single-date calendar with Rabbita-owned visible-month and
+/// selection state.
+///
+/// When no initial month, selected date, or `today` is supplied, the stable
+/// SSR fallback is January 1970. Supplying `today` both selects the initial
+/// visible month and enables the current-day treatment.
+#cfg(target="js")
+pub fn calendar(
+  default_month? : CalendarDate,
+  default_selected? : CalendarDate,
+  today? : CalendarDate,
+  show_outside_days? : Bool = true,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_select? : @cmd.Emit[CalendarDate],
+  on_month_change? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = calendar_initial_model(default_month, default_selected, today)
+  let (model, emit) = @rabbita.create_state(initial, update=fn(_, msg, model) {
+    calendar_update(id, on_select, on_month_change, today, msg, model)
+  })
+  let select = emit.map(date => CalendarChoose(date))
+  let set_focused = emit.map(date => CalendarSetFocused(date))
+  let move_focus = emit.map(date => CalendarMoveFocus(date))
+  model.view(model => {
+    let selected = model.selected
+    render_calendar(
+      month=model.visible,
+      selected?,
+      today?,
+      focused=model.focused,
+      show_outside_days~,
+      disabled~,
+      aria_label~,
+      on_previous=emit(CalendarNavigate(-1)),
+      on_next=emit(CalendarNavigate(1)),
+      on_select=select,
+      on_focus_change=set_focused,
+      on_focus_move=move_focus,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      previous_attrs?,
+      next_attrs?,
+      grid_attrs?,
+      day_attrs?,
+      style~,
+      header_style~,
+      caption_style~,
+      nav_style~,
+      previous_style~,
+      next_style~,
+      grid_style~,
+      weekday_style~,
+      cell_style~,
+      day_style~,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for `calendar`; renders the same requested initial
+/// month and selection as a constant incremental value.
+#cfg(not(target="js"))
+pub fn calendar(
+  default_month? : CalendarDate,
+  default_selected? : CalendarDate,
+  today? : CalendarDate,
+  show_outside_days? : Bool = true,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_select? : @cmd.Emit[CalendarDate],
+  on_month_change? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_select, on_month_change))
+  let model = calendar_initial_model(default_month, default_selected, today)
+  let select : @cmd.Emit[CalendarDate] = Emit(_ => @cmd.none)
+  let selected = model.selected
+  @rabbita.Val::constant(
+    render_calendar(
+      month=model.visible,
+      selected?,
+      today?,
+      focused=model.focused,
+      show_outside_days~,
+      disabled~,
+      aria_label~,
+      on_previous=@cmd.none,
+      on_next=@cmd.none,
+      on_select=select,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      previous_attrs?,
+      next_attrs?,
+      grid_attrs?,
+      day_attrs?,
+      style~,
+      header_style~,
+      caption_style~,
+      nav_style~,
+      previous_style~,
+      next_style~,
+      grid_style~,
+      weekday_style~,
+      cell_style~,
+      day_style~,
+    ),
+  )
+}

--- a/rui/calendar_carousel_test.mbt
+++ b/rui/calendar_carousel_test.mbt
@@ -1,0 +1,302 @@
+///|
+#cfg(target="js")
+extern "js" fn install_incremental_cc_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_incremental_cc(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  install_incremental_cc_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_incremental_cc(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+test "calendar date construction normalizes invalid fields" {
+  let date = @rui.calendar_date(year=2024, month=2, day=31)
+  assert_eq(date.year(), 2024)
+  assert_eq(date.month(), 2)
+  assert_eq(date.day(), 29)
+  assert_eq(date.to_iso_string(), "2024-02-29")
+}
+
+///|
+test "calendar black-box renders a semantic selected month" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let day_attrs = @html.Attrs::build().data_set("day-owner", "caller")
+  let html = render_incremental_cc(() => {
+    @rui.calendar(
+      default_month=@rui.calendar_date(year=2026, month=7, day=1),
+      default_selected=@rui.calendar_date(year=2026, month=7, day=15),
+      today=@rui.calendar_date(year=2026, month=7, day=16),
+      id="release-calendar",
+      aria_label="Release calendar",
+      attrs~,
+      day_attrs~,
+      style=["background:rebeccapurple"],
+      day_style=["border-radius:2px"],
+    )
+  })
+  assert_contains(html, "data-slot=\"calendar\"")
+  assert_contains(html, "role=\"group\"")
+  assert_contains(html, "aria-label=\"Release calendar\"")
+  assert_contains(html, "id=\"release-calendar-caption\"")
+  assert_contains(html, ">July 2026</span>")
+  assert_contains(html, "<table")
+  assert_contains(html, "data-slot=\"calendar-grid\"")
+  assert_contains(html, "role=\"grid\"")
+  assert_contains(html, "aria-labelledby=\"release-calendar-caption\"")
+  assert_contains(html, "scope=\"col\"")
+  assert_contains(html, "abbr=\"Sunday\"")
+  assert_contains(html, "data-day=\"2026-06-28\"")
+  assert_contains(html, "data-outside-day=\"\"")
+  assert_contains(html, "data-day=\"2026-07-15\"")
+  assert_contains(html, "data-selected-single=\"true\"")
+  assert_contains(html, "data-focused=\"\"")
+  assert_contains(html, "tabindex=\"0\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "aria-selected=\"true\"")
+  assert_contains(html, "data-day=\"2026-07-16\"")
+  assert_contains(html, "aria-current=\"date\"")
+  assert_contains(html, "aria-label=\"Go to previous month\"")
+  assert_contains(html, "aria-label=\"Go to next month\"")
+  assert_contains(html, "<svg")
+  assert_contains(html, "width=\"16\"")
+  assert_contains(html, "height=\"16\"")
+  assert_not_contains(html, "width:0.4375rem")
+  assert_contains(html, "data-day-owner=\"caller\"")
+  assert_contains(html, "background:rebeccapurple")
+  assert_contains(html, "border-radius:2px")
+  assert_contains(
+    html, "background:var(--rui-calendar-bg,var(--rui-calendar-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "border-color:var(--rui-calendar-border,var(--rui-calendar-base-border,transparent))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-calendar-shadow,var(--rui-calendar-base-shadow,none))",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-15\"", "--rui-calendar-base-bg:var(--rui-primary",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-16\"", "--rui-calendar-base-bg:var(--rui-accent",
+  )
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "role=\"group\"")
+  let original_day = render(@html.div(attrs=day_attrs, @html.nothing))
+  assert_contains(original_day, "data-day-owner=\"caller\"")
+  assert_not_contains(original_day, "data-day=")
+}
+
+///|
+test "calendar owns initial month and can hide outside dates" {
+  let month = @rui.calendar_date(year=2025, month=2, day=18)
+  let selected = @rui.calendar_date(year=2025, month=2, day=28)
+  let html = render_incremental_cc(() => {
+    @rui.calendar(
+      default_month=month,
+      default_selected=selected,
+      show_outside_days=false,
+    )
+  })
+  assert_contains(html, ">February 2025</span>")
+  assert_contains(html, "data-month=\"2025-02-01\"")
+  assert_contains(html, "data-day=\"2025-02-28\"")
+  assert_contains(html, "data-selected-single=\"true\"")
+  assert_contains(html, "visibility:hidden")
+  assert_not_contains(html, "data-day=\"2025-01-26\"")
+}
+
+///|
+test "carousel black-box exposes compound scope and slide state" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let item_attrs = @html.Attrs::build().data_set("item-owner", "caller")
+  let html = render_incremental_cc(() => {
+    @rui.carousel(
+      default_index=1,
+      count=3,
+      id="stories",
+      aria_label="Customer stories",
+      attrs~,
+      style=["max-width:30rem"],
+      scope => {
+        [
+          @rui.carousel_content(scope~, track_style=["gap:0.25rem"], [
+            @rui.carousel_item(
+              scope~,
+              index=0,
+              attrs=item_attrs,
+              @html.p("First"),
+            ),
+            @rui.carousel_item(
+              scope~,
+              index=1,
+              attrs=item_attrs,
+              @html.p("Second"),
+            ),
+            @rui.carousel_item(
+              scope~,
+              index=2,
+              attrs=item_attrs,
+              @html.p("Third"),
+            ),
+          ]),
+          @rui.carousel_previous(scope~),
+          @rui.carousel_next(scope~),
+        ]
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"carousel\"")
+  assert_contains(html, "role=\"region\"")
+  assert_contains(html, "aria-roledescription=\"carousel\"")
+  assert_contains(html, "aria-label=\"Customer stories\"")
+  assert_contains(html, "data-active-index=\"1\"")
+  assert_contains(html, "data-count=\"3\"")
+  assert_contains(html, "data-max-snap-index=\"2\"")
+  assert_contains(html, "data-slot=\"carousel-content\"")
+  assert_contains(html, "data-slot=\"carousel-track\"")
+  assert_contains(html, "--rui-carousel-ltr-offset:-100%")
+  assert_contains(html, "--rui-carousel-rtl-offset:100%")
+  assert_contains(
+    html, "transform:translate3d(var(--rui-carousel-offset,var(--rui-carousel-ltr-offset)),0,0)",
+  )
+  assert_contains(html, "data-swipe=\"true\"")
+  assert_contains(
+    html, "touch-action:var(--rui-carousel-touch-action,pan-y pinch-zoom)",
+  )
+  assert_contains(html, "margin-inline-start:-1rem")
+  assert_contains(html, "padding-inline-start:1rem")
+  assert_contains(html, "gap:0.25rem")
+  assert_contains(html, "data-index=\"1\"")
+  assert_contains(html, "data-state=\"active\"")
+  assert_contains(html, "aria-current=\"true\"")
+  assert_contains(html, "data-state=\"inactive\"")
+  assert_not_contains(html, " inert")
+  assert_contains(html, "aria-label=\"Previous slide\"")
+  assert_contains(html, "aria-label=\"Next slide\"")
+  assert_contains(html, "data-icon=\"previous\"")
+  assert_contains(html, "data-icon=\"next\"")
+  assert_contains(html, "width:1rem;height:1rem")
+  assert_contains(html, "--rui-carousel-control-inline-offset,-3rem")
+  assert_contains(
+    html, "inset-inline-start:var(--rui-carousel-control-inline-offset",
+  )
+  assert_contains(
+    html, "inset-inline-end:var(--rui-carousel-control-inline-offset",
+  )
+  assert_contains(html, "aria-live=\"polite\"")
+  assert_contains(html, ">Slide 2 of 3</span>")
+  assert_contains(html, "data-item-owner=\"caller\"")
+  assert_contains(html, "max-width:30rem")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "role=\"region\"")
+  let original_item = render(@html.div(attrs=item_attrs, @html.nothing))
+  assert_contains(original_item, "data-item-owner=\"caller\"")
+  assert_not_contains(original_item, "data-index")
+}
+
+///|
+test "carousel boundary controls and wrap-around use native buttons" {
+  let bounded = render_incremental_cc(() => {
+    @rui.carousel(default_index=0, count=2, scope => {
+      [@rui.carousel_previous(scope~), @rui.carousel_next(scope~)]
+    })
+  })
+  assert_contains(bounded, "data-slot=\"carousel-previous\"")
+  assert_contains(bounded, "data-direction=\"previous\"")
+  assert_contains(bounded, "data-variant=\"outline\"")
+  assert_contains(bounded, "data-size=\"icon-sm\"")
+  assert_contains(
+    bounded, "background:var(--rui-button-bg,var(--rui-button-base-bg,transparent))",
+  )
+  assert_contains(
+    bounded, "box-shadow:var(--rui-button-shadow,var(--rui-button-base-shadow,none))",
+  )
+  assert_contains(bounded, "data-state=\"disabled\"")
+  assert_contains(bounded, " disabled")
+  assert_contains(bounded, "data-slot=\"carousel-next\"")
+  assert_contains(bounded, "data-state=\"enabled\"")
+
+  let custom_control = render_incremental_cc(() => {
+    @rui.carousel(default_index=1, count=3, scope => {
+      @rui.carousel_previous(scope~, style=["inset-inline-start:-1rem"])
+    })
+  })
+  assert_contains(
+    custom_control, "inset-inline-start:var(--rui-carousel-control-inline-offset,-3rem)",
+  )
+  assert_contains(custom_control, "inset-inline-start:-1rem")
+
+  let wrapped = render_incremental_cc(() => {
+    @rui.carousel(
+      default_index=2,
+      count=3,
+      loop_=true,
+      orientation=@rui.CarouselVertical,
+      scope => {
+        [
+          @rui.carousel_items(scope~, items=[
+            @html.p("A"),
+            @html.p("B"),
+            @html.p("C"),
+          ]),
+          @rui.carousel_previous(scope~),
+          @rui.carousel_next(scope~),
+        ]
+      },
+    )
+  })
+  assert_contains(wrapped, "data-orientation=\"vertical\"")
+  assert_contains(wrapped, "--rui-carousel-block-offset:-200%")
+  assert_contains(
+    wrapped, "transform:translate3d(0,var(--rui-carousel-offset,var(--rui-carousel-block-offset)),0)",
+  )
+  assert_contains(wrapped, "--rui-carousel-height,12rem")
+  assert_contains(wrapped, "top:var(--rui-carousel-control-block-offset,-3rem)")
+  assert_contains(
+    wrapped, "bottom:var(--rui-carousel-control-block-offset,-3rem)",
+  )
+  assert_contains(wrapped, "data-direction=\"next\"")
+  assert_not_contains(wrapped, "data-state=\"disabled\"")
+}
+
+///|
+test "carousel owns its initial active slide" {
+  let html = render_incremental_cc(() => {
+    @rui.carousel(count=3, default_index=2, aria_label="Highlights", scope => {
+      [
+        @rui.carousel_items(scope~, items=[
+          @html.p("One"),
+          @html.p("Two"),
+          @html.p("Three"),
+        ]),
+        @rui.carousel_previous(scope~),
+        @rui.carousel_next(scope~),
+      ]
+    })
+  })
+  assert_contains(html, "aria-label=\"Highlights\"")
+  assert_contains(html, "data-active-index=\"2\"")
+  assert_contains(html, "--rui-carousel-ltr-offset:-200%")
+  assert_contains(html, ">Slide 3 of 3</span>")
+}

--- a/rui/calendar_focus_wbtest.mbt
+++ b/rui/calendar_focus_wbtest.mbt
@@ -1,0 +1,156 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_calendar_focus_fixture(
+  active_calendar : Int,
+) -> Unit =
+  #| activeCalendar => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const isoDate = "2041-11-03"
+  #|   const fixture = globalThis.__ruiCalendarFocusFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     focused: 0,
+  #|   }
+  #|   class FixtureHTMLElement {
+  #|     constructor() { this.nodeType = 1 }
+  #|   }
+  #|   globalThis.HTMLElement = FixtureHTMLElement
+  #|   const makeDay = owner => {
+  #|     const day = new FixtureHTMLElement()
+  #|     day.dataset = { day: isoDate }
+  #|     day.disabled = false
+  #|     day.tabIndex = -1
+  #|     day.getAttribute = name => name === "data-day" ? isoDate : ""
+  #|     day.hasAttribute = name => name === "disabled" && day.disabled
+  #|     day.focus = () => { fixture.focused = owner }
+  #|     return day
+  #|   }
+  #|   const firstDay = makeDay(1)
+  #|   const secondDay = makeDay(2)
+  #|   const makeRoot = (id, day) => ({
+  #|     id,
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     dataset: { slot: "calendar" },
+  #|     getAttribute: name => name === "data-slot" ? "calendar" : "",
+  #|     querySelectorAll: selector => selector === '[data-slot="calendar-day-button"]'
+  #|       ? [day]
+  #|       : [],
+  #|   })
+  #|   const firstRoot = makeRoot("calendar-first", firstDay)
+  #|   const secondRoot = makeRoot("calendar-second", secondDay)
+  #|   fixture.firstDay = firstDay
+  #|   fixture.secondDay = secondDay
+  #|   fixture.firstRoot = firstRoot
+  #|   fixture.secondRoot = secondRoot
+  #|   const activeRoot = activeCalendar === 1
+  #|     ? firstRoot
+  #|     : activeCalendar === 2 ? secondRoot : null
+  #|   globalThis.document = {
+  #|     activeElement: activeRoot
+  #|       ? { closest: selector => selector === '[data-slot="calendar"]' ? activeRoot : null }
+  #|       : null,
+  #|     getElementById: id => id === firstRoot.id
+  #|       ? firstRoot
+  #|       : id === secondRoot.id ? secondRoot : null,
+  #|     querySelectorAll: selector => {
+  #|       const roots = selector === '[data-slot="calendar"]'
+  #|         ? [firstRoot, secondRoot]
+  #|         : []
+  #|       return { length: roots.length, item: index => roots[index] || null }
+  #|     },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_calendar_focus_fixture_result() -> Int =
+  #| () => globalThis.__ruiCalendarFocusFixture.focused
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_calendar_focus_fixture_tab_index(calendar : Int) -> Int =
+  #| calendar => calendar === 1
+  #|   ? globalThis.__ruiCalendarFocusFixture.firstDay.tabIndex
+  #|   : globalThis.__ruiCalendarFocusFixture.secondDay.tabIndex
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_disable_calendar_focus_fixture_day(calendar : Int) -> Unit =
+  #| calendar => {
+  #|   const fixture = globalThis.__ruiCalendarFocusFixture
+  #|   if (calendar === 1) fixture.firstDay.disabled = true
+  #|   else fixture.secondDay.disabled = true
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_calendar_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCalendarFocusFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiCalendarFocusFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "calendar focus uses the requested root id with duplicate dates" {
+  ffi_install_calendar_focus_fixture(0)
+  focus_calendar_day("calendar-second", "2041-11-03")
+  let focused = ffi_calendar_focus_fixture_result()
+  let first_tab_index = ffi_calendar_focus_fixture_tab_index(1)
+  let second_tab_index = ffi_calendar_focus_fixture_tab_index(2)
+  ffi_restore_calendar_focus_fixture()
+  assert_eq(focused, 2)
+  assert_eq(first_tab_index, -1)
+  assert_eq(second_tab_index, 0)
+}
+
+///|
+#cfg(target="js")
+test "calendar focus without an id refuses ambiguous fallback roots" {
+  ffi_install_calendar_focus_fixture(0)
+  focus_calendar_day("", "2041-11-03")
+  let focused = ffi_calendar_focus_fixture_result()
+  let first_tab_index = ffi_calendar_focus_fixture_tab_index(1)
+  let second_tab_index = ffi_calendar_focus_fixture_tab_index(2)
+  ffi_restore_calendar_focus_fixture()
+  assert_eq(focused, 0)
+  assert_eq(first_tab_index, -1)
+  assert_eq(second_tab_index, -1)
+}
+
+///|
+#cfg(target="js")
+test "calendar focus without an id uses a unique matching fallback root" {
+  ffi_install_calendar_focus_fixture(0)
+  ffi_disable_calendar_focus_fixture_day(1)
+  focus_calendar_day("", "2041-11-03")
+  let focused = ffi_calendar_focus_fixture_result()
+  let first_tab_index = ffi_calendar_focus_fixture_tab_index(1)
+  let second_tab_index = ffi_calendar_focus_fixture_tab_index(2)
+  ffi_restore_calendar_focus_fixture()
+  assert_eq(focused, 2)
+  assert_eq(first_tab_index, -1)
+  assert_eq(second_tab_index, 0)
+}
+
+///|
+#cfg(target="js")
+test "calendar focus without an id prefers the active calendar" {
+  ffi_install_calendar_focus_fixture(2)
+  focus_calendar_day("", "2041-11-03")
+  let focused = ffi_calendar_focus_fixture_result()
+  let first_tab_index = ffi_calendar_focus_fixture_tab_index(1)
+  let second_tab_index = ffi_calendar_focus_fixture_tab_index(2)
+  ffi_restore_calendar_focus_fixture()
+  assert_eq(focused, 2)
+  assert_eq(first_tab_index, -1)
+  assert_eq(second_tab_index, 0)
+}

--- a/rui/calendar_selection.mbt
+++ b/rui/calendar_selection.mbt
@@ -1,0 +1,649 @@
+///|
+priv struct CalendarRangeModel {
+  visible : CalendarDate
+  selected : DateRange?
+  focused : CalendarDate
+} derive(Eq)
+
+///|
+priv struct CalendarMultipleModel {
+  visible : CalendarDate
+  selected : Array[CalendarDate]
+  focused : CalendarDate
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum CalendarRangeMsg {
+  CalendarRangeNavigate(Int)
+  CalendarRangeChoose(CalendarDate)
+  CalendarRangeSetFocused(CalendarDate)
+  CalendarRangeMoveFocus(CalendarDate)
+}
+
+///|
+#cfg(target="js")
+priv enum CalendarMultipleMsg {
+  CalendarMultipleNavigate(Int)
+  CalendarMultipleChoose(CalendarDate)
+  CalendarMultipleSetFocused(CalendarDate)
+  CalendarMultipleMoveFocus(CalendarDate)
+}
+
+///|
+fn calendar_selection_mode_name(mode : CalendarSelectionMode) -> String {
+  match mode {
+    CalendarSingleSelection => "single"
+    CalendarRangeSelection => "range"
+    CalendarMultipleSelection => "multiple"
+  }
+}
+
+///|
+fn calendar_contains_date(
+  dates : Array[CalendarDate],
+  target : CalendarDate,
+) -> Bool {
+  for date in dates {
+    if date == target {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn calendar_normalize_dates(dates : Array[CalendarDate]) -> Array[CalendarDate] {
+  let normalized : Array[CalendarDate] = []
+  for date in dates {
+    if !calendar_contains_date(normalized, date) {
+      normalized.push(date)
+    }
+  }
+  normalized
+}
+
+///|
+fn calendar_multiple_next_value(
+  current : Array[CalendarDate],
+  chosen : CalendarDate,
+) -> Array[CalendarDate] {
+  let next : Array[CalendarDate] = []
+  let mut removed = false
+  for date in current {
+    if date == chosen {
+      removed = true
+    } else {
+      next.push(date)
+    }
+  }
+  if !removed {
+    next.push(chosen)
+  }
+  next
+}
+
+///|
+fn calendar_range_next_value(
+  current : DateRange?,
+  chosen : CalendarDate,
+) -> DateRange {
+  if current is Some(current) && current.end is None {
+    date_range(start=current.start, end=chosen)
+  } else {
+    date_range(start=chosen)
+  }
+}
+
+///|
+fn calendar_range_initial_model(
+  default_month : CalendarDate?,
+  default_selected : DateRange?,
+  today : CalendarDate?,
+) -> CalendarRangeModel {
+  let selected = default_selected.map(range => range.start)
+  let calendar = calendar_initial_model(default_month, selected, today)
+  {
+    visible: calendar.visible,
+    selected: default_selected,
+    focused: calendar.focused,
+  }
+}
+
+///|
+fn calendar_multiple_initial_model(
+  default_month : CalendarDate?,
+  default_selected : Array[CalendarDate],
+  today : CalendarDate?,
+) -> CalendarMultipleModel {
+  let selected = calendar_normalize_dates(default_selected)
+  let calendar = calendar_initial_model(default_month, selected.get(0), today)
+  { visible: calendar.visible, selected, focused: calendar.focused }
+}
+
+///|
+fn render_calendar_range_model(
+  model : CalendarRangeModel,
+  today : CalendarDate?,
+  show_outside_days : Bool,
+  disabled : Bool,
+  aria_label : String,
+  on_previous : @cmd.Cmd?,
+  on_next : @cmd.Cmd?,
+  on_select : @cmd.Emit[CalendarDate]?,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+  id : String?,
+  class : String?,
+  title : String?,
+  hidden : Bool?,
+  attrs : @html.Attrs?,
+  previous_attrs : @html.Attrs?,
+  next_attrs : @html.Attrs?,
+  grid_attrs : @html.Attrs?,
+  day_attrs : @html.Attrs?,
+  style : Array[String],
+  header_style : Array[String],
+  caption_style : Array[String],
+  nav_style : Array[String],
+  previous_style : Array[String],
+  next_style : Array[String],
+  grid_style : Array[String],
+  weekday_style : Array[String],
+  cell_style : Array[String],
+  day_style : Array[String],
+) -> @html.Html {
+  let range_start = model.selected.map(range => range.start)
+  let range_end = if model.selected is Some(range) { range.end } else { None }
+  render_calendar(
+    month=model.visible,
+    selection_mode=CalendarRangeSelection,
+    range_start?,
+    range_end?,
+    today?,
+    focused=model.focused,
+    show_outside_days~,
+    disabled~,
+    aria_label~,
+    on_previous?,
+    on_next?,
+    on_select?,
+    on_focus_change?,
+    on_focus_move?,
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs?,
+    previous_attrs?,
+    next_attrs?,
+    grid_attrs?,
+    day_attrs?,
+    style~,
+    header_style~,
+    caption_style~,
+    nav_style~,
+    previous_style~,
+    next_style~,
+    grid_style~,
+    weekday_style~,
+    cell_style~,
+    day_style~,
+  )
+}
+
+///|
+fn render_calendar_multiple_model(
+  model : CalendarMultipleModel,
+  today : CalendarDate?,
+  show_outside_days : Bool,
+  disabled : Bool,
+  aria_label : String,
+  on_previous : @cmd.Cmd?,
+  on_next : @cmd.Cmd?,
+  on_select : @cmd.Emit[CalendarDate]?,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+  id : String?,
+  class : String?,
+  title : String?,
+  hidden : Bool?,
+  attrs : @html.Attrs?,
+  previous_attrs : @html.Attrs?,
+  next_attrs : @html.Attrs?,
+  grid_attrs : @html.Attrs?,
+  day_attrs : @html.Attrs?,
+  style : Array[String],
+  header_style : Array[String],
+  caption_style : Array[String],
+  nav_style : Array[String],
+  previous_style : Array[String],
+  next_style : Array[String],
+  grid_style : Array[String],
+  weekday_style : Array[String],
+  cell_style : Array[String],
+  day_style : Array[String],
+) -> @html.Html {
+  render_calendar(
+    month=model.visible,
+    selection_mode=CalendarMultipleSelection,
+    selected_dates=model.selected,
+    today?,
+    focused=model.focused,
+    show_outside_days~,
+    disabled~,
+    aria_label~,
+    on_previous?,
+    on_next?,
+    on_select?,
+    on_focus_change?,
+    on_focus_move?,
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs?,
+    previous_attrs?,
+    next_attrs?,
+    grid_attrs?,
+    day_attrs?,
+    style~,
+    header_style~,
+    caption_style~,
+    nav_style~,
+    previous_style~,
+    next_style~,
+    grid_style~,
+    weekday_style~,
+    cell_style~,
+    day_style~,
+  )
+}
+
+///|
+#cfg(target="js")
+fn calendar_range_update(
+  root_id : String?,
+  on_select : @cmd.Emit[DateRange]?,
+  on_month_change : @cmd.Emit[CalendarDate]?,
+  today : CalendarDate?,
+  msg : CalendarRangeMsg,
+  model : CalendarRangeModel,
+) -> (CalendarRangeModel, @cmd.Cmd) {
+  match msg {
+    CalendarRangeNavigate(delta) => {
+      let visible = calendar_shift_month(model.visible, delta)
+      let selected = model.selected.map(range => range.start)
+      let focused = calendar_focus_target(visible, selected, today)
+      (
+        { ..model, visible, focused },
+        calendar_emit_command(on_month_change, visible),
+      )
+    }
+    CalendarRangeChoose(date) => {
+      let selected = calendar_range_next_value(model.selected, date)
+      let visible = calendar_first_of_month(date)
+      let commands : Array[@cmd.Cmd] = [
+        calendar_emit_command(on_select, selected),
+      ]
+      if visible != model.visible {
+        commands.push(calendar_emit_command(on_month_change, visible))
+      }
+      (
+        { visible, selected: Some(selected), focused: date },
+        @cmd.batch(commands),
+      )
+    }
+    CalendarRangeSetFocused(date) => ({ ..model, focused: date }, @cmd.none)
+    CalendarRangeMoveFocus(date) => {
+      let visible = calendar_first_of_month(date)
+      let commands : Array[@cmd.Cmd] = [calendar_focus_day_cmd(root_id, date)]
+      if visible != model.visible {
+        commands.push(calendar_emit_command(on_month_change, visible))
+      }
+      ({ ..model, visible, focused: date }, @cmd.batch(commands))
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn calendar_multiple_update(
+  root_id : String?,
+  on_select : @cmd.Emit[Array[CalendarDate]]?,
+  on_month_change : @cmd.Emit[CalendarDate]?,
+  today : CalendarDate?,
+  msg : CalendarMultipleMsg,
+  model : CalendarMultipleModel,
+) -> (CalendarMultipleModel, @cmd.Cmd) {
+  match msg {
+    CalendarMultipleNavigate(delta) => {
+      let visible = calendar_shift_month(model.visible, delta)
+      let focused = calendar_focus_target(visible, model.selected.get(0), today)
+      (
+        { ..model, visible, focused },
+        calendar_emit_command(on_month_change, visible),
+      )
+    }
+    CalendarMultipleChoose(date) => {
+      let selected = calendar_multiple_next_value(model.selected, date)
+      let visible = calendar_first_of_month(date)
+      let commands : Array[@cmd.Cmd] = [
+        calendar_emit_command(on_select, selected.copy()),
+      ]
+      if visible != model.visible {
+        commands.push(calendar_emit_command(on_month_change, visible))
+      }
+      ({ visible, selected, focused: date }, @cmd.batch(commands))
+    }
+    CalendarMultipleSetFocused(date) => ({ ..model, focused: date }, @cmd.none)
+    CalendarMultipleMoveFocus(date) => {
+      let visible = calendar_first_of_month(date)
+      let commands : Array[@cmd.Cmd] = [calendar_focus_day_cmd(root_id, date)]
+      if visible != model.visible {
+        commands.push(calendar_emit_command(on_month_change, visible))
+      }
+      ({ ..model, visible, focused: date }, @cmd.batch(commands))
+    }
+  }
+}
+
+///|
+/// Stateful range-selection Calendar. The first activation starts a range;
+/// the second normalizes and completes it. Activating again starts a new
+/// range. Every change is reported through `on_select`.
+#cfg(target="js")
+pub fn calendar_range(
+  default_month? : CalendarDate,
+  default_selected? : DateRange,
+  today? : CalendarDate,
+  show_outside_days? : Bool = true,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_select? : @cmd.Emit[DateRange],
+  on_month_change? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = calendar_range_initial_model(
+    default_month, default_selected, today,
+  )
+  let (model, emit) = @rabbita.create_state(initial, update=fn(_, msg, model) {
+    calendar_range_update(id, on_select, on_month_change, today, msg, model)
+  })
+  let select = emit.map(date => CalendarRangeChoose(date))
+  let set_focused = emit.map(date => CalendarRangeSetFocused(date))
+  let move_focus = emit.map(date => CalendarRangeMoveFocus(date))
+  model.view(model => {
+    render_calendar_range_model(
+      model,
+      today,
+      show_outside_days,
+      disabled,
+      aria_label,
+      Some(emit(CalendarRangeNavigate(-1))),
+      Some(emit(CalendarRangeNavigate(1))),
+      Some(select),
+      Some(set_focused),
+      Some(move_focus),
+      id,
+      class,
+      title,
+      hidden,
+      attrs,
+      previous_attrs,
+      next_attrs,
+      grid_attrs,
+      day_attrs,
+      style,
+      header_style,
+      caption_style,
+      nav_style,
+      previous_style,
+      next_style,
+      grid_style,
+      weekday_style,
+      cell_style,
+      day_style,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for [`calendar_range`].
+#cfg(not(target="js"))
+pub fn calendar_range(
+  default_month? : CalendarDate,
+  default_selected? : DateRange,
+  today? : CalendarDate,
+  show_outside_days? : Bool = true,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_select? : @cmd.Emit[DateRange],
+  on_month_change? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_select, on_month_change))
+  let model = calendar_range_initial_model(
+    default_month, default_selected, today,
+  )
+  let select : @cmd.Emit[CalendarDate] = Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_calendar_range_model(
+      model,
+      today,
+      show_outside_days,
+      disabled,
+      aria_label,
+      Some(@cmd.none),
+      Some(@cmd.none),
+      Some(select),
+      None,
+      None,
+      id,
+      class,
+      title,
+      hidden,
+      attrs,
+      previous_attrs,
+      next_attrs,
+      grid_attrs,
+      day_attrs,
+      style,
+      header_style,
+      caption_style,
+      nav_style,
+      previous_style,
+      next_style,
+      grid_style,
+      weekday_style,
+      cell_style,
+      day_style,
+    ),
+  )
+}
+
+///|
+/// Stateful multiple-selection Calendar. Activating a date toggles it while
+/// preserving all other selected dates. `on_select` receives a fresh array
+/// after every toggle, including the empty selection.
+#cfg(target="js")
+pub fn calendar_multiple(
+  default_month? : CalendarDate,
+  default_selected? : Array[CalendarDate] = [],
+  today? : CalendarDate,
+  show_outside_days? : Bool = true,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_select? : @cmd.Emit[Array[CalendarDate]],
+  on_month_change? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = calendar_multiple_initial_model(
+    default_month, default_selected, today,
+  )
+  let (model, emit) = @rabbita.create_state(initial, update=fn(_, msg, model) {
+    calendar_multiple_update(id, on_select, on_month_change, today, msg, model)
+  })
+  let select = emit.map(date => CalendarMultipleChoose(date))
+  let set_focused = emit.map(date => CalendarMultipleSetFocused(date))
+  let move_focus = emit.map(date => CalendarMultipleMoveFocus(date))
+  model.view(model => {
+    render_calendar_multiple_model(
+      model,
+      today,
+      show_outside_days,
+      disabled,
+      aria_label,
+      Some(emit(CalendarMultipleNavigate(-1))),
+      Some(emit(CalendarMultipleNavigate(1))),
+      Some(select),
+      Some(set_focused),
+      Some(move_focus),
+      id,
+      class,
+      title,
+      hidden,
+      attrs,
+      previous_attrs,
+      next_attrs,
+      grid_attrs,
+      day_attrs,
+      style,
+      header_style,
+      caption_style,
+      nav_style,
+      previous_style,
+      next_style,
+      grid_style,
+      weekday_style,
+      cell_style,
+      day_style,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for [`calendar_multiple`].
+#cfg(not(target="js"))
+pub fn calendar_multiple(
+  default_month? : CalendarDate,
+  default_selected? : Array[CalendarDate] = [],
+  today? : CalendarDate,
+  show_outside_days? : Bool = true,
+  disabled? : Bool = false,
+  aria_label? : String = "Calendar",
+  on_select? : @cmd.Emit[Array[CalendarDate]],
+  on_month_change? : @cmd.Emit[CalendarDate],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  previous_attrs? : @html.Attrs,
+  next_attrs? : @html.Attrs,
+  grid_attrs? : @html.Attrs,
+  day_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  header_style? : Array[String] = [],
+  caption_style? : Array[String] = [],
+  nav_style? : Array[String] = [],
+  previous_style? : Array[String] = [],
+  next_style? : Array[String] = [],
+  grid_style? : Array[String] = [],
+  weekday_style? : Array[String] = [],
+  cell_style? : Array[String] = [],
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_select, on_month_change))
+  let model = calendar_multiple_initial_model(
+    default_month, default_selected, today,
+  )
+  let select : @cmd.Emit[CalendarDate] = Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_calendar_multiple_model(
+      model,
+      today,
+      show_outside_days,
+      disabled,
+      aria_label,
+      Some(@cmd.none),
+      Some(@cmd.none),
+      Some(select),
+      None,
+      None,
+      id,
+      class,
+      title,
+      hidden,
+      attrs,
+      previous_attrs,
+      next_attrs,
+      grid_attrs,
+      day_attrs,
+      style,
+      header_style,
+      caption_style,
+      nav_style,
+      previous_style,
+      next_style,
+      grid_style,
+      weekday_style,
+      cell_style,
+      day_style,
+    ),
+  )
+}

--- a/rui/calendar_selection_test.mbt
+++ b/rui/calendar_selection_test.mbt
@@ -1,0 +1,144 @@
+///|
+#cfg(target="js")
+extern "js" fn install_calendar_selection_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_calendar_selection(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_calendar_selection_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_calendar_selection(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+test "range calendar renders a continuous range across outside days" {
+  let start = @rui.calendar_date(year=2026, month=7, day=31)
+  let end = @rui.calendar_date(year=2026, month=8, day=3)
+  let notify : @cmd.Emit[@rui.DateRange] = Emit(_ => @cmd.none)
+  let html = render_calendar_selection(() => {
+    @rui.calendar_range(
+      default_month=@rui.calendar_date(year=2026, month=8, day=1),
+      default_selected=@rui.date_range(start~, end~),
+      today=@rui.calendar_date(year=2026, month=8, day=2),
+      aria_label="Deployment window",
+      on_select=notify,
+      id="deployment-window",
+      cell_style=["--range-cell-test:1"],
+      day_style=["font-variant-numeric:tabular-nums"],
+    )
+  })
+  assert_contains(html, "data-slot=\"calendar\"")
+  assert_contains(html, "data-mode=\"range\"")
+  assert_contains(html, "aria-label=\"Deployment window\"")
+  assert_contains(html, "data-range-start=\"2026-07-31\"")
+  assert_contains(html, "data-range-end=\"2026-08-03\"")
+  assert_contains(html, "aria-multiselectable=\"true\"")
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-31\"", "data-range-start=\"\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-31\"", "data-outside-day=\"\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-08-01\"", "data-range-middle=\"\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-08-02\"", "aria-selected=\"true\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-08-02\"", "data-focused=\"\"",
+  )
+  assert_element_tag_contains(html, "data-day=\"2026-08-02\"", "tabindex=\"0\"")
+  assert_element_tag_contains(
+    html, "data-day=\"2026-08-03\"", "data-range-end=\"\"",
+  )
+  assert_contains(
+    html, "linear-gradient(var(--rui-calendar-range-start-direction,to right)",
+  )
+  assert_contains(
+    html, "linear-gradient(var(--rui-calendar-range-end-direction,to right)",
+  )
+  assert_contains(html, "--range-cell-test:1")
+  assert_contains(html, "font-variant-numeric:tabular-nums")
+  assert_not_contains(html, "data-selected-single=\"true\"")
+}
+
+///|
+test "multiple calendar normalizes defaults and marks every selected date" {
+  let first = @rui.calendar_date(year=2026, month=7, day=4)
+  let second = @rui.calendar_date(year=2026, month=7, day=16)
+  let outside = @rui.calendar_date(year=2026, month=6, day=30)
+  let notify : @cmd.Emit[Array[@rui.CalendarDate]] = Emit(_ => @cmd.none)
+  let html = render_calendar_selection(() => {
+    @rui.calendar_multiple(
+      default_month=@rui.calendar_date(year=2026, month=7, day=1),
+      default_selected=[first, second, first, outside],
+      today=second,
+      aria_label="Available dates",
+      on_select=notify,
+      id="available-dates",
+    )
+  })
+  assert_contains(html, "data-mode=\"multiple\"")
+  assert_contains(html, "data-selected-count=\"3\"")
+  assert_contains(html, "aria-multiselectable=\"true\"")
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-04\"", "data-selected-multiple=\"\"",
+  )
+  assert_element_tag_contains(html, "data-day=\"2026-07-04\"", "tabindex=\"0\"")
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-16\"", "aria-current=\"date\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-06-30\"", "data-outside-day=\"\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-06-30\"", "aria-selected=\"true\"",
+  )
+  assert_element_tag_contains(
+    html, "data-day=\"2026-07-05\"", "aria-selected=\"false\"",
+  )
+  assert_not_contains(html, "data-selected-single=\"true\"")
+  assert_not_contains(html, "data-range-middle=\"\"")
+}
+
+///|
+test "selection variants preserve disabled and hidden outside-day semantics" {
+  let html = render_calendar_selection(() => {
+    @rui.calendar_range(
+      default_month=@rui.calendar_date(year=2025, month=2, day=1),
+      default_selected=@rui.date_range(
+        start=@rui.calendar_date(year=2025, month=2, day=10),
+      ),
+      show_outside_days=false,
+      disabled=true,
+      aria_label="Unavailable range",
+    )
+  })
+  assert_contains(html, "data-mode=\"range\"")
+  assert_contains(html, "data-disabled=\"\"")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "visibility:hidden")
+  assert_contains(html, " disabled")
+  assert_not_contains(html, "data-day=\"2025-01-26\"")
+  assert_element_tag_contains(
+    html, "data-day=\"2025-02-10\"", "data-range-start=\"\"",
+  )
+}

--- a/rui/calendar_selection_wbtest.mbt
+++ b/rui/calendar_selection_wbtest.mbt
@@ -1,0 +1,165 @@
+///|
+test "range calendar selection starts, completes in order, then restarts" {
+  let later = calendar_date(year=2026, month=7, day=18)
+  let earlier = calendar_date(year=2026, month=7, day=10)
+  let started = calendar_range_next_value(None, later)
+  assert_eq(started.start, later)
+  assert_eq(started.end, None)
+
+  let completed = calendar_range_next_value(Some(started), earlier)
+  assert_eq(completed.start, earlier)
+  assert_eq(completed.end, Some(later))
+
+  let restart = calendar_date(year=2026, month=8, day=2)
+  let restarted = calendar_range_next_value(Some(completed), restart)
+  assert_eq(restarted.start, restart)
+  assert_eq(restarted.end, None)
+}
+
+///|
+test "multiple calendar defaults are copied, deduplicated, and toggle cleanly" {
+  let first = calendar_date(year=2026, month=7, day=4)
+  let second = calendar_date(year=2026, month=7, day=16)
+  let third = calendar_date(year=2026, month=8, day=1)
+  let requested = [first, second, first]
+  let initial = calendar_multiple_initial_model(None, requested, None)
+  requested.push(third)
+  assert_eq(initial.selected, [first, second])
+  assert_eq(initial.visible, calendar_date(year=2026, month=7, day=1))
+  assert_eq(initial.focused, first)
+
+  let removed = calendar_multiple_next_value(initial.selected, first)
+  assert_eq(removed, [second])
+  let added = calendar_multiple_next_value(removed, third)
+  assert_eq(added, [second, third])
+  let emptied = calendar_multiple_next_value(
+    calendar_multiple_next_value([], first),
+    first,
+  )
+  assert_eq(emptied, [])
+}
+
+///|
+#cfg(target="js")
+test "range calendar update owns partial and completed selection state" {
+  let later = calendar_date(year=2026, month=7, day=18)
+  let earlier = calendar_date(year=2026, month=7, day=10)
+  let initial = calendar_range_initial_model(
+    Some(calendar_date(year=2026, month=7, day=1)),
+    None,
+    None,
+  )
+  let (started, _) = calendar_range_update(
+    Some("release-window"),
+    None,
+    None,
+    None,
+    CalendarRangeChoose(later),
+    initial,
+  )
+  assert_eq(started.selected, Some(date_range(start=later)))
+  assert_eq(started.focused, later)
+
+  let (completed, _) = calendar_range_update(
+    Some("release-window"),
+    None,
+    None,
+    None,
+    CalendarRangeChoose(earlier),
+    started,
+  )
+  assert_eq(completed.selected, Some(date_range(start=earlier, end=later)))
+  assert_eq(completed.visible, calendar_date(year=2026, month=7, day=1))
+  assert_eq(completed.focused, earlier)
+}
+
+///|
+#cfg(target="js")
+test "multiple calendar update toggles and follows outside-month choices" {
+  let july = calendar_date(year=2026, month=7, day=1)
+  let outside = calendar_date(year=2026, month=8, day=2)
+  let initial = calendar_multiple_initial_model(Some(july), [], None)
+  let (selected, _) = calendar_multiple_update(
+    Some("available-dates"),
+    None,
+    None,
+    None,
+    CalendarMultipleChoose(outside),
+    initial,
+  )
+  assert_eq(selected.selected, [outside])
+  assert_eq(selected.visible, calendar_date(year=2026, month=8, day=1))
+  assert_eq(selected.focused, outside)
+
+  let (removed, _) = calendar_multiple_update(
+    Some("available-dates"),
+    None,
+    None,
+    None,
+    CalendarMultipleChoose(outside),
+    selected,
+  )
+  assert_eq(removed.selected, [])
+  assert_eq(removed.focused, outside)
+
+  let june = calendar_date(year=2026, month=6, day=30)
+  let (moved, _) = calendar_multiple_update(
+    Some("available-dates"),
+    None,
+    None,
+    None,
+    CalendarMultipleMoveFocus(june),
+    removed,
+  )
+  assert_eq(moved.visible, calendar_date(year=2026, month=6, day=1))
+  assert_eq(moved.focused, june)
+}
+
+///|
+#cfg(target="js")
+test "selection updates report new values and outside-month changes" {
+  let july = calendar_date(year=2026, month=7, day=1)
+  let outside = calendar_date(year=2026, month=8, day=2)
+  let range_seen : Ref[DateRange?] = Ref(None)
+  let month_seen : Ref[CalendarDate?] = Ref(None)
+  let range_notify : @cmd.Emit[DateRange] = Emit(value => {
+    range_seen.val = Some(value)
+    @cmd.none
+  })
+  let month_notify : @cmd.Emit[CalendarDate] = Emit(value => {
+    month_seen.val = Some(value)
+    @cmd.none
+  })
+  let range_initial = calendar_range_initial_model(Some(july), None, None)
+  let (range_next, _) = calendar_range_update(
+    None,
+    Some(range_notify),
+    Some(month_notify),
+    None,
+    CalendarRangeChoose(outside),
+    range_initial,
+  )
+  assert_eq(range_seen.val, range_next.selected)
+  assert_eq(month_seen.val, Some(calendar_date(year=2026, month=8, day=1)))
+
+  let multiple_seen : Ref[Array[CalendarDate]] = Ref([])
+  let multiple_notify : @cmd.Emit[Array[CalendarDate]] = Emit(values => {
+    multiple_seen.val = values
+    @cmd.none
+  })
+  let multiple_initial = calendar_multiple_initial_model(Some(july), [], None)
+  let (multiple_next, _) = calendar_multiple_update(
+    None,
+    Some(multiple_notify),
+    None,
+    None,
+    CalendarMultipleChoose(outside),
+    multiple_initial,
+  )
+  assert_eq(multiple_seen.val, [outside])
+  assert_eq(multiple_next.selected, [outside])
+
+  // The callback receives its own array, not the component's state storage.
+  multiple_seen.val.push(july)
+  assert_eq(multiple_next.selected, [outside])
+}

--- a/rui/card.mbt
+++ b/rui/card.mbt
@@ -1,0 +1,204 @@
+///|
+pub(all) enum CardSize {
+  Default
+  Sm
+} derive(Debug, Eq)
+
+///|
+const CardBaseStyle : String = "--rui-card-radius:calc(var(--rui-radius,0.625rem) + 0.125rem);display:flex;flex-direction:column;gap:var(--rui-card-spacing,1.5rem);border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-card-radius,0.75rem);background:var(--rui-card,oklch(1 0 0));padding-block:var(--rui-card-spacing,1.5rem);color:var(--rui-card-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem;box-shadow:0 1px 3px 0 rgb(0 0 0 / 0.1),0 1px 2px -1px rgb(0 0 0 / 0.1)"
+
+///|
+const CardDefaultSizeStyle : String = "--rui-card-spacing:1.5rem;--rui-card-title-size:1rem;--rui-card-title-line-height:1"
+
+///|
+const CardSmSizeStyle : String = "--rui-card-spacing:1rem;--rui-card-title-size:0.875rem;--rui-card-title-line-height:1.25rem"
+
+///|
+const CardHeaderStyle : String = "display:grid;grid-template-columns:var(--rui-card-header-columns,minmax(0,1fr));grid-template-rows:auto auto;align-items:start;column-gap:var(--rui-card-header-column-gap,0);row-gap:0.5rem;padding-inline:var(--rui-card-spacing,1.5rem);border-radius:var(--rui-card-radius,0.75rem) var(--rui-card-radius,0.75rem) 0 0"
+
+///|
+const CardTitleStyle : String = "grid-column:1;grid-row:1;min-width:0;font-size:var(--rui-card-title-size,1rem);line-height:var(--rui-card-title-line-height,1);font-weight:600;overflow-wrap:anywhere"
+
+///|
+const CardDescriptionStyle : String = "grid-column:1;grid-row:2;min-width:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem;overflow-wrap:anywhere"
+
+///|
+const CardActionStyle : String = "grid-column:2;grid-row:1 / span 2;align-self:start;justify-self:end"
+
+///|
+const CardContentStyle : String = "min-width:0;padding-inline:var(--rui-card-spacing,1.5rem)"
+
+///|
+const CardFooterStyle : String = "display:flex;align-items:center;padding-inline:var(--rui-card-spacing,1.5rem);border-radius:0 0 var(--rui-card-radius,0.875rem) var(--rui-card-radius,0.875rem)"
+
+///|
+fn card_size_style(size : CardSize) -> String {
+  match size {
+    Default => CardDefaultSizeStyle
+    Sm => CardSmSizeStyle
+  }
+}
+
+///|
+fn card_size_value(size : CardSize) -> String {
+  match size {
+    Default => "default"
+    Sm => "sm"
+  }
+}
+
+///|
+fn card_part_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+/// Render the root of a composable Vega card.
+///
+/// `--rui-card-spacing` is inherited by every card part. Appending a value through
+/// `style` changes the spacing of the complete composition without CSS setup.
+pub fn[C : @html.IsChildren] card(
+  size? : CardSize = Default,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = card_part_attrs(attrs, "card").data_set(
+    "size",
+    card_size_value(size),
+  )
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        CardBaseStyle,
+        card_size_style(size),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] card_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CardHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=card_part_attrs(attrs, "card-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] card_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CardTitleStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=card_part_attrs(attrs, "card-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] card_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CardDescriptionStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=card_part_attrs(attrs, "card-description"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] card_action(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CardActionStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=card_part_attrs(attrs, "card-action"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] card_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CardContentStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=card_part_attrs(attrs, "card-content"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] card_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CardFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=card_part_attrs(attrs, "card-footer"),
+    children,
+  )
+}

--- a/rui/carousel.mbt
+++ b/rui/carousel.mbt
@@ -1,0 +1,1629 @@
+///|
+pub(all) enum CarouselOrientation {
+  CarouselHorizontal
+  CarouselVertical
+} derive(Debug, Eq)
+
+///|
+/// Opaque state passed from `carousel` to its compound content, item, and
+/// previous/next controls.
+struct CarouselScope {
+  index : Int
+  count : Int
+  max_index : Int
+  loop_ : Bool
+  orientation : CarouselOrientation
+  emit : @cmd.Emit[Int]
+}
+
+///|
+#cfg(target="js")
+priv struct CarouselModel {
+  index : Int
+  max_index : Int
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum CarouselMsg {
+  CarouselSetIndex(Int)
+  CarouselMeasured(Int)
+}
+
+///|
+const CarouselRootStyle : String = "position:relative;display:block;width:100%;min-width:0;color:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const CarouselScopeStyle : String = "display:contents"
+
+///|
+const CarouselViewportStyle : String = "position:relative;width:100%;min-width:0;overflow:hidden;touch-action:var(--rui-carousel-touch-action,pan-y pinch-zoom);cursor:var(--rui-carousel-cursor,grab);user-select:var(--rui-carousel-user-select,auto);-webkit-user-select:var(--rui-carousel-user-select,auto)"
+
+///|
+const CarouselViewportVerticalStyle : String = "height:var(--rui-carousel-height,12rem);--rui-carousel-touch-action:pan-x pinch-zoom"
+
+///|
+const CarouselTrackStyle : String = "display:flex;min-width:0;will-change:transform;transition:var(--rui-carousel-track-transition,transform 300ms cubic-bezier(0.22,1,0.36,1))"
+
+///|
+const CarouselTrackHorizontalStyle : String = "flex-direction:row;margin-inline-start:-1rem"
+
+///|
+const CarouselTrackVerticalStyle : String = "height:100%;flex-direction:column;margin-top:-1rem"
+
+///|
+const CarouselItemStyle : String = "position:relative;min-width:0;flex-grow:0;flex-shrink:0;flex-basis:100%"
+
+///|
+const CarouselItemHorizontalStyle : String = "padding-inline-start:1rem"
+
+///|
+const CarouselItemVerticalStyle : String = "min-height:100%;padding-top:1rem"
+
+///|
+const CarouselControlStyle : String = "position:absolute;z-index:2;border-radius:9999px"
+
+///|
+const CarouselPreviousHorizontalStyle : String = "top:50%;inset-inline-start:var(--rui-carousel-control-inline-offset,-3rem);transform:translateY(-50%)"
+
+///|
+const CarouselNextHorizontalStyle : String = "top:50%;inset-inline-end:var(--rui-carousel-control-inline-offset,-3rem);transform:translateY(-50%)"
+
+///|
+const CarouselPreviousVerticalStyle : String = "top:var(--rui-carousel-control-block-offset,-3rem);left:50%;transform:translateX(-50%)"
+
+///|
+const CarouselNextVerticalStyle : String = "bottom:var(--rui-carousel-control-block-offset,-3rem);left:50%;transform:translateX(-50%)"
+
+///|
+const CarouselChevronBoxStyle : String = "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center"
+
+///|
+const CarouselChevronStyle : String = "display:block;width:0.5rem;height:0.5rem;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform-origin:center"
+
+///|
+const CarouselChevronLeftStyle : String = "transform:rotate(135deg)"
+
+///|
+const CarouselChevronRightStyle : String = "transform:rotate(-45deg)"
+
+///|
+const CarouselChevronUpStyle : String = "transform:rotate(225deg)"
+
+///|
+const CarouselChevronDownStyle : String = "transform:rotate(45deg)"
+
+///|
+const CarouselScreenReaderStyle : String = "position:absolute;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap"
+
+///|
+fn carousel_orientation_value(orientation : CarouselOrientation) -> String {
+  match orientation {
+    CarouselHorizontal => "horizontal"
+    CarouselVertical => "vertical"
+  }
+}
+
+///|
+fn carousel_count(count : Int) -> Int {
+  if count < 0 {
+    0
+  } else {
+    count
+  }
+}
+
+///|
+fn carousel_index(index : Int, count : Int) -> Int {
+  if count <= 0 || index < 0 {
+    0
+  } else if index >= count {
+    count - 1
+  } else {
+    index
+  }
+}
+
+///|
+fn carousel_previous_index(scope : CarouselScope) -> Int {
+  if scope.max_index <= 0 {
+    scope.index
+  } else if scope.index > 0 {
+    scope.index - 1
+  } else if scope.loop_ {
+    scope.max_index
+  } else {
+    scope.index
+  }
+}
+
+///|
+fn carousel_next_index(scope : CarouselScope) -> Int {
+  if scope.max_index <= 0 {
+    scope.index
+  } else if scope.index < scope.max_index {
+    scope.index + 1
+  } else if scope.loop_ {
+    0
+  } else {
+    scope.index
+  }
+}
+
+///|
+/// Return the active zero-based index from a compound carousel scope.
+pub fn carousel_active_index(scope : CarouselScope) -> Int {
+  scope.index
+}
+
+///|
+/// Return the normalized number of slides from a compound carousel scope.
+pub fn carousel_slide_count(scope : CarouselScope) -> Int {
+  scope.count
+}
+
+///|
+pub fn carousel_can_previous(scope : CarouselScope) -> Bool {
+  scope.max_index > 0 && (scope.loop_ || scope.index > 0)
+}
+
+///|
+pub fn carousel_can_next(scope : CarouselScope) -> Bool {
+  scope.max_index > 0 && (scope.loop_ || scope.index < scope.max_index)
+}
+
+///|
+fn carousel_track_transform(scope : CarouselScope) -> String {
+  let offset = scope.index * 100
+  match scope.orientation {
+    CarouselHorizontal =>
+      "--rui-carousel-ltr-offset:-\{offset}%;--rui-carousel-rtl-offset:\{offset}%;transform:translate3d(var(--rui-carousel-offset,var(--rui-carousel-ltr-offset)),0,0)"
+    CarouselVertical =>
+      "--rui-carousel-block-offset:-\{offset}%;transform:translate3d(0,var(--rui-carousel-offset,var(--rui-carousel-block-offset)),0)"
+  }
+}
+
+///|
+fn carousel_track_orientation_style(
+  orientation : CarouselOrientation,
+) -> String {
+  match orientation {
+    CarouselHorizontal => CarouselTrackHorizontalStyle
+    CarouselVertical => CarouselTrackVerticalStyle
+  }
+}
+
+///|
+fn carousel_viewport_orientation_style(
+  orientation : CarouselOrientation,
+) -> String {
+  match orientation {
+    CarouselHorizontal => ""
+    CarouselVertical => CarouselViewportVerticalStyle
+  }
+}
+
+///|
+fn carousel_item_orientation_style(orientation : CarouselOrientation) -> String {
+  match orientation {
+    CarouselHorizontal => CarouselItemHorizontalStyle
+    CarouselVertical => CarouselItemVerticalStyle
+  }
+}
+
+///|
+fn carousel_control_position_style(
+  orientation : CarouselOrientation,
+  previous : Bool,
+) -> String {
+  match (orientation, previous) {
+    (CarouselHorizontal, true) => CarouselPreviousHorizontalStyle
+    (CarouselHorizontal, false) => CarouselNextHorizontalStyle
+    (CarouselVertical, true) => CarouselPreviousVerticalStyle
+    (CarouselVertical, false) => CarouselNextVerticalStyle
+  }
+}
+
+///|
+fn carousel_control_chevron_style(
+  orientation : CarouselOrientation,
+  previous : Bool,
+) -> String {
+  match (orientation, previous) {
+    (CarouselHorizontal, true) => CarouselChevronLeftStyle
+    (CarouselHorizontal, false) => CarouselChevronRightStyle
+    (CarouselVertical, true) => CarouselChevronUpStyle
+    (CarouselVertical, false) => CarouselChevronDownStyle
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_key_step(event : @dom.KeyboardEvent, orientation : String) -> Int {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.shift_key() {
+    return 0
+  }
+  if event.target().to_element() is Some(target) &&
+    target.closest("input,textarea,select,[contenteditable=\"true\"]")
+    is Some(_) {
+    return 0
+  }
+  if orientation == "vertical" {
+    if event.key() == "ArrowUp" {
+      -1
+    } else if event.key() == "ArrowDown" {
+      1
+    } else {
+      0
+    }
+  } else {
+    let rtl = if event.current_target().to_option() is Some(current_target) &&
+      current_target.to_element() is Some(element) {
+      ui_element_is_rtl(element)
+    } else {
+      false
+    }
+    if event.key() == "ArrowLeft" {
+      if rtl {
+        1
+      } else {
+        -1
+      }
+    } else if event.key() == "ArrowRight" {
+      if rtl {
+        -1
+      } else {
+        1
+      }
+    } else {
+      0
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+let carousel_id_counter : Ref[Int] = Ref(0)
+
+///|
+#cfg(target="js")
+fn carousel_next_id() -> String {
+  carousel_id_counter.val += 1
+  "rui-carousel-\{carousel_id_counter.val}"
+}
+
+///|
+#cfg(target="js")
+priv struct CarouselLayoutState {
+  root : @dom.Element
+  mut viewport : @dom.Element
+  mut track : @dom.Element
+  mut items : Array[@dom.Element]
+  mut notify : (Int) -> Unit
+  mut previous_index : Int?
+  mut offset : Double?
+  mut reported_max : Int?
+  mut observer : @dom.ResizeObserver?
+  mut transition_generation : Int
+}
+
+///|
+#cfg(target="js")
+let carousel_layout_states : Array[CarouselLayoutState] = []
+
+///|
+#cfg(target="js")
+fn carousel_element_owned_by(
+  root : @dom.Element,
+  element : @dom.Element,
+) -> Bool {
+  element.closest("[data-slot=\"carousel\"]") is Some(owner) &&
+  owner.is_same_node(root.as_node())
+}
+
+///|
+#cfg(target="js")
+fn carousel_owned_elements(
+  root : @dom.Element,
+  selector : String,
+) -> Array[@dom.Element] {
+  root
+  .query_selector_all(selector)
+  .filter(element => carousel_element_owned_by(root, element))
+}
+
+///|
+#cfg(target="js")
+fn carousel_owned_element(
+  root : @dom.Element,
+  selector : String,
+) -> @dom.Element? {
+  carousel_owned_elements(root, selector).get(0)
+}
+
+///|
+#cfg(target="js")
+fn carousel_layout_state(root : @dom.Element) -> CarouselLayoutState? {
+  for state in carousel_layout_states {
+    if state.root.is_same_node(root.as_node()) {
+      return Some(state)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn carousel_remove_layout_state(root : @dom.Element) -> Unit {
+  for index, state in carousel_layout_states {
+    if state.root.is_same_node(root.as_node()) {
+      if state.observer is Some(observer) {
+        observer.disconnect()
+      }
+      ignore(carousel_layout_states.remove(index))
+      return
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_item_dimension(item : @dom.Element, vertical : Bool) -> Double {
+  let offset = if item.to_html_element() is Some(html) {
+    if vertical {
+      html.get_offset_height()
+    } else {
+      html.get_offset_width()
+    }
+  } else {
+    0.0
+  }
+  if offset > 0.0 {
+    offset
+  } else {
+    let rect = item.get_bounding_client_rect()
+    (if vertical { rect.get_height() } else { rect.get_width() }).max(0.0)
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_item_offset(item : @dom.Element, vertical : Bool) -> Double {
+  if item.to_html_element() is Some(html) {
+    if vertical {
+      html.get_offset_top()
+    } else {
+      html.get_offset_left()
+    }
+  } else {
+    0.0
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_restore_transition(
+  state : CarouselLayoutState,
+  generation : Int,
+  transition : String,
+) -> Unit {
+  if state.transition_generation != generation ||
+    state.track.to_html_element() is None {
+    return
+  }
+  guard state.track.to_html_element() is Some(track) else { return }
+  let style = track.get_style()
+  if transition == "" {
+    ignore(style.remove_property("transition"))
+  } else {
+    style.set_property("transition", transition)
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_set_control_state(control : @dom.Element, enabled : Bool) -> Unit {
+  control.set_attribute("aria-disabled", ui_bool(!enabled))
+  control.set_attribute(
+    "data-state",
+    if enabled {
+      "enabled"
+    } else {
+      "disabled"
+    },
+  )
+  if enabled {
+    control.remove_attribute("disabled")
+    control.remove_attribute("data-disabled")
+  } else {
+    control.set_attribute("disabled", "")
+    control.set_attribute("data-disabled", "")
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_sync_layout_state(
+  state : CarouselLayoutState,
+  suppress_initial : Bool,
+) -> Int {
+  if state.items.length() == 0 || state.track.to_html_element() is None {
+    return 0
+  }
+  guard state.track.to_html_element() is Some(track_html) else { return 0 }
+  let vertical = state.root.get_attribute("data-orientation").unwrap_or("") ==
+    "vertical"
+  let rtl = !vertical && ui_element_is_rtl(state.viewport)
+  let first = state.items[0]
+  let first_offset = carousel_item_offset(first, vertical)
+  let first_right = carousel_item_offset(first, false) +
+    carousel_item_dimension(first, false)
+  let starts : Array[Double] = []
+  let sizes : Array[Double] = []
+  for item in state.items {
+    let start = if vertical {
+      (carousel_item_offset(item, true) - first_offset).max(0.0)
+    } else if rtl {
+      (first_right -
+      (carousel_item_offset(item, false) + carousel_item_dimension(item, false))).max(
+        0.0,
+      )
+    } else {
+      (carousel_item_offset(item, false) - carousel_item_offset(first, false)).max(
+        0.0,
+      )
+    }
+    starts.push(start)
+    sizes.push(carousel_item_dimension(item, vertical))
+  }
+  let mut content_span = 0.0
+  for index, start in starts {
+    content_span = content_span.max(start + sizes[index])
+  }
+  let viewport_size = (if vertical {
+    state.viewport.get_client_height()
+  } else {
+    state.viewport.get_client_width()
+  }).max(0.0)
+  let max_travel = (content_span - viewport_size).max(0.0)
+  let mut max_index = 0
+  if max_travel > 0.5 {
+    max_index = state.items.length() - 1
+    for index, start in starts {
+      if start >= max_travel - 0.5 {
+        max_index = index
+        break
+      }
+    }
+  }
+  let requested = ui_parse_int_or(
+    state.root.get_attribute("data-active-index").unwrap_or(""),
+    0,
+  ).clamp(min=0, max=state.items.length() - 1)
+  let index = requested.min(max_index)
+  let travel = starts[index].clamp(min=0.0, max=max_travel)
+  let offset = if travel == 0.0 { 0.0 } else if rtl { travel } else { -travel }
+  let loop_ = state.root.get_attribute("data-loop").unwrap_or("") == "true"
+  let wrapped = if state.previous_index is Some(previous) {
+    loop_ &&
+    max_index > 0 &&
+    (
+      (previous == 0 && index == max_index) ||
+      (previous == max_index && index == 0)
+    )
+  } else {
+    false
+  }
+  if (suppress_initial && state.previous_index is None) || wrapped {
+    let style = track_html.get_style()
+    let transition = style.get_property_value("transition")
+    state.transition_generation += 1
+    let generation = state.transition_generation
+    style.set_property("transition", "none")
+    ignore(
+      @dom.window().request_animation_frame(_ => {
+        carousel_restore_transition(state, generation, transition)
+      }),
+    )
+  }
+  track_html.get_style().set_property("--rui-carousel-offset", "\{offset}px")
+  state.offset = Some(offset)
+  state.previous_index = Some(index)
+  state.root.set_attribute("data-max-snap-index", "\{max_index}")
+  for item_index, item in state.items {
+    let visible = sizes[item_index] > 0.0 &&
+      starts[item_index] + sizes[item_index] > travel + 0.5 &&
+      starts[item_index] < travel + viewport_size - 0.5
+    item.set_attribute("data-visible", ui_bool(visible))
+    if visible {
+      item.remove_attribute("aria-hidden")
+      item.remove_attribute("inert")
+    } else {
+      item.set_attribute("aria-hidden", "true")
+      item.set_attribute("inert", "")
+    }
+  }
+  if carousel_owned_element(state.root, "[data-slot=\"carousel-previous\"]")
+    is Some(previous) {
+    carousel_set_control_state(previous, max_index > 0 && (loop_ || index > 0))
+  }
+  if carousel_owned_element(state.root, "[data-slot=\"carousel-next\"]")
+    is Some(next) {
+    carousel_set_control_state(
+      next,
+      max_index > 0 && (loop_ || index < max_index),
+    )
+  }
+  max_index
+}
+
+///|
+#cfg(target="js")
+fn carousel_report_layout(state : CarouselLayoutState, max_index : Int) -> Unit {
+  if state.reported_max != Some(max_index) {
+    state.reported_max = Some(max_index)
+    (state.notify)(max_index)
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_layout_targets_changed(
+  state : CarouselLayoutState,
+  viewport : @dom.Element,
+  track : @dom.Element,
+  items : Array[@dom.Element],
+) -> Bool {
+  if !state.viewport.is_same_node(viewport.as_node()) ||
+    !state.track.is_same_node(track.as_node()) ||
+    state.items.length() != items.length() {
+    return true
+  }
+  for index, item in items {
+    if !state.items[index].is_same_node(item.as_node()) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+#cfg(target="js")
+fn carousel_observe_layout(state : CarouselLayoutState) -> Unit {
+  if state.observer is None {
+    state.observer = Some(
+      @dom.ResizeObserver::new((_, _) => {
+        if !state.root.get_is_connected() {
+          carousel_remove_layout_state(state.root)
+        } else {
+          carousel_report_layout(
+            state,
+            carousel_sync_layout_state(state, false),
+          )
+        }
+      }),
+    )
+  }
+  if state.observer is Some(observer) {
+    observer.observe(state.viewport)
+    observer.observe(state.track)
+    for item in state.items {
+      observer.observe(item)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_layout_offset(track : @dom.Element) -> Double? {
+  for state in carousel_layout_states {
+    if state.track.is_same_node(track.as_node()) {
+      return state.offset
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn carousel_sync_layout(id : String, notify : (Int) -> Unit) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  guard root.get_attribute("data-slot").unwrap_or("") == "carousel" else {
+    return
+  }
+  guard carousel_owned_element(root, "[data-slot=\"carousel-content\"]")
+    is Some(viewport) else {
+    return
+  }
+  guard carousel_owned_element(root, "[data-slot=\"carousel-track\"]")
+    is Some(track) else {
+    return
+  }
+  let items = carousel_owned_elements(root, "[data-slot=\"carousel-item\"]")
+  if items.length() == 0 {
+    return
+  }
+  let state = if carousel_layout_state(root) is Some(state) {
+    if carousel_layout_targets_changed(state, viewport, track, items) &&
+      state.observer is Some(observer) {
+      observer.disconnect()
+      state.observer = None
+    }
+    state.viewport = viewport
+    state.track = track
+    state.items = items
+    state.notify = notify
+    state
+  } else {
+    let state : CarouselLayoutState = {
+      root,
+      viewport,
+      track,
+      items,
+      notify,
+      previous_index: None,
+      offset: None,
+      reported_max: None,
+      observer: None,
+      transition_generation: 0,
+    }
+    carousel_layout_states.push(state)
+    state
+  }
+  carousel_report_layout(state, carousel_sync_layout_state(state, true))
+  carousel_observe_layout(state)
+}
+
+///|
+#cfg(target="js")
+fn carousel_sync_layout_cmd(
+  id : String,
+  emit : @cmd.Emit[CarouselMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        carousel_sync_layout(id, max_index => {
+          scheduler.add(emit(CarouselMeasured(max_index)))
+        })
+      },
+      purpose="carousel-layout",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+priv struct CarouselPointerState {
+  viewport : @dom.Element
+  track : @dom.Element
+  pointer_id : Int
+  horizontal : Bool
+  rtl : Bool
+  can_previous : Bool
+  can_next : Bool
+  resist_previous : Bool
+  resist_next : Bool
+  start_x : Int
+  start_y : Int
+  start_time : Double
+  size : Double
+  base_offset : Double?
+  base_percent : Double
+  mut active : Bool
+  original_transform : String
+  original_transition : String
+  original_cursor : String
+  original_user_select : String
+  mut suppress_click : @dom.Listener?
+}
+
+///|
+#cfg(target="js")
+let carousel_pointer_states : Array[CarouselPointerState] = []
+
+///|
+#cfg(target="js")
+fn carousel_pointer_state(viewport : @dom.Element) -> CarouselPointerState? {
+  for state in carousel_pointer_states {
+    if state.viewport.is_same_node(viewport.as_node()) {
+      return Some(state)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn carousel_remove_pointer_state(viewport : @dom.Element) -> Unit {
+  for index, state in carousel_pointer_states {
+    if state.viewport.is_same_node(viewport.as_node()) {
+      ignore(carousel_pointer_states.remove(index))
+      return
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_restore_style_property(
+  style : @dom.CSSStyleDeclaration,
+  name : String,
+  value : String,
+) -> Unit {
+  if value == "" {
+    ignore(style.remove_property(name))
+  } else {
+    style.set_property(name, value)
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_remove_click_suppression(state : CarouselPointerState) -> Unit {
+  if state.suppress_click is Some(listener) {
+    state.viewport.remove_event_listener_with_options(
+      "click",
+      listener,
+      capture=true,
+    )
+    state.suppress_click = None
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_install_click_suppression(state : CarouselPointerState) -> Unit {
+  if state.suppress_click is Some(_) {
+    return
+  }
+  let listener : @dom.Listener = click => {
+    click.prevent_default()
+    click.stop_propagation()
+    carousel_remove_click_suppression(state)
+  }
+  state.suppress_click = Some(listener)
+  state.viewport.add_event_listener_with_options(
+    "click",
+    listener,
+    capture=true,
+  )
+}
+
+///|
+#cfg(target="js")
+fn carousel_release_pointer_state(
+  state : CarouselPointerState,
+  keep_click_suppression : Bool,
+) -> Unit {
+  if state.track.to_html_element() is Some(track) {
+    let style = track.get_style()
+    carousel_restore_style_property(
+      style,
+      "transform",
+      state.original_transform,
+    )
+    carousel_restore_style_property(
+      style,
+      "transition",
+      state.original_transition,
+    )
+  }
+  if state.viewport.to_html_element() is Some(viewport) {
+    let style = viewport.get_style()
+    carousel_restore_style_property(
+      style,
+      "--rui-carousel-cursor",
+      state.original_cursor,
+    )
+    carousel_restore_style_property(
+      style,
+      "--rui-carousel-user-select",
+      state.original_user_select,
+    )
+  }
+  state.viewport.remove_attribute("data-dragging")
+  if state.viewport.has_pointer_capture(state.pointer_id) {
+    state.viewport.release_pointer_capture(state.pointer_id)
+  }
+  carousel_remove_pointer_state(state.viewport)
+  if keep_click_suppression && state.suppress_click is Some(_) {
+    ignore(
+      @dom.window().set_timeout(
+        () => carousel_remove_click_suppression(state),
+        0,
+      ),
+    )
+  } else {
+    carousel_remove_click_suppression(state)
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_pointer_start(
+  event : @dom.MouseEvent,
+  orientation : String,
+  index : Int,
+  can_previous : Bool,
+  can_next : Bool,
+) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  if pointer.get_default_prevented() ||
+    !pointer.get_is_primary() ||
+    (pointer.get_pointer_type() == "mouse" && pointer.get_button() != 0) ||
+    (!can_previous && !can_next) {
+    return false
+  }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(viewport) else { return false }
+  guard viewport.to_html_element() is Some(viewport_html) else { return false }
+  guard viewport.query_selector("[data-slot=\"carousel-track\"]") is Some(track) else {
+    return false
+  }
+  guard track.to_html_element() is Some(track_html) else { return false }
+  if pointer.target().to_element() is Some(target) &&
+    target.closest("input,textarea,select,[contenteditable=\"true\"]")
+    is Some(_) {
+    return false
+  }
+  if carousel_pointer_state(viewport) is Some(previous) {
+    carousel_release_pointer_state(previous, false)
+  }
+  let horizontal = orientation == "horizontal"
+  let rtl = horizontal && ui_element_is_rtl(viewport)
+  let root = viewport.closest("[data-slot=\"carousel\"]")
+  let max_index = if root is Some(root) {
+    ui_parse_int_or(
+      root.get_attribute("data-max-snap-index").unwrap_or(""),
+      (ui_parse_int_or(root.get_attribute("data-count").unwrap_or(""), 1) - 1).max(
+        0,
+      ),
+    )
+  } else {
+    0
+  }
+  let loop_ = root is Some(root) &&
+    root.get_attribute("data-loop").unwrap_or("") == "true"
+  let track_style = track_html.get_style()
+  let viewport_style = viewport_html.get_style()
+  let state : CarouselPointerState = {
+    viewport,
+    track,
+    pointer_id: pointer.get_pointer_id(),
+    horizontal,
+    rtl,
+    can_previous,
+    can_next,
+    resist_previous: loop_ && index <= 0,
+    resist_next: loop_ && index >= max_index,
+    start_x: pointer.get_client_x(),
+    start_y: pointer.get_client_y(),
+    start_time: pointer.get_time_stamp(),
+    size: if horizontal {
+      viewport.get_client_width()
+    } else {
+      viewport.get_client_height()
+    },
+    base_offset: carousel_layout_offset(track),
+    base_percent: (index * 100 * (if horizontal && rtl { 1 } else { -1 })).to_double(),
+    active: false,
+    original_transform: track_style.get_property_value("transform"),
+    original_transition: track_style.get_property_value("transition"),
+    original_cursor: viewport_style.get_property_value("--rui-carousel-cursor"),
+    original_user_select: viewport_style.get_property_value(
+      "--rui-carousel-user-select",
+    ),
+    suppress_click: None,
+  }
+  carousel_pointer_states.push(state)
+  viewport.set_pointer_capture(state.pointer_id)
+  true
+}
+
+///|
+#cfg(target="js")
+fn carousel_pointer_move(event : @dom.MouseEvent) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(viewport) else { return false }
+  guard carousel_pointer_state(viewport) is Some(state) else { return false }
+  guard state.pointer_id == pointer.get_pointer_id() else { return false }
+  guard viewport.to_html_element() is Some(viewport_html) else { return false }
+  guard state.track.to_html_element() is Some(track_html) else {
+    carousel_release_pointer_state(state, false)
+    return false
+  }
+  let primary = if state.horizontal {
+    pointer.get_client_x() - state.start_x
+  } else {
+    pointer.get_client_y() - state.start_y
+  }
+  let cross = if state.horizontal {
+    pointer.get_client_y() - state.start_y
+  } else {
+    pointer.get_client_x() - state.start_x
+  }
+  if !state.active {
+    if primary.abs() < 6 || primary.abs() <= cross.abs() {
+      return false
+    }
+    state.active = true
+    carousel_install_click_suppression(state)
+    viewport.set_attribute("data-dragging", "true")
+    viewport_html.get_style().set_property("--rui-carousel-cursor", "grabbing")
+    viewport_html.get_style().set_property("--rui-carousel-user-select", "none")
+  }
+  let toward_next = if state.horizontal {
+    if state.rtl {
+      primary > 0
+    } else {
+      primary < 0
+    }
+  } else {
+    primary < 0
+  }
+  let blocked = if toward_next {
+    !state.can_next || state.resist_next
+  } else {
+    !state.can_previous || state.resist_previous
+  }
+  let visual = if blocked {
+    primary.to_double() * 0.35
+  } else {
+    primary.to_double()
+  }
+  let base = if state.base_offset is Some(offset) {
+    "\{offset}px"
+  } else {
+    "\{state.base_percent}%"
+  }
+  let transform = if state.horizontal {
+    "translate3d(calc(\{base} + \{visual}px),0,0)"
+  } else {
+    "translate3d(0,calc(\{base} + \{visual}px),0)"
+  }
+  let track_style = track_html.get_style()
+  track_style.set_property("transition", "none")
+  track_style.set_property("transform", transform)
+  true
+}
+
+///|
+#cfg(target="js")
+fn carousel_pointer_end(event : @dom.MouseEvent) -> Int {
+  guard event.to_pointer_event() is Some(pointer) else { return 0 }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return 0
+  }
+  guard current_target.to_element() is Some(viewport) else { return 0 }
+  guard carousel_pointer_state(viewport) is Some(state) else { return 0 }
+  guard state.pointer_id == pointer.get_pointer_id() else { return 0 }
+  let primary = if state.horizontal {
+    pointer.get_client_x() - state.start_x
+  } else {
+    pointer.get_client_y() - state.start_y
+  }
+  let elapsed = (pointer.get_time_stamp() - state.start_time).max(1.0)
+  let threshold = (state.size * 0.12).max(24.0).min(64.0)
+  let qualifies = state.active &&
+    (
+      primary.abs().to_double() >= threshold ||
+      (primary.abs() >= 12 && primary.abs().to_double() / elapsed >= 0.45)
+    )
+  let toward_next = if state.horizontal {
+    if state.rtl {
+      primary > 0
+    } else {
+      primary < 0
+    }
+  } else {
+    primary < 0
+  }
+  let mut step = if qualifies { if toward_next { 1 } else { -1 } } else { 0 }
+  if (step > 0 && !state.can_next) || (step < 0 && !state.can_previous) {
+    step = 0
+  }
+  let dragged = state.active
+  carousel_release_pointer_state(state, dragged)
+  if step != 0 {
+    step
+  } else if dragged {
+    2
+  } else {
+    0
+  }
+}
+
+///|
+#cfg(target="js")
+fn carousel_pointer_cancel(event : @dom.MouseEvent) -> Unit {
+  guard event.to_pointer_event() is Some(pointer) else { return }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return
+  }
+  guard current_target.to_element() is Some(viewport) else { return }
+  guard carousel_pointer_state(viewport) is Some(state) else { return }
+  guard state.pointer_id == pointer.get_pointer_id() else { return }
+  carousel_release_pointer_state(state, false)
+}
+
+///|
+#cfg(target="js")
+fn carousel_bind_pointer_attrs(
+  attrs : @html.Attrs,
+  scope : CarouselScope,
+) -> Unit {
+  ignore(
+    attrs
+    .on_pointerdown(event => {
+      ignore(
+        carousel_pointer_start(
+          event,
+          carousel_orientation_value(scope.orientation),
+          scope.index,
+          carousel_can_previous(scope),
+          carousel_can_next(scope),
+        ),
+      )
+      @cmd.none
+    })
+    .on_pointermove(event => {
+      if carousel_pointer_move(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    })
+    .on_pointerup(event => {
+      let result = carousel_pointer_end(event)
+      if result != 0 {
+        event.prevent_default()
+      }
+      if result == -1 {
+        (scope.emit)(carousel_previous_index(scope))
+      } else if result == 1 {
+        (scope.emit)(carousel_next_index(scope))
+      } else {
+        @cmd.none
+      }
+    })
+    .on_pointercancel(event => {
+      carousel_pointer_cancel(event)
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn carousel_bind_pointer_attrs(
+  attrs : @html.Attrs,
+  scope : CarouselScope,
+) -> Unit {
+  ignore((attrs, scope))
+}
+
+///|
+#cfg(target="js")
+fn carousel_keyboard_attrs(scope : CarouselScope) -> @html.Attrs {
+  let attrs = @html.Attrs::build().data_set("slot", "carousel-scope")
+  ignore(
+    attrs.on_keydown(event => {
+      let step = carousel_key_step(
+        event,
+        carousel_orientation_value(scope.orientation),
+      )
+      if step < 0 && carousel_can_previous(scope) {
+        event.prevent_default()
+        (scope.emit)(carousel_previous_index(scope))
+      } else if step > 0 && carousel_can_next(scope) {
+        event.prevent_default()
+        (scope.emit)(carousel_next_index(scope))
+      } else {
+        @cmd.none
+      }
+    }),
+  )
+  attrs
+}
+
+///|
+#cfg(not(target="js"))
+fn carousel_keyboard_attrs(scope : CarouselScope) -> @html.Attrs {
+  ignore(scope)
+  @html.Attrs::build().data_set("slot", "carousel-scope")
+}
+
+///|
+fn carousel_status(scope : CarouselScope) -> @html.Html {
+  let text = if scope.count == 0 {
+    "No slides"
+  } else {
+    "Slide \{scope.index + 1} of \{scope.count}"
+  }
+  @html.span(
+    style=[UiBoxSizing, CarouselScreenReaderStyle],
+    attrs=@html.Attrs::build()
+      .data_set("slot", "carousel-status")
+      .aria_live("polite")
+      .aria_atomic("true"),
+    text,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] render_carousel(
+  scope : CarouselScope,
+  aria_label : String?,
+  id : String?,
+  class : String?,
+  title : String?,
+  hidden : Bool?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (CarouselScope) -> C,
+) -> @html.Html {
+  let root_attrs = ui_attrs(attrs)
+    .data_set("slot", "carousel")
+    .data_set("orientation", carousel_orientation_value(scope.orientation))
+    .data_set("active-index", scope.index.to_string())
+    .data_set("count", scope.count.to_string())
+    .data_set("max-snap-index", scope.max_index.to_string())
+    .data_set("loop", ui_bool(scope.loop_))
+    .role("region")
+    .aria_roledescription("carousel")
+    .aria_orientation(carousel_orientation_value(scope.orientation))
+  if aria_label is Some(label) {
+    ignore(root_attrs.aria_label(label))
+  }
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, CarouselRootStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=root_attrs,
+    [
+      @html.div(
+        style=[UiBoxSizing, CarouselScopeStyle],
+        attrs=carousel_keyboard_attrs(scope),
+        children(scope),
+      ),
+      carousel_status(scope),
+    ],
+  )
+}
+
+///|
+/// Render the clipping viewport and translated slide track for a scope.
+///
+/// Component props style the viewport; `track_attrs` and `track_style` target
+/// the moving flex track. All caller attribute values are cloned.
+pub fn[C : @html.IsChildren] carousel_content(
+  scope~ : CarouselScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  track_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  track_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let orientation = carousel_orientation_value(scope.orientation)
+  let viewport_attrs = ui_attrs(attrs)
+    .data_set("slot", "carousel-content")
+    .data_set("orientation", orientation)
+    .data_set("swipe", "true")
+  carousel_bind_pointer_attrs(viewport_attrs, scope)
+  let moving_attrs = ui_attrs(track_attrs)
+    .data_set("slot", "carousel-track")
+    .data_set("orientation", orientation)
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        CarouselViewportStyle,
+        carousel_viewport_orientation_style(scope.orientation),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=viewport_attrs,
+    @html.div(
+      style=ui_styles(
+        [
+          UiBoxSizing,
+          CarouselTrackStyle,
+          carousel_track_orientation_style(scope.orientation),
+          carousel_track_transform(scope),
+        ],
+        track_style,
+      ),
+      attrs=moving_attrs,
+      children,
+    ),
+  )
+}
+
+///|
+/// Render one semantic carousel slide.
+///
+/// Mounted stateful carousels measure the viewport and make only truly clipped
+/// slides inert. Static/controlled markup stays conservative because active
+/// index alone cannot determine visibility when callers customize item sizes.
+pub fn[C : @html.IsChildren] carousel_item(
+  scope~ : CarouselScope,
+  index~ : Int,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let active = index == scope.index && index >= 0 && index < scope.count
+  let label = aria_label.unwrap_or("Slide \{index + 1} of \{scope.count}")
+  let item_attrs = ui_attrs(attrs)
+    .data_set("slot", "carousel-item")
+    .data_set("orientation", carousel_orientation_value(scope.orientation))
+    .data_set("index", index.to_string())
+    .data_set("state", if active { "active" } else { "inactive" })
+    .data_set("active", ui_bool(active))
+    .role("group")
+    .aria_roledescription("slide")
+    .aria_label(label)
+    .aria_posinset((index + 1).to_string())
+    .aria_setsize(scope.count.to_string())
+  if active {
+    ignore(item_attrs.aria_current("true"))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        CarouselItemStyle,
+        carousel_item_orientation_style(scope.orientation),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=item_attrs,
+    children,
+  )
+}
+
+///|
+/// Convenience composition for an array of already-built slide bodies.
+pub fn carousel_items(
+  scope~ : CarouselScope,
+  items~ : Array[@html.Html],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  track_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  track_style? : Array[String] = [],
+  item_style? : Array[String] = [],
+) -> @html.Html {
+  let slides : Array[@html.Html] = []
+  for index, item in items {
+    slides.push(carousel_item(scope~, index~, style=item_style, item))
+  }
+  carousel_content(
+    scope~,
+    id?,
+    class?,
+    title?,
+    attrs?,
+    track_attrs?,
+    style~,
+    track_style~,
+    slides,
+  )
+}
+
+///|
+fn carousel_control(
+  scope : CarouselScope,
+  previous : Bool,
+  disabled : Bool,
+  aria_label : String,
+  id : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let can_move = if previous {
+    carousel_can_previous(scope)
+  } else {
+    carousel_can_next(scope)
+  }
+  let disabled = disabled || !can_move
+  let direction = if previous { "previous" } else { "next" }
+  let target = if previous {
+    carousel_previous_index(scope)
+  } else {
+    carousel_next_index(scope)
+  }
+  let control_attrs = ui_attrs(attrs)
+    .data_set("slot", "carousel-\{direction}")
+    .data_set("direction", direction)
+    .data_set("state", if disabled { "disabled" } else { "enabled" })
+    .data_set("variant", button_variant_value(Outline))
+    .data_set("size", button_size_value(IconSm))
+    .aria_label(aria_label)
+    .aria_disabled(ui_bool(disabled))
+  if disabled {
+    ignore(control_attrs.data_set("disabled", ""))
+  } else {
+    ignore(control_attrs.on_click(_ => (scope.emit)(target)))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        ButtonOutlineStyle,
+        ButtonSizeIconSmStyle,
+        CarouselControlStyle,
+        carousel_control_position_style(scope.orientation, previous),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=control_attrs,
+    @html.span(
+      style=[UiBoxSizing, CarouselChevronBoxStyle],
+      attrs=@html.Attrs::build()
+        .aria_hidden("true")
+        .data_set("icon", if previous { "previous" } else { "next" }),
+      @html.span(
+        style=[
+          UiBoxSizing,
+          CarouselChevronStyle,
+          carousel_control_chevron_style(scope.orientation, previous),
+        ],
+        @html.nothing,
+      ),
+    ),
+  )
+}
+
+///|
+/// Render the previous control bound to a carousel scope.
+pub fn carousel_previous(
+  scope~ : CarouselScope,
+  disabled? : Bool = false,
+  aria_label? : String = "Previous slide",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  carousel_control(
+    scope, true, disabled, aria_label, id, class, title, attrs, style,
+  )
+}
+
+///|
+/// Render the next control bound to a carousel scope.
+pub fn carousel_next(
+  scope~ : CarouselScope,
+  disabled? : Bool = false,
+  aria_label? : String = "Next slide",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  carousel_control(
+    scope, false, disabled, aria_label, id, class, title, attrs, style,
+  )
+}
+
+///|
+/// Render one indexed Carousel state for the native incremental fallback.
+///
+/// This synchronous primitive uses the 100% slide fallback encoded in the
+/// track. Use stateful `carousel` for automatic measured snapping when public
+/// `track_style`/item styles introduce gaps or non-default flex bases; callers
+/// that own DOM measurement may also set `--rui-carousel-offset` themselves.
+#cfg(not(target="js"))
+fn[C : @html.IsChildren] render_carousel_index(
+  index~ : Int,
+  count~ : Int,
+  loop_? : Bool = false,
+  orientation? : CarouselOrientation = CarouselHorizontal,
+  aria_label? : String,
+  on_index_change? : @cmd.Emit[Int],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (CarouselScope) -> C,
+) -> @html.Html {
+  let count = carousel_count(count)
+  let index = carousel_index(index, count)
+  let max_index = carousel_index(count - 1, count)
+  let emit = on_index_change.unwrap_or(Emit(_ => @cmd.none))
+  render_carousel(
+    { index, count, max_index, loop_, orientation, emit },
+    aria_label,
+    id,
+    class,
+    title,
+    hidden,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+/// Stateful carousel root. The active slide is component-local; the scope
+/// binds content, items, previous/next buttons, and orientation-aware arrow
+/// keys without Embla or another runtime dependency.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] carousel(
+  count~ : Int,
+  default_index? : Int = 0,
+  loop_? : Bool = false,
+  orientation? : CarouselOrientation = CarouselHorizontal,
+  aria_label? : String,
+  on_index_change? : @cmd.Emit[Int],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (CarouselScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let count = carousel_count(count)
+  let initial = carousel_index(default_index, count)
+  let root_id = id.unwrap_or(carousel_next_id())
+  let initial_max = carousel_index(count - 1, count)
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=fn(emit) {
+      (
+        { index: initial, max_index: initial_max },
+        carousel_sync_layout_cmd(root_id, emit),
+      )
+    },
+    update=fn(emit, message, current) {
+      match message {
+        CarouselSetIndex(requested) => {
+          let next = carousel_index(requested, count).clamp(
+            min=0,
+            max=current.max_index,
+          )
+          let notify = if on_index_change is Some(callback) {
+            callback(next)
+          } else {
+            @cmd.none
+          }
+          (
+            { ..current, index: next },
+            @cmd.batch([notify, carousel_sync_layout_cmd(root_id, emit)]),
+          )
+        }
+        CarouselMeasured(measured) => {
+          let max_index = carousel_index(measured, count)
+          let index = current.index.clamp(min=0, max=max_index)
+          if max_index == current.max_index && index == current.index {
+            (current, @cmd.none)
+          } else {
+            let notify = if index != current.index &&
+              on_index_change is Some(callback) {
+              callback(index)
+            } else {
+              @cmd.none
+            }
+            (
+              { index, max_index },
+              @cmd.batch([notify, carousel_sync_layout_cmd(root_id, emit)]),
+            )
+          }
+        }
+      }
+    },
+  )
+  model.view(model => {
+    let set_index = emit.map(index => CarouselSetIndex(index))
+    render_carousel(
+      {
+        index: model.index,
+        count,
+        max_index: model.max_index,
+        loop_,
+        orientation,
+        emit: set_index,
+      },
+      aria_label,
+      Some(root_id),
+      class,
+      title,
+      hidden,
+      attrs,
+      style,
+      children,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for `carousel`; renders the requested initial scope as
+/// a constant incremental value.
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] carousel(
+  count~ : Int,
+  default_index? : Int = 0,
+  loop_? : Bool = false,
+  orientation? : CarouselOrientation = CarouselHorizontal,
+  aria_label? : String,
+  on_index_change? : @cmd.Emit[Int],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (CarouselScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_index_change)
+  let count = carousel_count(count)
+  let index = carousel_index(default_index, count)
+  let emit = @cmd.Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_carousel_index(
+      index~,
+      count~,
+      loop_~,
+      orientation~,
+      aria_label?,
+      on_index_change=emit,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      style~,
+      children,
+    ),
+  )
+}

--- a/rui/carousel_layout_wbtest.mbt
+++ b/rui/carousel_layout_wbtest.mbt
@@ -1,0 +1,323 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_carousel_layout_fixture(
+  orientation : String,
+  rtl : Bool,
+  active : Int,
+  loop_ : Bool,
+  viewport_size : Int,
+) -> Unit =
+  #| (orientation, rtl, active, loop, viewportSize) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const saved = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     ResizeObserver: globalThis.ResizeObserver,
+  #|     hadResizeObserver: own("ResizeObserver"),
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement })
+  #|   const values = new Map([
+  #|     ["transition", "var(--rui-carousel-track-transition)"],
+  #|   ])
+  #|   const style = {
+  #|     getPropertyValue: key => values.get(key) || "",
+  #|     setProperty: (key, value) => values.set(key, String(value)),
+  #|     removeProperty: key => {
+  #|       const value = values.get(key) || ""
+  #|       values.delete(key)
+  #|       return value
+  #|     },
+  #|   }
+  #|   const root = new HTMLElement()
+  #|   Object.assign(root, {
+  #|     dataset: {
+  #|       slot: "carousel",
+  #|       orientation,
+  #|       activeIndex: String(active),
+  #|       count: "3",
+  #|       loop: String(loop),
+  #|     },
+  #|     isConnected: true,
+  #|     getAttribute(name) {
+  #|       const key = name.replace(/^data-/, "").replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+  #|       return this.dataset[key] ?? ""
+  #|     },
+  #|     setAttribute(name, value) {
+  #|       const key = name.replace(/^data-/, "").replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+  #|       this.dataset[key] = String(value)
+  #|     },
+  #|   })
+  #|   const closest = selector => selector === '[data-slot="carousel"]' ? root : null
+  #|   const item = index => {
+  #|     const attributes = new Map()
+  #|     const entry = new HTMLElement()
+  #|     Object.assign(entry, {
+  #|       dataset: { slot: "carousel-item", index: String(index) },
+  #|       offsetLeft: 0,
+  #|       offsetTop: 0,
+  #|       offsetWidth: 100,
+  #|       offsetHeight: 100,
+  #|       inert: false,
+  #|       attributes,
+  #|       closest,
+  #|       setAttribute(name, value) {
+  #|         attributes.set(name, String(value))
+  #|         if (name === "data-visible") this.dataset.visible = String(value)
+  #|         if (name === "inert") this.inert = true
+  #|       },
+  #|       removeAttribute(name) {
+  #|         attributes.delete(name)
+  #|         if (name === "data-visible") delete this.dataset.visible
+  #|         if (name === "inert") this.inert = false
+  #|       },
+  #|       getAttribute: name => attributes.get(name) || "",
+  #|     })
+  #|     return entry
+  #|   }
+  #|   const items = [item(0), item(1), item(2)]
+  #|   const place = (size, itemSize, step) => {
+  #|     viewport.clientWidth = size
+  #|     viewport.clientHeight = size
+  #|     items.forEach((entry, index) => {
+  #|       entry.offsetWidth = itemSize
+  #|       entry.offsetHeight = itemSize
+  #|       entry.offsetTop = index * step
+  #|       entry.offsetLeft = rtl ? (items.length - 1 - index) * step : index * step
+  #|     })
+  #|   }
+  #|   const track = new HTMLElement()
+  #|   Object.assign(track, { dataset: { slot: "carousel-track" }, style, closest })
+  #|   const viewport = new HTMLElement()
+  #|   Object.assign(viewport, {
+  #|     dataset: { slot: "carousel-content" },
+  #|     clientWidth: viewportSize,
+  #|     clientHeight: viewportSize,
+  #|     closest,
+  #|   })
+  #|   const control = slot => {
+  #|     const entry = new HTMLElement()
+  #|     Object.assign(entry, {
+  #|       dataset: { slot },
+  #|       disabled: false,
+  #|       attributes: new Map(),
+  #|       closest,
+  #|       setAttribute(name, value) {
+  #|         this.attributes.set(name, String(value))
+  #|         if (name === "disabled") this.disabled = true
+  #|       },
+  #|       removeAttribute(name) {
+  #|         this.attributes.delete(name)
+  #|         if (name === "disabled") this.disabled = false
+  #|       },
+  #|     })
+  #|     return entry
+  #|   }
+  #|   const previous = control("carousel-previous")
+  #|   const next = control("carousel-next")
+  #|   const bySelector = selector => {
+  #|     if (selector === '[data-slot="carousel-content"]') return [viewport]
+  #|     if (selector === '[data-slot="carousel-track"]') return [track]
+  #|     if (selector === '[data-slot="carousel-item"]') return items
+  #|     if (selector === '[data-slot="carousel-previous"]') return [previous]
+  #|     if (selector === '[data-slot="carousel-next"]') return [next]
+  #|     return []
+  #|   }
+  #|   root.querySelectorAll = bySelector
+  #|   place(viewportSize, 100, 105)
+  #|   const fixture = globalThis.__ruiCarouselLayoutFixture = {
+  #|     saved,
+  #|     root,
+  #|     viewport,
+  #|     track,
+  #|     items,
+  #|     previous,
+  #|     next,
+  #|     values,
+  #|     raf: [],
+  #|     resize: null,
+  #|     place,
+  #|   }
+  #|   globalThis.document = {
+  #|     getElementById: id => id === "layout-carousel" ? root : null,
+  #|   }
+  #|   globalThis.window = {
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: name => name === "direction" ? (rtl ? "rtl" : "ltr") : "",
+  #|     }),
+  #|     requestAnimationFrame(callback) {
+  #|       fixture.raf.push(callback)
+  #|       return fixture.raf.length
+  #|     },
+  #|   }
+  #|   globalThis.ResizeObserver = class {
+  #|     constructor(callback) { fixture.resize = callback }
+  #|     observe() { }
+  #|     disconnect() { }
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_offset() -> String =
+  #| () => globalThis.__ruiCarouselLayoutFixture.values.get("--rui-carousel-offset") || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_transition() -> String =
+  #| () => globalThis.__ruiCarouselLayoutFixture.values.get("transition") || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_visible(index : Int) -> Bool =
+  #| index => globalThis.__ruiCarouselLayoutFixture.items[index]?.dataset.visible === "true"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_hidden(index : Int) -> Bool =
+  #| index => globalThis.__ruiCarouselLayoutFixture.items[index]?.getAttribute("aria-hidden") === "true"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_inert(index : Int) -> Bool =
+  #| index => Boolean(globalThis.__ruiCarouselLayoutFixture.items[index]?.inert)
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_next_disabled() -> Bool =
+  #| () => globalThis.__ruiCarouselLayoutFixture.next.disabled
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_set_active(index : Int) -> Unit =
+  #| index => { globalThis.__ruiCarouselLayoutFixture.root.dataset.activeIndex = String(index) }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_resize(
+  viewport_size : Int,
+  item_size : Int,
+  step : Int,
+) -> Unit =
+  #| (viewportSize, itemSize, step) => {
+  #|   const fixture = globalThis.__ruiCarouselLayoutFixture
+  #|   fixture.place(viewportSize, itemSize, step)
+  #|   fixture.resize?.()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_layout_flush_frame() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCarouselLayoutFixture
+  #|   const callbacks = fixture.raf.splice(0)
+  #|   callbacks.forEach(callback => callback())
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_carousel_layout_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCarouselLayoutFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.saved.hadDocument, fixture.saved.document)
+  #|   restore("window", fixture.saved.hadWindow, fixture.saved.window)
+  #|   restore(
+  #|     "EventTarget",
+  #|     fixture.saved.hadEventTarget,
+  #|     fixture.saved.EventTarget,
+  #|   )
+  #|   restore("Node", fixture.saved.hadNode, fixture.saved.Node)
+  #|   restore(
+  #|     "HTMLElement",
+  #|     fixture.saved.hadHTMLElement,
+  #|     fixture.saved.HTMLElement,
+  #|   )
+  #|   restore("ResizeObserver", fixture.saved.hadResizeObserver, fixture.saved.ResizeObserver)
+  #|   delete globalThis.__ruiCarouselLayoutFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "carousel layout measures gap and basis exposes every visible slide and resizes" {
+  ffi_install_carousel_layout_fixture("horizontal", false, 1, false, 205)
+  let max_index = Ref(-1)
+  carousel_sync_layout("layout-carousel", measured => max_index.val = measured)
+  assert_eq(max_index.val, 1)
+  assert_eq(ffi_carousel_layout_offset(), "-105px")
+  assert_true(!ffi_carousel_layout_visible(0))
+  assert_true(ffi_carousel_layout_hidden(0))
+  assert_true(ffi_carousel_layout_inert(0))
+  assert_true(ffi_carousel_layout_visible(1))
+  assert_true(ffi_carousel_layout_visible(2))
+  assert_true(!ffi_carousel_layout_hidden(2))
+  assert_true(!ffi_carousel_layout_inert(2))
+  assert_true(ffi_carousel_layout_next_disabled())
+  assert_eq(ffi_carousel_layout_transition(), "none")
+  ffi_carousel_layout_flush_frame()
+  assert_eq(
+    ffi_carousel_layout_transition(),
+    "var(--rui-carousel-track-transition)",
+  )
+  ffi_carousel_layout_resize(150, 75, 80)
+  assert_eq(max_index.val, 2)
+  assert_eq(ffi_carousel_layout_offset(), "-80px")
+  ffi_restore_carousel_layout_fixture()
+}
+
+///|
+#cfg(target="js")
+test "carousel measured offsets preserve RTL and vertical directions" {
+  ffi_install_carousel_layout_fixture("horizontal", true, 2, false, 100)
+  carousel_sync_layout("layout-carousel", _ => ())
+  assert_eq(ffi_carousel_layout_offset(), "210px")
+  ffi_restore_carousel_layout_fixture()
+
+  ffi_install_carousel_layout_fixture("vertical", false, 2, false, 100)
+  carousel_sync_layout("layout-carousel", _ => ())
+  assert_eq(ffi_carousel_layout_offset(), "-210px")
+  ffi_restore_carousel_layout_fixture()
+}
+
+///|
+#cfg(target="js")
+test "carousel loop wrap installs the target offset without a long transition" {
+  ffi_install_carousel_layout_fixture("horizontal", false, 2, true, 100)
+  carousel_sync_layout("layout-carousel", _ => ())
+  assert_eq(ffi_carousel_layout_offset(), "-210px")
+  ffi_carousel_layout_flush_frame()
+  assert_eq(
+    ffi_carousel_layout_transition(),
+    "var(--rui-carousel-track-transition)",
+  )
+  ffi_carousel_layout_set_active(0)
+  carousel_sync_layout("layout-carousel", _ => ())
+  assert_eq(ffi_carousel_layout_offset(), "0px")
+  assert_eq(ffi_carousel_layout_transition(), "none")
+  ffi_carousel_layout_flush_frame()
+  assert_eq(
+    ffi_carousel_layout_transition(),
+    "var(--rui-carousel-track-transition)",
+  )
+  ffi_carousel_layout_set_active(2)
+  carousel_sync_layout("layout-carousel", _ => ())
+  assert_eq(ffi_carousel_layout_offset(), "-210px")
+  assert_eq(ffi_carousel_layout_transition(), "none")
+  ffi_restore_carousel_layout_fixture()
+}

--- a/rui/carousel_pointer_wbtest.mbt
+++ b/rui/carousel_pointer_wbtest.mbt
@@ -1,0 +1,469 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_carousel_pointer_fixture(rtl : Bool) -> Unit =
+  #| rtl => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const values = new Map([
+  #|     ["transform", "original-transform"],
+  #|     ["transition", "original-transition"],
+  #|   ])
+  #|   const style = {
+  #|     getPropertyValue: key => values.get(key) ?? "",
+  #|     setProperty: (key, value) => { values.set(key, String(value)) },
+  #|     removeProperty: key => {
+  #|       const value = values.get(key) ?? ""
+  #|       values.delete(key)
+  #|       return value
+  #|     },
+  #|   }
+  #|   const listeners = {}
+  #|   const fixture = globalThis.__ruiCarouselPointerFixture = {
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own("PointerEvent"),
+  #|     values,
+  #|     listeners,
+  #|     timeouts: [],
+  #|     captures: 0,
+  #|     releases: 0,
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class PointerEvent {
+  #|     constructor(init) { Object.assign(this, init) }
+  #|   }
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement, PointerEvent })
+  #|   const track = new HTMLElement()
+  #|   track.style = style
+  #|   const root = new HTMLElement()
+  #|   Object.assign(root, {
+  #|     dataset: {
+  #|       slot: "carousel",
+  #|       count: "3",
+  #|       loop: "false",
+  #|       maxSnapIndex: "2",
+  #|     },
+  #|     getAttribute(name) {
+  #|       const key = name.replace(/^data-/, "").replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+  #|       return this.dataset[key] ?? ""
+  #|     },
+  #|   })
+  #|   const viewport = new HTMLElement()
+  #|   Object.assign(viewport, {
+  #|     style: {
+  #|       getPropertyValue: key => values.get(`viewport:${key}`) ?? "",
+  #|       setProperty: (key, value) => { values.set(`viewport:${key}`, String(value)) },
+  #|       removeProperty: key => {
+  #|         const name = `viewport:${key}`
+  #|         const value = values.get(name) ?? ""
+  #|         values.delete(name)
+  #|         return value
+  #|       },
+  #|     },
+  #|     dataset: {},
+  #|     clientWidth: 300,
+  #|     clientHeight: 240,
+  #|     querySelector: selector => selector === '[data-slot="carousel-track"]' ? track : null,
+  #|     closest: selector => selector === '[data-slot="carousel"]' ? root : null,
+  #|     setAttribute(name, value) {
+  #|       if (name === "data-dragging") this.dataset.dragging = value
+  #|     },
+  #|     removeAttribute(name) {
+  #|       if (name === "data-dragging") delete this.dataset.dragging
+  #|     },
+  #|     setPointerCapture(pointerId) {
+  #|       this.__capturedPointerId = pointerId
+  #|       fixture.captures += 1
+  #|     },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId !== pointerId) return
+  #|       delete this.__capturedPointerId
+  #|       fixture.releases += 1
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|     addEventListener: (type, callback, options) => {
+  #|       const capture = typeof options === "boolean" ? options : !!options?.capture
+  #|       listeners[`${type}:${capture}`] = callback
+  #|     },
+  #|     removeEventListener: (type, callback, options) => {
+  #|       const capture = typeof options === "boolean" ? options : !!options?.capture
+  #|       const key = `${type}:${capture}`
+  #|       if (listeners[key] === callback) delete listeners[key]
+  #|     },
+  #|   })
+  #|   fixture.viewport = viewport
+  #|   fixture.track = track
+  #|   fixture.root = root
+  #|   globalThis.window = {
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: name => name === "direction" ? (rtl ? "rtl" : "ltr") : "",
+  #|     }),
+  #|     setTimeout(callback) {
+  #|       fixture.timeouts.push(callback)
+  #|       return fixture.timeouts.length
+  #|     },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_pointer_fixture_event(
+  x : Int,
+  y : Int,
+  time : Int,
+  button : Int,
+  interactive : Bool,
+) -> @dom.MouseEvent =
+  #| (x, y, time, button, interactive) => {
+  #|   const fixture = globalThis.__ruiCarouselPointerFixture
+  #|   const target = new HTMLElement()
+  #|   target.closest = () => interactive ? target : null
+  #|   return new PointerEvent({
+  #|     currentTarget: fixture.viewport,
+  #|     target,
+  #|     clientX: x,
+  #|     clientY: y,
+  #|     timeStamp: time,
+  #|     pointerId: 7,
+  #|     pointerType: "touch",
+  #|     isPrimary: true,
+  #|     button,
+  #|     defaultPrevented: false,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_keyboard_fixture_event(
+  key : String,
+  rtl : Bool,
+  modified : Bool,
+  interactive : Bool,
+) -> @dom.KeyboardEvent =
+  #| (key, rtl, modified, interactive) => {
+  #|   globalThis.window.getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "direction" ? (rtl ? "rtl" : "ltr") : "",
+  #|   })
+  #|   const currentTarget = new HTMLElement()
+  #|   const target = new HTMLElement()
+  #|   target.closest = () => interactive ? target : null
+  #|   return {
+  #|     key,
+  #|     altKey: modified,
+  #|     ctrlKey: false,
+  #|     metaKey: false,
+  #|     shiftKey: false,
+  #|     currentTarget,
+  #|     target,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_pointer_fixture_transform() -> String =
+  #| () => globalThis.__ruiCarouselPointerFixture.values.get("transform") ?? ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_pointer_fixture_dragging() -> Bool =
+  #| () => globalThis.__ruiCarouselPointerFixture.viewport.dataset.dragging === "true"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_pointer_fixture_captures() -> Int =
+  #| () => globalThis.__ruiCarouselPointerFixture.captures
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_pointer_fixture_releases() -> Int =
+  #| () => globalThis.__ruiCarouselPointerFixture.releases
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_carousel_pointer_fixture_element(kind : Int) -> @dom.Element =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiCarouselPointerFixture
+  #|   if (kind === 0) return fixture.root
+  #|   if (kind === 1) return fixture.viewport
+  #|   return fixture.track
+  #| }
+
+///|
+#cfg(target="js")
+fn carousel_pointer_fixture_has_state() -> Bool {
+  carousel_pointer_state(ffi_carousel_pointer_fixture_element(1)) is Some(_)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_configure_carousel_pointer_root(
+  loop_ : Bool,
+  max_index : Int,
+) -> Unit =
+  #| (loop, maxIndex) => {
+  #|   const fixture = globalThis.__ruiCarouselPointerFixture
+  #|   fixture.root.dataset.loop = String(loop)
+  #|   fixture.root.dataset.maxSnapIndex = String(maxIndex)
+  #| }
+
+///|
+#cfg(target="js")
+fn configure_carousel_pointer_measurement(
+  offset : Int,
+  loop_ : Bool,
+  max_index : Int,
+) -> Unit {
+  ffi_configure_carousel_pointer_root(loop_, max_index)
+  let root = ffi_carousel_pointer_fixture_element(0)
+  let viewport = ffi_carousel_pointer_fixture_element(1)
+  let track = ffi_carousel_pointer_fixture_element(2)
+  carousel_layout_states.push({
+    root,
+    viewport,
+    track,
+    items: [],
+    notify: _ => (),
+    previous_index: None,
+    offset: Some(offset.to_double()),
+    reported_max: None,
+    observer: None,
+    transition_generation: 0,
+  })
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_carousel_suppressed_click() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCarouselPointerFixture
+  #|   const listener = fixture.listeners["click:true"]
+  #|   if (!listener) return false
+  #|   const event = {
+  #|     prevented: false,
+  #|     stopped: false,
+  #|     preventDefault() { this.prevented = true },
+  #|     stopPropagation() { this.stopped = true },
+  #|   }
+  #|   listener(event)
+  #|   return event.prevented && event.stopped
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_carousel_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCarouselPointerFixture
+  #|   if (!fixture) return
+  #|   for (const callback of fixture.timeouts) callback()
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiCarouselPointerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "carousel pointer drag advances LTR and suppresses the release click" {
+  ffi_install_carousel_pointer_fixture(false)
+  let start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, false)
+  let drag_move = ffi_carousel_pointer_fixture_event(60, 103, 100, 0, false)
+  let finish = ffi_carousel_pointer_fixture_event(60, 103, 300, 0, false)
+  assert_true(carousel_pointer_start(start, "horizontal", 1, true, true))
+  assert_eq(ffi_carousel_pointer_fixture_captures(), 1)
+  assert_true(carousel_pointer_move(drag_move))
+  assert_true(ffi_carousel_pointer_fixture_dragging())
+  assert_eq(
+    ffi_carousel_pointer_fixture_transform(),
+    "translate3d(calc(-100% + -90px),0,0)",
+  )
+  assert_eq(carousel_pointer_end(finish), 1)
+  assert_eq(ffi_carousel_pointer_fixture_transform(), "original-transform")
+  assert_eq(ffi_carousel_pointer_fixture_releases(), 1)
+  assert_true(!carousel_pointer_fixture_has_state())
+  assert_true(ffi_fire_carousel_suppressed_click())
+  ffi_restore_carousel_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "carousel pointer drag follows RTL and vertical logical direction" {
+  ffi_install_carousel_pointer_fixture(true)
+  let rtl_start = ffi_carousel_pointer_fixture_event(100, 100, 0, 0, false)
+  let rtl_move = ffi_carousel_pointer_fixture_event(190, 100, 100, 0, false)
+  let rtl_finish = ffi_carousel_pointer_fixture_event(190, 100, 300, 0, false)
+  assert_true(carousel_pointer_start(rtl_start, "horizontal", 1, true, true))
+  assert_true(carousel_pointer_move(rtl_move))
+  assert_eq(
+    ffi_carousel_pointer_fixture_transform(),
+    "translate3d(calc(100% + 90px),0,0)",
+  )
+  assert_eq(carousel_pointer_end(rtl_finish), 1)
+  ffi_restore_carousel_pointer_fixture()
+
+  ffi_install_carousel_pointer_fixture(false)
+  let vertical_start = ffi_carousel_pointer_fixture_event(100, 150, 0, 0, false)
+  let vertical_move = ffi_carousel_pointer_fixture_event(102, 70, 100, 0, false)
+  let vertical_finish = ffi_carousel_pointer_fixture_event(
+    102, 70, 300, 0, false,
+  )
+  assert_true(carousel_pointer_start(vertical_start, "vertical", 1, true, true))
+  assert_true(carousel_pointer_move(vertical_move))
+  assert_eq(
+    ffi_carousel_pointer_fixture_transform(),
+    "translate3d(0,calc(-100% + -80px),0)",
+  )
+  assert_eq(carousel_pointer_end(vertical_finish), 1)
+  ffi_restore_carousel_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "carousel pointer drag respects threshold boundaries cancellation and inputs" {
+  ffi_install_carousel_pointer_fixture(false)
+  let small_start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, false)
+  let small_move = ffi_carousel_pointer_fixture_event(147, 100, 100, 0, false)
+  let small_finish = ffi_carousel_pointer_fixture_event(147, 100, 300, 0, false)
+  assert_true(carousel_pointer_start(small_start, "horizontal", 1, true, true))
+  assert_true(!carousel_pointer_move(small_move))
+  assert_eq(carousel_pointer_end(small_finish), 0)
+  ffi_restore_carousel_pointer_fixture()
+
+  ffi_install_carousel_pointer_fixture(false)
+  let edge_start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, false)
+  let edge_move = ffi_carousel_pointer_fixture_event(50, 100, 100, 0, false)
+  let edge_finish = ffi_carousel_pointer_fixture_event(50, 100, 300, 0, false)
+  assert_true(carousel_pointer_start(edge_start, "horizontal", 2, true, false))
+  assert_true(carousel_pointer_move(edge_move))
+  assert_eq(
+    ffi_carousel_pointer_fixture_transform(),
+    "translate3d(calc(-200% + -35px),0,0)",
+  )
+  assert_eq(carousel_pointer_end(edge_finish), 2)
+  ffi_restore_carousel_pointer_fixture()
+
+  ffi_install_carousel_pointer_fixture(false)
+  let cancel_start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, false)
+  let cancel_move = ffi_carousel_pointer_fixture_event(50, 100, 100, 0, false)
+  assert_true(carousel_pointer_start(cancel_start, "horizontal", 1, true, true))
+  assert_true(carousel_pointer_move(cancel_move))
+  carousel_pointer_cancel(cancel_move)
+  assert_true(!carousel_pointer_fixture_has_state())
+  assert_eq(ffi_carousel_pointer_fixture_transform(), "original-transform")
+  ffi_restore_carousel_pointer_fixture()
+
+  ffi_install_carousel_pointer_fixture(false)
+  let input_start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, true)
+  assert_true(!carousel_pointer_start(input_start, "horizontal", 1, true, true))
+  ffi_restore_carousel_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "carousel pointer drag uses measured offsets and resists an uncloned loop edge" {
+  ffi_install_carousel_pointer_fixture(false)
+  configure_carousel_pointer_measurement(-105, false, 2)
+  let measured_start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, false)
+  let measured_move = ffi_carousel_pointer_fixture_event(
+    100, 100, 100, 0, false,
+  )
+  let measured_finish = ffi_carousel_pointer_fixture_event(
+    100, 100, 300, 0, false,
+  )
+  assert_true(
+    carousel_pointer_start(measured_start, "horizontal", 1, true, true),
+  )
+  assert_true(carousel_pointer_move(measured_move))
+  assert_eq(
+    ffi_carousel_pointer_fixture_transform(),
+    "translate3d(calc(-105px + -50px),0,0)",
+  )
+  assert_eq(carousel_pointer_end(measured_finish), 1)
+  ffi_restore_carousel_pointer_fixture()
+
+  ffi_install_carousel_pointer_fixture(false)
+  configure_carousel_pointer_measurement(-210, true, 2)
+  let loop_start = ffi_carousel_pointer_fixture_event(150, 100, 0, 0, false)
+  let loop_move = ffi_carousel_pointer_fixture_event(50, 100, 100, 0, false)
+  let loop_finish = ffi_carousel_pointer_fixture_event(50, 100, 300, 0, false)
+  assert_true(carousel_pointer_start(loop_start, "horizontal", 2, true, true))
+  assert_true(carousel_pointer_move(loop_move))
+  assert_eq(
+    ffi_carousel_pointer_fixture_transform(),
+    "translate3d(calc(-210px + -35px),0,0)",
+  )
+  assert_eq(carousel_pointer_end(loop_finish), 1)
+  ffi_restore_carousel_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "carousel keyboard stepping preserves orientation RTL and editable guards" {
+  ffi_install_carousel_pointer_fixture(false)
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowRight", false, false, false),
+      "horizontal",
+    ),
+    1,
+  )
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowLeft", false, false, false),
+      "horizontal",
+    ),
+    -1,
+  )
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowRight", true, false, false),
+      "horizontal",
+    ),
+    -1,
+  )
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowUp", false, false, false),
+      "vertical",
+    ),
+    -1,
+  )
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowDown", false, false, false),
+      "vertical",
+    ),
+    1,
+  )
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowRight", false, true, false),
+      "horizontal",
+    ),
+    0,
+  )
+  assert_eq(
+    carousel_key_step(
+      ffi_carousel_keyboard_fixture_event("ArrowRight", false, false, true),
+      "horizontal",
+    ),
+    0,
+  )
+  ffi_restore_carousel_pointer_fixture()
+}

--- a/rui/catalog_test.mbt
+++ b/rui/catalog_test.mbt
@@ -1,0 +1,348 @@
+///|
+fn catalog_test_icon(path : String) -> @html.Html {
+  @html.span(
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(width=16, height=16, view_box="0 0 24 24", [
+      @svg.path(
+        d=path,
+        fill="none",
+        stroke="currentColor",
+        stroke_width=2,
+        attrs=@svg.Attrs::build()
+          .stroke_linecap("round")
+          .stroke_linejoin("round"),
+      ),
+    ]),
+  )
+}
+
+///|
+test "Vega catalog content primitives expose stable slots" {
+  let html = render(
+    @html.div([
+      @rui.aspect_ratio(ratio=1.5, "Preview"),
+      @rui.direction(direction=@rui.Rtl, "RTL"),
+      @rui.spinner(label="Loading"),
+      @rui.kbd_group([@rui.kbd("⌘"), @rui.kbd("K")]),
+      @rui.empty([
+        @rui.empty_header([
+          @rui.empty_media(
+            variant=@rui.EmptyMediaIcon,
+            catalog_test_icon("M12 5v14M5 12h14"),
+          ),
+          @rui.empty_title("No results"),
+          @rui.empty_description("Try another query."),
+        ]),
+        @rui.empty_content(@rui.button("Create")),
+      ]),
+      @rui.item_group(
+        @rui.item(variant=@rui.ItemOutline, [
+          @rui.item_media(
+            variant=@rui.ItemMediaIcon,
+            catalog_test_icon("M4 4h16v16H4zM4 9h16"),
+          ),
+          @rui.item_content([
+            @rui.item_title("Account"),
+            @rui.item_description("Workspace owner"),
+          ]),
+          @rui.item_actions(@rui.button(size=@rui.Sm, "Open")),
+        ]),
+      ),
+      @rui.marker(variant=@rui.MarkerSeparator, [
+        @rui.marker_icon(catalog_test_icon("M12 12h.01")),
+        @rui.marker_content("Today"),
+      ]),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"aspect-ratio\"")
+  assert_contains(html, "aspect-ratio:1.5")
+  assert_contains(html, "data-slot=\"direction\"")
+  assert_contains(html, "dir=\"rtl\"")
+  assert_contains(html, "data-slot=\"spinner\"")
+  assert_contains(html, "role=\"status\"")
+  assert_contains(html, "data-slot=\"kbd-group\"")
+  assert_contains(html, "data-slot=\"empty\"")
+  assert_contains(html, "data-slot=\"empty-icon\"")
+  assert_contains(html, "data-slot=\"item-group\"")
+  assert_contains(html, "data-slot=\"item-actions\"")
+  assert_contains(html, "data-slot=\"marker\"")
+  assert_contains(html, "data-variant=\"separator\"")
+}
+
+///|
+test "message attachment and bubble families compose without global CSS" {
+  let html = render(
+    @html.div([
+      @rui.message_group(
+        @rui.message(align=@rui.AlignEnd, [
+          @rui.message_avatar("Y"),
+          @rui.message_content([
+            @rui.message_header("Yorkin"),
+            @rui.bubble(variant=@rui.BubbleSecondary, [
+              @rui.bubble_content("Ship it."),
+              @rui.bubble_reactions([
+                catalog_test_icon("M20 6 9 17l-5-5"),
+                @html.span("2"),
+              ]),
+            ]),
+            @rui.message_footer("Delivered"),
+          ]),
+        ]),
+      ),
+      @rui.attachment_group(
+        @rui.attachment(
+          state=@rui.AttachmentUploading,
+          orientation=@rui.AttachmentHorizontal,
+          [
+            @rui.attachment_media("PDF"),
+            @rui.attachment_content([
+              @rui.attachment_title("spec.pdf"),
+              @rui.attachment_description("42 KB"),
+            ]),
+            @rui.attachment_actions(
+              @rui.attachment_action(
+                aria_label="Remove",
+                catalog_test_icon("M18 6 6 18M6 6l12 12"),
+              ),
+            ),
+            @rui.attachment_trigger(aria_label="Open spec", "Open"),
+          ],
+        ),
+      ),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"message-group\"")
+  assert_contains(html, "data-align=\"end\"")
+  assert_contains(html, "data-slot=\"bubble\"")
+  assert_contains(html, "data-variant=\"secondary\"")
+  assert_contains(html, "data-slot=\"bubble-reactions\"")
+  assert_contains(html, "data-slot=\"attachment-group\"")
+  assert_contains(html, "data-state=\"uploading\"")
+  assert_contains(
+    html, "background:var(--rui-attachment-bg,var(--rui-attachment-base-bg,var(--rui-card,var(--rui-background,white))))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-attachment-shadow,var(--rui-attachment-base-shadow,none))",
+  )
+  assert_contains(html, "data-slot=\"attachment-media\"")
+  assert_contains(html, "data-slot=\"attachment-action\"")
+  assert_contains(html, "data-slot=\"attachment-trigger\"")
+
+  let error_html = render(
+    @rui.attachment(state=@rui.AttachmentError, @html.nothing),
+  )
+  assert_contains(
+    error_html, "--rui-attachment-base-border:color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 30%,transparent)",
+  )
+}
+
+///|
+test "field form input-group scroll-area and chart expose the official parts" {
+  let html = render(
+    @html.div([
+      @rui.form(
+        @rui.form_item(invalid=true, [
+          @rui.form_label(for_="email", "Email"),
+          @rui.form_control(
+            @rui.input_group(invalid=true, [
+              @rui.input_group_addon(for_="email", "@"),
+              @rui.input_group_input(id="email", value="hello@example.com"),
+              @rui.input_group_button("Copy"),
+            ]),
+          ),
+          @rui.form_description("Used for notifications."),
+          @rui.form_message("Already registered."),
+        ]),
+      ),
+      @rui.field_set([
+        @rui.field_legend("Profile"),
+        @rui.field_group(
+          @rui.field(orientation=@rui.FieldHorizontal, [
+            @rui.field_label(for_="name", "Name"),
+            @rui.field_content(@rui.input(id="name")),
+          ]),
+        ),
+      ]),
+      @rui.scroll_area(style=["height:8rem"], [
+        @html.p("Scrollable"),
+        @rui.scroll_bar(),
+      ]),
+      @rui.chart_container(aria_label="Revenue", [
+        @rui.chart_style(
+          variables=[("revenue", "rebeccapurple"), ("--color-cost", "tomato")],
+          [
+            @rui.chart_tooltip(
+              @rui.chart_tooltip_content([
+                @rui.chart_tooltip_label("Q2"),
+                @rui.chart_tooltip_item(
+                  label="Revenue",
+                  value="$120k",
+                  indicator=@rui.ChartLine,
+                ),
+              ]),
+            ),
+            @rui.chart_legend_content(
+              @rui.chart_legend_item(color="rebeccapurple", "Revenue"),
+            ),
+          ],
+        ),
+      ]),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"form\"")
+  assert_contains(html, "data-slot=\"form-item\"")
+  assert_contains(html, "data-slot=\"form-label\"")
+  assert_contains(html, "data-slot=\"form-description\"")
+  assert_contains(html, "data-slot=\"form-message\"")
+  assert_contains(html, "data-slot=\"input-group\"")
+  assert_contains(html, "data-slot=\"input-group-addon\"")
+  assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)))",
+  )
+  assert_contains(html, "data-slot=\"field-set\"")
+  assert_contains(html, "data-slot=\"field-legend\"")
+  assert_contains(html, "data-orientation=\"horizontal\"")
+  assert_contains(html, "data-slot=\"scroll-area\"")
+  assert_contains(html, "data-slot=\"scroll-area-scrollbar\"")
+  assert_contains(html, "data-slot=\"chart\"")
+  assert_contains(html, "aria-label=\"Revenue\"")
+  assert_contains(html, "data-slot=\"chart-style\"")
+  assert_contains(html, "--color-revenue:rebeccapurple")
+  assert_contains(html, "--color-cost:tomato")
+  assert_contains(html, "data-slot=\"chart-tooltip\"")
+  assert_contains(html, "data-slot=\"chart-tooltip-item\"")
+  assert_contains(html, "data-indicator=\"line\"")
+  assert_contains(html, "data-slot=\"chart-legend-content\"")
+  assert_contains(html, "data-slot=\"chart-legend-item\"")
+  assert_not_contains(html, "<style")
+}
+
+///|
+test "stateful catalog components render their incremental initial model" {
+  let html = render_incremental(() => {
+    let toggle_view = @rui.toggle_group(
+      default_values=["bold"],
+      multiple=true,
+      id="formatting",
+      scope => {
+        @html.div([
+          @rui.toggle_group_item(scope~, value="bold", "B"),
+          @rui.toggle_group_item(scope~, value="italic", "I"),
+        ])
+      },
+    )
+    let slider_view = @rui.slider(
+      id="volume",
+      default_value=35,
+      aria_label="Volume",
+    )
+    let otp_view = @rui.input_otp(id="otp", default_value="123", max_length=6)
+    let resizable_view = @rui.resizable_panel_group(
+      id="split",
+      default_size=40,
+      scope => {
+        @html.div([
+          @rui.resizable_panel(scope~, side=@rui.FirstPanel, "A"),
+          @rui.resizable_handle(scope~, with_handle=true),
+          @rui.resizable_panel(scope~, side=@rui.SecondPanel, "B"),
+        ])
+      },
+    )
+    let scroller_view = @rui.message_scroller(id="thread", scope => {
+      @html.div([
+        @rui.message_scroller_viewport(
+          scope~,
+          @rui.message_scroller_content(
+            @rui.message_scroller_item(scroll_anchor=true, "Latest"),
+          ),
+        ),
+        @rui.message_scroller_button(
+          scope~,
+          label="Jump to latest message",
+          catalog_test_icon("m6 9 6 6 6-6"),
+        ),
+      ])
+    })
+    let toaster_view = @rui.toaster(scope => {
+      @html.button(
+        type_="button",
+        on_click=scope.show(title="Saved", description="Changes persisted"),
+        "Notify",
+      )
+    })
+    toggle_view.view6(
+      slider_view,
+      otp_view,
+      resizable_view,
+      scroller_view,
+      toaster_view,
+      (
+        toggle_html,
+        slider_html,
+        otp_html,
+        resizable_html,
+        scroller_html,
+        toaster_html,
+      ) => {
+        @html.div([
+          toggle_html, slider_html, otp_html, resizable_html, scroller_html, toaster_html,
+        ])
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"toggle-group\"")
+  assert_contains(html, "data-state=\"on\"")
+  assert_contains(html, "data-slot=\"slider\"")
+  assert_contains(html, "data-value=\"35\"")
+  assert_contains(html, "type=\"range\"")
+  assert_contains(html, "data-slot=\"input-otp\"")
+  assert_contains(html, "value=\"123\"")
+  assert_contains(html, "data-slot=\"resizable-panel-group\"")
+  assert_contains(html, "data-size=\"40\"")
+  assert_contains(html, "data-slot=\"resizable-handle\"")
+  assert_contains(html, "aria-orientation=\"horizontal\"")
+  assert_contains(html, "data-slot=\"message-scroller\"")
+  assert_contains(html, "data-slot=\"message-scroller-button\"")
+  assert_contains(
+    html, "--rui-message-scroller-shift:100%;--rui-message-scroller-scale:0.95",
+  )
+  assert_contains(
+    html, "--rui-button-base-border:var(--rui-border,oklch(0.922 0 0))",
+  )
+  assert_contains(html, "--rui-button-base-bg:var(--rui-background,white)")
+  assert_contains(
+    html, "--rui-button-base-fg:var(--rui-foreground,oklch(0.145 0 0))",
+  )
+  assert_not_contains(
+    html, "transform:translateX(-50%);border-color:var(--rui-border",
+  )
+  assert_contains(html, "data-slot=\"toaster\"")
+}
+
+///|
+test "message scroller initial position matches its requested edge" {
+  let html = render_incremental(() => {
+    @rui.message_scroller(id="initial-thread", default_at_end=true, scope => {
+      @html.div([
+        @rui.message_scroller_viewport(scope~, "Messages"),
+        @rui.message_scroller_button(
+          scope~,
+          direction=@rui.ScrollStart,
+          label="Jump to first message",
+          catalog_test_icon("m18 15-6-6-6 6"),
+        ),
+        @rui.message_scroller_button(
+          scope~,
+          direction=@rui.ScrollEnd,
+          label="Jump to latest message",
+          catalog_test_icon("m6 9 6 6 6-6"),
+        ),
+      ])
+    })
+  })
+  assert_contains(html, "data-at-start=\"false\"")
+  assert_contains(html, "data-at-end=\"true\"")
+  assert_contains(html, "data-direction=\"start\"")
+  assert_contains(html, "data-active=\"true\"")
+  assert_contains(html, "data-direction=\"end\"")
+}

--- a/rui/chart.mbt
+++ b/rui/chart.mbt
@@ -1,0 +1,328 @@
+///|
+pub(all) enum ChartIndicator {
+  ChartDot
+  ChartLine
+  ChartDashed
+} derive(Debug, Eq)
+
+///|
+const ChartContentsCarrierStyle : String = "display:contents"
+
+///|
+const ChartLegendContentStyle : String = "display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:1rem"
+
+///|
+fn chart_indicator_value(indicator : ChartIndicator) -> String {
+  match indicator {
+    ChartDot => "dot"
+    ChartLine => "line"
+    ChartDashed => "dashed"
+  }
+}
+
+///|
+fn chart_indicator_style(indicator : ChartIndicator, color : String) -> String {
+  match indicator {
+    ChartDot =>
+      "width:0.625rem;height:0.625rem;border-radius:2px;background:\{color}"
+    ChartLine =>
+      "width:0.25rem;align-self:stretch;border-radius:2px;background:\{color}"
+    ChartDashed => "width:0;height:1rem;border-left:1.5px dashed \{color}"
+  }
+}
+
+///|
+/// Vega chart surface for an application-provided SVG, canvas, or chart engine.
+pub fn[C : @html.IsChildren] chart_container(
+  aria_label? : String,
+  aspect? : String = "16 / 9",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let chart_attrs = ui_attrs(attrs).data_set("slot", "chart")
+  if aria_label is Some(label) {
+    ignore(chart_attrs.role("img").aria_label(label))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=chart_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "display:flex;width:100%;min-width:0;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;aspect-ratio:\{aspect}",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+/// Carry chart-engine tooltip output without introducing a layout box.
+///
+/// Rabbita does not bundle a chart engine, so this is the native composition
+/// adapter corresponding to shadcn's `ChartTooltip` export. The application
+/// still owns pointer tracking and supplies the rendered tooltip content.
+pub fn[C : @html.IsChildren] chart_tooltip(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "chart-tooltip"),
+    style=ui_styles([ChartContentsCarrierStyle], style),
+    children,
+  )
+}
+
+///|
+/// Scope chart color variables to `children` with inline custom properties.
+///
+/// A variable named `revenue` becomes `--color-revenue`; names already
+/// starting with `--` are kept verbatim. Unlike shadcn's Recharts helper this
+/// never emits a `<style>` element, so it remains CSP-friendly and copyable.
+pub fn[C : @html.IsChildren] chart_style(
+  variables? : Array[(String, String)] = [],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let carrier_attrs = ui_attrs(attrs).data_set("slot", "chart-style")
+  for entry in variables {
+    if entry.0 != "" {
+      let property = if entry.0.has_prefix("--") {
+        entry.0
+      } else {
+        "--color-\{entry.0}"
+      }
+      ignore(carrier_attrs.style(property, entry.1))
+    }
+  }
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=carrier_attrs,
+    style=ui_styles([ChartContentsCarrierStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] chart_tooltip_content(
+  active? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    hidden=!active,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .role("status")
+      .aria_live("polite")
+      .data_set("slot", "chart-tooltip-content")
+      .data_set("state", if active { "open" } else { "closed" }),
+    style=ui_styles(
+      [
+        "display:grid;min-width:8rem;align-items:start;gap:0.375rem;border:1px solid color-mix(in oklch,var(--rui-border,oklch(0.922 0 0)) 50%,transparent);border-radius:0.5rem;background:var(--rui-background,white);padding:0.375rem 0.625rem;color:var(--rui-foreground,oklch(0.145 0 0));font-size:0.75rem;line-height:1rem;box-shadow:0 8px 24px rgb(0 0 0 / 0.12)",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] chart_tooltip_label(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "chart-tooltip-label"),
+    style=ui_styles(["font-weight:500"], style),
+    children,
+  )
+}
+
+///|
+pub fn chart_tooltip_item(
+  label~ : String,
+  value~ : String,
+  color? : String = "currentColor",
+  indicator? : ChartIndicator = ChartDot,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "chart-tooltip-item")
+      .data_set("indicator", chart_indicator_value(indicator)),
+    style=ui_styles(
+      ["display:flex;width:100%;align-items:center;gap:0.5rem"],
+      style,
+    ),
+    [
+      @html.span(
+        attrs=@html.Attrs::build().aria_hidden("true"),
+        style=[chart_indicator_style(indicator, color)],
+        "",
+      ),
+      @html.span(
+        style=[
+          "min-width:0;flex:1;color:var(--rui-muted-foreground,oklch(0.556 0 0))",
+        ],
+        label,
+      ),
+      @html.span(
+        style=[
+          "font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--rui-foreground,oklch(0.145 0 0))",
+        ],
+        value,
+      ),
+    ],
+  )
+}
+
+///|
+fn[C : @html.IsChildren] chart_legend_surface(
+  slot : String,
+  position? : String = "bottom",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", slot).data_set("position", position),
+    style=ui_styles(
+      [
+        ChartLegendContentStyle,
+        if position == "top" {
+          "padding-bottom:0.75rem"
+        } else {
+          "padding-top:0.75rem"
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+/// Carry an application chart engine's legend output.
+///
+/// This compatibility spelling predates the explicit shadcn content part;
+/// prefer [`chart_legend_content`] for new compound composition.
+pub fn[C : @html.IsChildren] chart_legend(
+  position? : String = "bottom",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  chart_legend_surface(
+    "chart-legend",
+    position~,
+    id?,
+    class?,
+    title?,
+    attrs?,
+    style~,
+    children,
+  )
+}
+
+///|
+/// Render the official shadcn chart legend content surface.
+pub fn[C : @html.IsChildren] chart_legend_content(
+  position? : String = "bottom",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  chart_legend_surface(
+    "chart-legend-content",
+    position~,
+    id?,
+    class?,
+    title?,
+    attrs?,
+    style~,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] chart_legend_item(
+  color? : String = "currentColor",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "chart-legend-item"),
+    style=ui_styles(["display:flex;align-items:center;gap:0.375rem"], style),
+    [
+      @html.span(
+        attrs=@html.Attrs::build().aria_hidden("true"),
+        style=[
+          "width:0.5rem;height:0.5rem;flex-shrink:0;border-radius:2px;background:\{color}",
+        ],
+        "",
+      ),
+      @html.span(children),
+    ],
+  )
+}

--- a/rui/checkbox.mbt
+++ b/rui/checkbox.mbt
@@ -1,0 +1,282 @@
+///|
+const CheckboxBaseStyle : String = "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-primary-foreground,oklch(0.985 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.375rem);margin:0;padding:0;background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-primary-foreground,oklch(0.985 0 0))));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));cursor:pointer;user-select:none;appearance:none;-webkit-appearance:none;vertical-align:middle;outline-offset:2px"
+
+///|
+const CheckboxCheckedStyle : String = "--rui-control-base-border:var(--rui-primary,oklch(0.205 0 0));--rui-control-base-bg:var(--rui-primary,oklch(0.205 0 0))"
+
+///|
+const CheckboxUncheckedStyle : String = "--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-bg:var(--rui-input-background,transparent)"
+
+///|
+const CheckboxInvalidStyle : String = "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+const CheckboxReadOnlyStyle : String = "cursor:default"
+
+///|
+const CheckboxIndicatorStyle : String = "display:block;box-sizing:border-box;flex-shrink:0;pointer-events:none;transition:opacity 100ms ease,transform 100ms ease"
+
+///|
+fn checkbox_state(checked : Bool, indeterminate : Bool) -> (String, String) {
+  if indeterminate {
+    ("mixed", "indeterminate")
+  } else if checked {
+    ("true", "checked")
+  } else {
+    ("false", "unchecked")
+  }
+}
+
+///|
+fn checkbox_state_style(checked : Bool, indeterminate : Bool) -> String {
+  if checked || indeterminate {
+    CheckboxCheckedStyle
+  } else {
+    CheckboxUncheckedStyle
+  }
+}
+
+///|
+fn checkbox_read_only_style(read_only : Bool) -> String {
+  if read_only {
+    CheckboxReadOnlyStyle
+  } else {
+    ""
+  }
+}
+
+///|
+fn checkbox_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    CheckboxInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+fn checkbox_indicator_state_style(
+  checked : Bool,
+  indeterminate : Bool,
+) -> String {
+  if indeterminate {
+    "width:0.5rem;height:0.125rem;border-radius:9999px;background:currentColor;opacity:1;transform:scale(1)"
+  } else if checked {
+    "width:0.375rem;height:0.625rem;border-right:0.125rem solid currentColor;border-bottom:0.125rem solid currentColor;opacity:1;transform:translateY(-0.0625rem) rotate(45deg)"
+  } else {
+    "width:0.375rem;height:0.625rem;opacity:0;transform:scale(0.75)"
+  }
+}
+
+///|
+#cfg(target="js")
+fn checkbox_bind_keyboard_attrs(attrs : @html.Attrs) -> Unit {
+  ignore(
+    attrs.on_keydown(event => {
+      if event.key() == "Enter" {
+        event.prevent_default()
+      }
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn checkbox_bind_keyboard_attrs(attrs : @html.Attrs) -> Unit {
+  ignore(attrs)
+}
+
+///|
+/// Render one checkbox state for the incremental wrapper.
+///
+/// Mouse activation and Space request the next value through
+/// `on_checked_change`. Enter's native button activation is cancelled so it
+/// intentionally does not change this checkbox.
+/// The component is not a form control and does not create a hidden input.
+fn render_checkbox(
+  checked? : Bool = false,
+  indeterminate? : Bool = false,
+  disabled? : Bool = false,
+  read_only? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_checked_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let (aria_checked, data_state) = checkbox_state(checked, indeterminate)
+  let next_checked = !checked
+  let control_attrs = ui_attrs(attrs).data_set("slot", "checkbox")
+  ignore(control_attrs.role("checkbox"))
+  ignore(control_attrs.aria_checked(aria_checked))
+  ignore(control_attrs.aria_disabled(ui_bool(disabled)))
+  ignore(control_attrs.aria_readonly(ui_bool(read_only)))
+  ignore(control_attrs.data_set("state", data_state))
+  if indeterminate {
+    ignore(control_attrs.data_set("indeterminate", ""))
+  } else if checked {
+    ignore(control_attrs.data_set("checked", ""))
+  } else {
+    ignore(control_attrs.data_set("unchecked", ""))
+  }
+  if disabled {
+    ignore(control_attrs.data_set("disabled", ""))
+  }
+  if read_only {
+    ignore(control_attrs.data_set("readonly", ""))
+  }
+  if invalid {
+    ignore(control_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  if aria_label is Some(label) {
+    ignore(control_attrs.aria_label(label))
+  }
+  checkbox_bind_keyboard_attrs(control_attrs)
+  if !disabled && !read_only && on_checked_change is Some(emit) {
+    ignore(control_attrs.on_click(_ => emit(next_checked)))
+  }
+  let indicator_attrs = @html.Attrs::build()
+    .data_set("slot", "checkbox-indicator")
+    .data_set("state", data_state)
+  if indeterminate {
+    ignore(indicator_attrs.data_set("indeterminate", ""))
+  } else if checked {
+    ignore(indicator_attrs.data_set("checked", ""))
+  } else {
+    ignore(indicator_attrs.data_set("unchecked", ""))
+  }
+  ignore(indicator_attrs.aria_hidden("true"))
+  let indicator = @html.span(
+    style=[
+      UiBoxSizing,
+      CheckboxIndicatorStyle,
+      checkbox_indicator_state_style(checked, indeterminate),
+    ],
+    attrs=indicator_attrs,
+    "",
+  )
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        CheckboxBaseStyle,
+        checkbox_state_style(checked, indeterminate),
+        checkbox_read_only_style(read_only),
+        checkbox_invalid_style(invalid),
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=control_attrs,
+    indicator,
+  )
+}
+
+///|
+priv struct CheckboxModel {
+  checked : Bool
+  indeterminate : Bool
+} derive(Eq)
+
+///|
+priv enum CheckboxMsg {
+  CheckboxChange(Bool)
+}
+
+///|
+/// Build a black-box checkbox with component-local incremental state.
+#cfg(target="js")
+pub fn checkbox(
+  default_checked? : Bool = false,
+  default_indeterminate? : Bool = false,
+  disabled? : Bool = false,
+  read_only? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_checked_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = {
+    checked: default_checked,
+    indeterminate: default_indeterminate,
+  }
+  let (model, emit) = @rabbita.create_state(initial, update=fn(_, msg, _) {
+    let next = match msg {
+      CheckboxChange(checked) => { checked, indeterminate: false }
+    }
+    let command = if on_checked_change is Some(notify) {
+      notify(next.checked)
+    } else {
+      @cmd.none
+    }
+    (next, command)
+  })
+  model.view(model => {
+    render_checkbox(
+      checked=model.checked,
+      indeterminate=model.indeterminate,
+      disabled~,
+      read_only~,
+      invalid~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      on_checked_change=@cmd.Emit(checked => emit(CheckboxChange(checked))),
+      attrs?,
+      style~,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for `checkbox`: render the initial state as a constant
+/// incremental value.
+#cfg(not(target="js"))
+pub fn checkbox(
+  default_checked? : Bool = false,
+  default_indeterminate? : Bool = false,
+  disabled? : Bool = false,
+  read_only? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_checked_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_checked_change)
+  @rabbita.Val::constant(
+    render_checkbox(
+      checked=default_checked,
+      indeterminate=default_indeterminate,
+      disabled~,
+      read_only~,
+      invalid~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      attrs?,
+      style~,
+    ),
+  )
+}

--- a/rui/collapsible.mbt
+++ b/rui/collapsible.mbt
@@ -1,0 +1,452 @@
+///|
+const CollapsibleRootStyle : String = "display:block;width:100%;min-width:0;color:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const CollapsibleTriggerStyle : String = AccordionTriggerStyle
+
+///|
+const CollapsibleTriggerLabelStyle : String = "display:block;min-width:0;flex:1"
+
+///|
+const CollapsibleIndicatorBoxStyle : String = "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));pointer-events:none"
+
+///|
+const CollapsibleIndicatorStyle : String = "display:block;width:0.4375rem;height:0.4375rem;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform-origin:center;transition:transform 150ms ease"
+
+///|
+const CollapsibleIndicatorClosedStyle : String = "transform:translateY(-0.125rem) rotate(45deg)"
+
+///|
+const CollapsibleIndicatorOpenStyle : String = "transform:translateY(0.125rem) rotate(225deg)"
+
+///|
+const CollapsibleContentOuterStyle : String = "display:grid;min-width:0;grid-template-rows:var(--rui-collapsible-content-rows,0fr);opacity:var(--rui-collapsible-content-opacity,0);visibility:var(--rui-collapsible-content-visibility,hidden);transition:grid-template-rows 200ms cubic-bezier(0.22,1,0.36,1),opacity 150ms ease,visibility 0s linear var(--rui-collapsible-content-visibility-delay,200ms)"
+
+///|
+const CollapsibleContentOpenStyle : String = "--rui-collapsible-content-rows:1fr;--rui-collapsible-content-opacity:1;--rui-collapsible-content-visibility:visible;--rui-collapsible-content-visibility-delay:0s"
+
+///|
+const CollapsibleContentClosedStyle : String = "--rui-collapsible-content-rows:0fr;--rui-collapsible-content-opacity:0;--rui-collapsible-content-visibility:hidden;--rui-collapsible-content-visibility-delay:200ms"
+
+///|
+const CollapsibleContentClipStyle : String = "min-width:0;min-height:0;overflow:hidden"
+
+///|
+const CollapsibleContentStyle : String = "min-width:0;padding:0.25rem 0.625rem 0.75rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.5;overflow-wrap:anywhere"
+
+///|
+fn collapsible_state(open : Bool) -> String {
+  if open {
+    "open"
+  } else {
+    "closed"
+  }
+}
+
+///|
+fn collapsible_state_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  open : Bool,
+) -> @html.Attrs {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("state", collapsible_state(open))
+  if open {
+    ignore(element_attrs.data_set("open", ""))
+  } else {
+    ignore(element_attrs.data_set("closed", ""))
+  }
+  element_attrs
+}
+
+///|
+#cfg(target="js")
+fn collapsible_bind_open_change(
+  attrs : @html.Attrs,
+  open : Bool,
+  emit : @cmd.Emit[Bool],
+) -> Unit {
+  ignore(
+    attrs.on_click(event => {
+      event.prevent_default()
+      emit(!open)
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn collapsible_bind_open_change(
+  attrs : @html.Attrs,
+  open : Bool,
+  emit : @cmd.Emit[Bool],
+) -> Unit {
+  ignore((attrs, open, emit))
+}
+
+///|
+fn collapsible_indicator(open : Bool) -> @html.Html {
+  let state = collapsible_state(open)
+  @html.span(
+    style=[UiBoxSizing, CollapsibleIndicatorBoxStyle],
+    attrs=@html.Attrs::build()
+      .aria_hidden("true")
+      .data_set("slot", "collapsible-indicator")
+      .data_set("state", state),
+    @html.span(
+      style=[
+        UiBoxSizing,
+        CollapsibleIndicatorStyle,
+        if open {
+          CollapsibleIndicatorOpenStyle
+        } else {
+          CollapsibleIndicatorClosedStyle
+        },
+      ],
+      attrs=@html.Attrs::build().data_set("state", state),
+      @html.nothing,
+    ),
+  )
+}
+
+///|
+/// Render the root used by a controlled collapsible.
+pub fn[C : @html.IsChildren] collapsible_root(
+  open? : Bool = false,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = collapsible_state_attrs(attrs, "collapsible", open).aria_disabled(
+    ui_bool(disabled),
+  )
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        CollapsibleRootStyle,
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the native button trigger for a controlled collapsible.
+///
+/// The native button supplies pointer, Enter, and Space activation. The
+/// component appends its state request after any caller click handler stored
+/// in `attrs`.
+pub fn[C : @html.IsChildren] collapsible_trigger(
+  open? : Bool = false,
+  disabled? : Bool = false,
+  controls? : String,
+  show_indicator? : Bool = true,
+  on_open_change? : @cmd.Emit[Bool],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = collapsible_state_attrs(
+      attrs, "collapsible-trigger", open,
+    )
+    .aria_expanded(ui_bool(open))
+    .aria_disabled(ui_bool(disabled))
+  if controls is Some(controls) {
+    ignore(element_attrs.aria_controls(controls))
+  }
+  if disabled {
+    ignore(element_attrs.data_set("disabled", "").tabindex(-1))
+  }
+  if !disabled && on_open_change is Some(emit) {
+    collapsible_bind_open_change(element_attrs, open, emit)
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        CollapsibleTriggerStyle,
+        if open {
+          AccordionTriggerOpenStyle
+        } else {
+          ""
+        },
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    [
+      @html.span(
+        style=[UiBoxSizing, CollapsibleTriggerLabelStyle],
+        attrs=@html.Attrs::build().data_set("slot", "collapsible-trigger-label"),
+        children,
+      ),
+      if show_indicator {
+        collapsible_indicator(open)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+/// Render the collapsible panel. Content remains mounted so both entering and
+/// leaving states can animate without a component-specific script.
+pub fn[C : @html.IsChildren] collapsible_content(
+  open? : Bool = false,
+  force_mount? : Bool = false,
+  labelledby? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  body_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = collapsible_state_attrs(
+      attrs, "collapsible-content", open,
+    )
+    .data_set("force-mount", ui_bool(force_mount))
+    .aria_hidden(ui_bool(!open))
+    .inert(!open)
+  if labelledby is Some(labelledby) {
+    ignore(element_attrs.aria_labelledby(labelledby))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        CollapsibleContentOuterStyle,
+        if open {
+          CollapsibleContentOpenStyle
+        } else {
+          CollapsibleContentClosedStyle
+        },
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    @html.div(
+      style=[UiBoxSizing, CollapsibleContentClipStyle],
+      attrs=@html.Attrs::build().data_set("slot", "collapsible-content-clip"),
+      @html.div(
+        style=ui_styles([UiBoxSizing, CollapsibleContentStyle], body_style),
+        attrs=@html.Attrs::build().data_set("slot", "collapsible-content-body"),
+        children,
+      ),
+    ),
+  )
+}
+
+///|
+/// Render the current collapsible state for the public incremental component.
+fn[T : @html.IsChildren, C : @html.IsChildren] render_collapsible(
+  open~ : Bool,
+  disabled? : Bool = false,
+  show_indicator? : Bool = true,
+  force_mount? : Bool = false,
+  on_open_change? : @cmd.Emit[Bool],
+  id? : String,
+  trigger_id? : String,
+  content_id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  trigger_attrs? : @html.Attrs,
+  content_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+  content_body_style? : Array[String] = [],
+  trigger~ : T,
+  content~ : C,
+) -> @html.Html {
+  let resolved_trigger_id = match trigger_id {
+    Some(trigger_id) => Some(trigger_id)
+    None => id.map(id => id + "-trigger")
+  }
+  let resolved_content_id = match content_id {
+    Some(content_id) => Some(content_id)
+    None => id.map(id => id + "-content")
+  }
+  let trigger_html = {
+    let controls = resolved_content_id
+    let id = resolved_trigger_id
+    let attrs = trigger_attrs
+    collapsible_trigger(
+      open~,
+      disabled~,
+      controls?,
+      show_indicator~,
+      on_open_change?,
+      id?,
+      attrs?,
+      style=trigger_style,
+      trigger,
+    )
+  }
+  let content_html = {
+    let labelledby = resolved_trigger_id
+    let id = resolved_content_id
+    let attrs = content_attrs
+    collapsible_content(
+      open~,
+      force_mount~,
+      labelledby?,
+      id?,
+      attrs?,
+      style=content_style,
+      body_style=content_body_style,
+      content,
+    )
+  }
+  collapsible_root(
+    open~,
+    disabled~,
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs?,
+    style~,
+    [trigger_html, content_html],
+  )
+}
+
+///|
+/// Build a self-contained collapsible with component-local incremental state.
+#cfg(target="js")
+pub fn[T : @html.IsChildren, C : @html.IsChildren] collapsible(
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  show_indicator? : Bool = true,
+  force_mount? : Bool = false,
+  id? : String,
+  trigger_id? : String,
+  content_id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  trigger_attrs? : @html.Attrs,
+  content_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+  content_body_style? : Array[String] = [],
+  trigger~ : T,
+  content~ : C,
+) -> @rabbita.Val[@html.Html] {
+  let (open, set_open) = @rabbita.create_variable(default_open)
+  let on_open_change = set_open.map(next => _ => next)
+  open.view(open => {
+    render_collapsible(
+      open~,
+      disabled~,
+      show_indicator~,
+      force_mount~,
+      on_open_change~,
+      id?,
+      trigger_id?,
+      content_id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      trigger_attrs?,
+      content_attrs?,
+      style~,
+      trigger_style~,
+      content_style~,
+      content_body_style~,
+      trigger~,
+      content~,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: render the requested initial state as a constant
+/// incremental value.
+#cfg(not(target="js"))
+pub fn[T : @html.IsChildren, C : @html.IsChildren] collapsible(
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  show_indicator? : Bool = true,
+  force_mount? : Bool = false,
+  id? : String,
+  trigger_id? : String,
+  content_id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  trigger_attrs? : @html.Attrs,
+  content_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+  content_body_style? : Array[String] = [],
+  trigger~ : T,
+  content~ : C,
+) -> @rabbita.Val[@html.Html] {
+  @rabbita.Val::constant(
+    render_collapsible(
+      open=default_open,
+      disabled~,
+      show_indicator~,
+      force_mount~,
+      id?,
+      trigger_id?,
+      content_id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      trigger_attrs?,
+      content_attrs?,
+      style~,
+      trigger_style~,
+      content_style~,
+      content_body_style~,
+      trigger~,
+      content~,
+    ),
+  )
+}

--- a/rui/collapsible_wbtest.mbt
+++ b/rui/collapsible_wbtest.mbt
@@ -1,0 +1,18 @@
+///|
+test "collapsible hover uses the accent surface without changing accordion hover" {
+  assert_true(
+    UiInteractionCss.contains(
+      "[data-slot=\"collapsible-trigger\"]:not([aria-disabled=\"true\"]):hover",
+    ),
+  )
+  assert_true(
+    UiInteractionCss.contains(
+      "--rui-accordion-bg:var(--rui-accent,oklch(0.97 0 0))",
+    ),
+  )
+  assert_true(
+    UiInteractionCss.contains(
+      "[data-slot=\"accordion-trigger\"]:not([aria-disabled=\"true\"]):hover",
+    ),
+  )
+}

--- a/rui/combobox.mbt
+++ b/rui/combobox.mbt
@@ -1,0 +1,1831 @@
+///|
+struct ComboboxOption {
+  value : String
+  label : String
+  disabled : Bool
+}
+
+///|
+pub fn combobox_option(
+  value~ : String,
+  label~ : String,
+  disabled? : Bool = false,
+) -> ComboboxOption {
+  { value, label, disabled }
+}
+
+///|
+priv struct ComboboxModel {
+  open : Bool
+  query : String
+  values : Array[String]
+  active : Int
+} derive(Eq)
+
+///|
+priv enum ComboboxMsg {
+  ComboboxOpen
+  ComboboxToggle
+  ComboboxNativeChanged(Bool)
+  ComboboxSetQuery(String)
+  ComboboxMove(Int)
+  ComboboxFirst
+  ComboboxLast
+  ComboboxHighlight(Int)
+  ComboboxChoose(Int)
+  ComboboxRemove(String)
+  ComboboxClear
+  ComboboxClose
+  ComboboxDismiss
+}
+
+///|
+/// Opaque component-local state supplied to the combobox compound API.
+struct ComboboxScope {
+  id : String
+  options : Array[ComboboxOption]
+  model : ComboboxModel
+  multiple : Bool
+  placeholder : String
+  empty_text : String
+  disabled : Bool
+  invalid : Bool
+  required : Bool
+  name : String?
+  side : PopupSide
+  align : PopupAlign
+  side_offset : Int
+  align_offset : Int
+  emit : @cmd.Emit[ComboboxMsg]
+  content_id : Ref[String]
+  anchor_id : Ref[String]
+  has_input : Ref[Bool]
+}
+
+///|
+const ComboboxRootStyle : String = "position:relative;display:flex;width:100%;min-width:0;flex-direction:column"
+
+///|
+const ComboboxControlStyle : String = "display:flex;width:100%;min-height:2.25rem;min-width:0;align-items:center;gap:0.375rem;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));padding:0.25rem 0.375rem;box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));outline-offset:2px"
+
+///|
+const ComboboxControlLayoutStyle : String = "display:flex;width:100%;min-width:0"
+
+///|
+const ComboboxChipsStyle : String = "display:flex;width:100%;min-width:0;min-height:2.25rem;flex:1;flex-wrap:wrap;align-items:center;gap:0.375rem;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));background-clip:padding-box;padding:0.375rem 0.625rem;color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));font-size:0.875rem;line-height:1.25rem;outline:none"
+
+///|
+const ComboboxContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:flex;width:var(--rui-floating-anchor-width,anchor-size(width));min-width:min(calc(var(--rui-floating-anchor-width,anchor-size(width)) + 1.75rem),calc(100vw - 1rem));max-width:var(--rui-floating-available-width,calc(100vw - 1rem));max-height:min(24rem,var(--rui-floating-available-height,calc(100vh - 1rem)));transform-origin:var(--rui-floating-transform-origin,center);flex-direction:column;overflow:hidden;margin:0;border:1px solid color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:0;color:var(--rui-popover-foreground,oklch(0.145 0 0));box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const ComboboxItemStyle : String = "position:relative;display:flex;width:100%;min-height:2rem;align-items:center;gap:0.5rem;border:0;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent));padding-block:0.375rem;padding-inline:0.5rem 2rem;color:var(--rui-menu-item-fg,var(--rui-menu-item-base-fg,inherit));font:inherit;font-size:0.875rem;line-height:1.25rem;text-align:start;white-space:nowrap;outline:none;cursor:pointer"
+
+///|
+const ComboboxInputBaseStyle : String = "border:0;background:transparent;padding:0.125rem 0.25rem;color:var(--rui-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem;outline:none"
+
+///|
+const ComboboxInputLayoutStyle : String = "width:100%;min-width:3rem;flex:1"
+
+///|
+const ComboboxChipsInputLayoutStyle : String = "width:auto;min-width:4rem;flex:1"
+
+///|
+const ComboboxTriggerIconStyle : String = "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;line-height:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));pointer-events:none"
+
+///|
+fn combobox_trigger_icon() -> @html.Html {
+  @html.span(
+    attrs=@html.Attrs::build()
+      .aria_hidden("true")
+      .data_set("slot", "combobox-trigger-icon"),
+    style=[ComboboxTriggerIconStyle],
+    ui_chevron_down_icon(),
+  )
+}
+
+///|
+fn combobox_contains(values : Array[String], value : String) -> Bool {
+  for current in values {
+    if current == value {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn combobox_option_index(
+  options : Array[ComboboxOption],
+  value : String,
+) -> Int {
+  for index, option in options {
+    if option.value == value {
+      return index
+    }
+  }
+  -1
+}
+
+///|
+fn combobox_selected_label(scope : ComboboxScope) -> String {
+  if scope.model.values.length() == 0 {
+    return scope.placeholder
+  }
+  let labels : Array[String] = []
+  for value in scope.model.values {
+    let index = combobox_option_index(scope.options, value)
+    if index >= 0 {
+      labels.push(scope.options[index].label)
+    }
+  }
+  labels.join(", ")
+}
+
+///|
+fn combobox_selected_input_value(
+  options : Array[ComboboxOption],
+  values : Array[String],
+  multiple : Bool,
+) -> String {
+  if multiple || values.length() == 0 {
+    return ""
+  }
+  let index = combobox_option_index(options, values[0])
+  if index >= 0 {
+    options[index].label
+  } else {
+    ""
+  }
+}
+
+///|
+fn combobox_filter_query(
+  options : Array[ComboboxOption],
+  values : Array[String],
+  multiple : Bool,
+  query : String,
+) -> String {
+  let selected_input = combobox_selected_input_value(options, values, multiple)
+  if !multiple && selected_input != "" && query == selected_input {
+    ""
+  } else {
+    query
+  }
+}
+
+///|
+fn combobox_matches(option : ComboboxOption, query : String) -> Bool {
+  query == "" ||
+  option.label.to_lower().contains(query.to_lower()) ||
+  option.value.to_lower().contains(query.to_lower())
+}
+
+///|
+fn combobox_first_match(
+  options : Array[ComboboxOption],
+  query : String,
+  reverse : Bool,
+) -> Int {
+  if reverse {
+    let mut index = options.length() - 1
+    while index >= 0 {
+      if !options[index].disabled && combobox_matches(options[index], query) {
+        return index
+      }
+      index -= 1
+    }
+  } else {
+    for index, option in options {
+      if !option.disabled && combobox_matches(option, query) {
+        return index
+      }
+    }
+  }
+  -1
+}
+
+///|
+fn combobox_next_match(
+  options : Array[ComboboxOption],
+  query : String,
+  current : Int,
+  direction : Int,
+) -> Int {
+  let length = options.length()
+  if length == 0 {
+    return -1
+  }
+  let mut index = current
+  let mut remaining = length
+  while remaining > 0 {
+    index = if direction < 0 {
+      if index <= 0 {
+        length - 1
+      } else {
+        index - 1
+      }
+    } else if index < 0 || index >= length - 1 {
+      0
+    } else {
+      index + 1
+    }
+    if !options[index].disabled && combobox_matches(options[index], query) {
+      return index
+    }
+    remaining -= 1
+  }
+  -1
+}
+
+///|
+fn combobox_normalize_values(
+  options : Array[ComboboxOption],
+  values : Array[String],
+  multiple : Bool,
+) -> Array[String] {
+  let result : Array[String] = []
+  for value in values {
+    let index = combobox_option_index(options, value)
+    if index >= 0 &&
+      !options[index].disabled &&
+      !combobox_contains(result, value) &&
+      (multiple || result.length() == 0) {
+      result.push(value)
+    }
+  }
+  result
+}
+
+///|
+fn combobox_remove_value(
+  values : Array[String],
+  value : String,
+) -> Array[String] {
+  let result : Array[String] = []
+  for current in values {
+    if current != value {
+      result.push(current)
+    }
+  }
+  result
+}
+
+///|
+fn combobox_toggle_value(
+  values : Array[String],
+  value : String,
+  multiple : Bool,
+) -> Array[String] {
+  if !multiple {
+    [value]
+  } else if combobox_contains(values, value) {
+    combobox_remove_value(values, value)
+  } else {
+    let next = values.copy()
+    next.push(value)
+    next
+  }
+}
+
+///|
+fn combobox_item_id(scope : ComboboxScope, index : Int) -> String {
+  "\{scope.id}-item-\{index}"
+}
+
+///|
+fn combobox_notify_open(notify : @cmd.Emit[Bool]?, value : Bool) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn combobox_notify_query(
+  notify : @cmd.Emit[String]?,
+  value : String,
+) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn combobox_notify_values(
+  on_value_change : @cmd.Emit[String]?,
+  on_values_change : @cmd.Emit[Array[String]]?,
+  values : Array[String],
+) -> @cmd.Cmd {
+  let commands : Array[@cmd.Cmd] = []
+  if on_values_change is Some(notify) {
+    commands.push(notify(values))
+  }
+  if on_value_change is Some(notify) {
+    commands.push(notify(if values.length() > 0 { values[0] } else { "" }))
+  }
+  @cmd.batch(commands)
+}
+
+///|
+#cfg(target="js")
+fn focus_combobox_control(id : String) -> Unit {
+  guard ui_element_by_id(id + "-root") is Some(root) else { return }
+  guard ui_find_descendant(root, element => {
+      let slot = element.get_attribute("data-slot").unwrap_or("")
+      slot == "combobox-input" ||
+      slot == "combobox-chip-input" ||
+      slot == "combobox-trigger"
+    })
+    is Some(control) else {
+    return
+  }
+  ui_focus_element(control)
+}
+
+///|
+#cfg(target="js")
+fn combobox_popup_cmd(
+  id : String,
+  open : Bool?,
+  focus_control : Bool,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    let set_layer = () => {
+      if open is Some(open) {
+        ui_listbox_set_open_now(id, "combobox-content", open)
+      }
+    }
+    let focus : (() -> Unit)? = if focus_control {
+      Some(() => focus_combobox_control(id))
+    } else {
+      None
+    }
+    ui_listbox_run_open_sequence(set_layer, focus)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn combobox_popup_cmd(
+  id : String,
+  open : Bool?,
+  focus_control : Bool,
+) -> @cmd.Cmd {
+  ignore((id, open, focus_control))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn bind_combobox_events(id : String, dispatch : (Int) -> Unit) -> Unit {
+  guard ui_element_by_id(id + "-root") is Some(root) else { return }
+  root.add_event_listener("focusout", event => {
+    guard event.to_focus_event() is Some(focus_event) else { return }
+    let stayed_inside = focus_event.related_target() is Some(related) &&
+      ui_element_contains_target(root, related)
+    if root.get_attribute("data-state").unwrap_or("") == "open" &&
+      !stayed_inside {
+      dispatch(7)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn combobox_root_mousedown(event : @dom.MouseEvent) -> @cmd.Cmd {
+  guard event.current_target().to_option() is Some(current_target) &&
+    current_target.to_element() is Some(root) &&
+    event.target().to_element() is Some(event_target) else {
+    return @cmd.none
+  }
+  if event_target.closest("[data-slot=\"combobox-item\"]") is Some(item) &&
+    item.closest("[data-slot=\"combobox\"]") is Some(owner) &&
+    owner.is_same_node(root.as_node()) {
+    event.prevent_default()
+  }
+  guard event_target.closest(
+      "[data-slot=\"combobox-trigger\"],[data-slot=\"combobox-clear\"]",
+    )
+    is Some(action) &&
+    action.closest("[data-slot=\"combobox\"]") is Some(owner) &&
+    owner.is_same_node(root.as_node()) else {
+    return @cmd.none
+  }
+  guard root.query_selector(
+      "[data-slot=\"combobox-input\"],[data-slot=\"combobox-chip-input\"]",
+    )
+    is Some(input) else {
+    return @cmd.none
+  }
+  event.prevent_default()
+  ui_focus_element_without_scroll(input)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn combobox_root_click(
+  scope : ComboboxScope,
+  event : @dom.MouseEvent,
+) -> @cmd.Cmd {
+  guard event.current_target().to_option() is Some(current_target) &&
+    current_target.to_element() is Some(root) &&
+    event.target().to_element() is Some(event_target) else {
+    return @cmd.none
+  }
+  guard event_target.closest(
+      "[data-slot=\"combobox-input\"],[data-slot=\"combobox-chip-input\"]",
+    )
+    is Some(target) &&
+    target.closest("[data-slot=\"combobox\"]") is Some(owner) &&
+    owner.is_same_node(root.as_node()) else {
+    return @cmd.none
+  }
+  (scope.emit)(ComboboxOpen)
+}
+
+///|
+#cfg(target="js")
+fn combobox_root_keydown(
+  scope : ComboboxScope,
+  event : @dom.KeyboardEvent,
+) -> @cmd.Cmd {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.is_composing() {
+    return @cmd.none
+  }
+  guard event.current_target().to_option() is Some(current_target) &&
+    current_target.to_element() is Some(root) &&
+    event.target().to_element() is Some(event_target) else {
+    return @cmd.none
+  }
+  guard event_target.closest(
+      "[data-slot=\"combobox-input\"],[data-slot=\"combobox-chip-input\"],[data-slot=\"combobox-item\"],[data-slot=\"combobox-trigger\"]",
+    )
+    is Some(target) &&
+    target.closest("[data-slot=\"combobox\"]") is Some(owner) &&
+    owner.is_same_node(root.as_node()) else {
+    return @cmd.none
+  }
+  let key = event.key()
+  let slot = target.get_attribute("data-slot").unwrap_or("")
+  let input = slot == "combobox-input" || slot == "combobox-chip-input"
+  if key == "Tab" && scope.model.open {
+    return (scope.emit)(ComboboxDismiss)
+  }
+  let message : ComboboxMsg? = match key {
+    "ArrowDown" => Some(ComboboxMove(1))
+    "ArrowUp" => Some(ComboboxMove(-1))
+    "Home" if !input => Some(ComboboxFirst)
+    "End" if !input => Some(ComboboxLast)
+    "Enter" if slot == "combobox-item" ||
+      (scope.model.open && target.has_attribute("aria-activedescendant")) =>
+      Some(ComboboxChoose(-1))
+    "Escape" if scope.model.open => Some(ComboboxClose)
+    _ => None
+  }
+  if message is Some(message) {
+    event.prevent_default()
+    (scope.emit)(message)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn combobox_bind_root_events(
+  attrs : @html.Attrs,
+  scope : ComboboxScope,
+) -> Unit {
+  ignore(attrs.on_mousedown(combobox_root_mousedown))
+  ignore(attrs.on_click(event => combobox_root_click(scope, event)))
+  ignore(attrs.on_keydown(event => combobox_root_keydown(scope, event)))
+}
+
+///|
+#cfg(not(target="js"))
+fn combobox_bind_root_events(
+  attrs : @html.Attrs,
+  scope : ComboboxScope,
+) -> Unit {
+  ignore((attrs, scope))
+}
+
+///|
+#cfg(target="js")
+fn combobox_bind_events_cmd(
+  id : String,
+  emit : @cmd.Emit[ComboboxMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id + "-root",
+      () => bind_combobox_events(id, _ => scheduler.add(emit(ComboboxDismiss))),
+      purpose="combobox-focusout",
+    )
+  })
+}
+
+///|
+fn combobox_root_attrs(
+  scope : ComboboxScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  let root_attrs = popup_state_attrs(attrs, "combobox", scope.model.open)
+    .data_set("multiple", ui_bool(scope.multiple))
+    .data_set("active-index", "\{scope.model.active}")
+  if scope.disabled {
+    ignore(root_attrs.data_set("disabled", "").aria_disabled("true"))
+  }
+  if scope.invalid {
+    ignore(root_attrs.data_set("invalid", "").aria_invalid("true"))
+  }
+  combobox_bind_root_events(root_attrs, scope)
+  root_attrs
+}
+
+///|
+pub fn combobox_value(
+  scope~ : ComboboxScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  prefix? : @html.Html,
+) -> @html.Html {
+  let empty = scope.model.values.length() == 0
+  let prefix_html = prefix.unwrap_or(@html.nothing)
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "combobox-value")
+      .data_set("placeholder", ui_bool(empty)),
+    style=ui_styles(
+      [
+        "display:flex;min-width:0;flex:1;align-items:center;gap:0.375rem;overflow:hidden;text-overflow:ellipsis",
+        if empty {
+          "color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    [
+      prefix_html,
+      @html.span(
+        style=["min-width:0;overflow:hidden;text-overflow:ellipsis"],
+        combobox_selected_label(scope),
+      ),
+    ],
+  )
+}
+
+///|
+pub fn combobox_trigger(
+  scope~ : ComboboxScope,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let resolved_id = id.unwrap_or("\{scope.id}-trigger")
+  if !scope.has_input.val {
+    scope.anchor_id.val = resolved_id
+  }
+  let trigger_attrs = popup_state_attrs(
+      attrs,
+      "combobox-trigger",
+      scope.model.open,
+    )
+    .aria_haspopup("listbox")
+    .aria_expanded(ui_bool(scope.model.open))
+  if scope.has_input.val {
+    ignore(trigger_attrs.tabindex(-1))
+  } else {
+    ignore(trigger_attrs.role("combobox"))
+  }
+  if scope.model.open {
+    ignore(trigger_attrs.aria_controls(scope.content_id.val))
+  }
+  if !scope.has_input.val && scope.model.open && scope.model.active >= 0 {
+    ignore(
+      trigger_attrs.aria_activedescendant(
+        combobox_item_id(scope, scope.model.active),
+      ),
+    )
+  }
+  if aria_label is Some(label) {
+    ignore(trigger_attrs.aria_label(label))
+  }
+  if !scope.disabled {
+    ignore(trigger_attrs.on_click(_ => (scope.emit)(ComboboxToggle)))
+  }
+  @html.button(
+    id=resolved_id,
+    class?,
+    title?,
+    type_="button",
+    disabled=scope.disabled,
+    attrs=trigger_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        SelectTriggerStyle,
+        input_invalid_style(scope.invalid),
+        ui_disabled_style(scope.disabled),
+        popup_anchor_style(resolved_id),
+      ],
+      style,
+    ),
+    [combobox_value(scope~), combobox_trigger_icon()],
+  )
+}
+
+///|
+#cfg(target="js")
+fn combobox_input_keydown(
+  scope : ComboboxScope,
+  event : @dom.KeyboardEvent,
+) -> @cmd.Cmd {
+  let key = event.key()
+  if scope.multiple &&
+    !scope.disabled &&
+    scope.model.query == "" &&
+    scope.model.values.length() > 0 &&
+    (key == "Backspace" || key == "Delete") &&
+    !event.alt_key() &&
+    !event.ctrl_key() &&
+    !event.meta_key() &&
+    !event.is_composing() {
+    event.prevent_default()
+    (scope.emit)(
+      ComboboxRemove(scope.model.values[scope.model.values.length() - 1]),
+    )
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn combobox_input_keyboard_attrs(
+  scope : ComboboxScope,
+  attrs : @html.Attrs,
+) -> @html.Attrs {
+  attrs.on_keydown(event => combobox_input_keydown(scope, event))
+}
+
+///|
+#cfg(not(target="js"))
+fn combobox_input_keyboard_attrs(
+  scope : ComboboxScope,
+  attrs : @html.Attrs,
+) -> @html.Attrs {
+  ignore(scope)
+  attrs
+}
+
+///|
+fn combobox_input_surface(
+  scope : ComboboxScope,
+  slot : String,
+  layout_style : String,
+  aria_label : String,
+  auto_complete : @html.AutoComplete,
+  id : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let resolved_id = id.unwrap_or("\{scope.id}-input")
+  scope.has_input.val = true
+  scope.anchor_id.val = resolved_id
+  let display_value = scope.model.query
+  let input_attrs = combobox_input_keyboard_attrs(
+    scope,
+    popup_state_attrs(attrs, slot, scope.model.open)
+    .role("combobox")
+    .aria_label(aria_label)
+    .aria_autocomplete("list")
+    .aria_expanded(ui_bool(scope.model.open))
+    .aria_haspopup("listbox")
+    .aria_invalid(ui_bool(scope.invalid))
+    .aria_required(ui_bool(scope.required)),
+  )
+  if scope.model.open {
+    ignore(input_attrs.aria_controls(scope.content_id.val))
+  }
+  if scope.model.open && scope.model.active >= 0 {
+    ignore(
+      input_attrs.aria_activedescendant(
+        combobox_item_id(scope, scope.model.active),
+      ),
+    )
+  }
+  if scope.disabled {
+    ignore(input_attrs.disabled(true))
+  }
+  @html.input(
+    input_type=@html.Text,
+    value=display_value,
+    placeholder=scope.placeholder,
+    auto_complete~,
+    id=resolved_id,
+    class?,
+    title?,
+    on_input=scope.emit.map(value => ComboboxSetQuery(value)),
+    attrs=input_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        layout_style,
+        ComboboxInputBaseStyle,
+        ui_disabled_style(scope.disabled),
+        popup_anchor_style(resolved_id),
+      ],
+      style,
+    ),
+  )
+}
+
+///|
+pub fn combobox_input(
+  scope~ : ComboboxScope,
+  aria_label? : String = "Search options",
+  auto_complete? : @html.AutoComplete = @html.Off,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  combobox_input_surface(
+    scope,
+    "combobox-input",
+    ComboboxInputLayoutStyle,
+    aria_label,
+    auto_complete,
+    id,
+    class,
+    title,
+    attrs,
+    style,
+  )
+}
+
+///|
+/// Render the query input inside a multi-select chips surface.
+///
+/// It shares the regular combobox input's value, ARIA active-descendant, query
+/// updates, focus opening, and keyboard navigation while exposing shadcn's
+/// singular `combobox-chip-input` data slot.
+pub fn combobox_chips_input(
+  scope~ : ComboboxScope,
+  aria_label? : String = "Search options",
+  auto_complete? : @html.AutoComplete = @html.Off,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  combobox_input_surface(
+    scope,
+    "combobox-chip-input",
+    ComboboxChipsInputLayoutStyle,
+    aria_label,
+    auto_complete,
+    id,
+    class,
+    title,
+    attrs,
+    style,
+  )
+}
+
+///|
+pub fn combobox_clear(
+  scope~ : ComboboxScope,
+  label? : String = "Clear selection",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let hidden = scope.model.values.length() == 0 && scope.model.query == ""
+  let clear_attrs = ui_attrs(attrs)
+    .aria_label(label)
+    .data_set("slot", "combobox-clear")
+    .data_set("variant", button_variant_value(Ghost))
+    .data_set("size", button_size_value(IconXs))
+    .tabindex(-1)
+  if !scope.disabled {
+    ignore(clear_attrs.on_click(_ => (scope.emit)(ComboboxClear)))
+  }
+  @html.button(
+    id?,
+    class?,
+    title?,
+    hidden~,
+    type_="button",
+    disabled=scope.disabled,
+    attrs=clear_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(Ghost),
+        button_size_style(IconXs),
+        "flex:none;--rui-button-base-fg:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:1rem",
+        ui_disabled_style(scope.disabled),
+      ],
+      style,
+    ),
+    ui_x_icon(),
+  )
+}
+
+///|
+fn combobox_default_trigger(scope : ComboboxScope) -> @html.Html {
+  let trigger_attrs = popup_state_attrs(
+      None,
+      "combobox-trigger",
+      scope.model.open,
+    )
+    .data_set("variant", button_variant_value(Ghost))
+    .data_set("size", button_size_value(IconXs))
+    .aria_label("Toggle options")
+    .aria_haspopup("listbox")
+    .aria_expanded(ui_bool(scope.model.open))
+    .tabindex(-1)
+  if scope.model.open {
+    ignore(trigger_attrs.aria_controls(scope.content_id.val))
+  }
+  if !scope.disabled {
+    ignore(trigger_attrs.on_click(_ => (scope.emit)(ComboboxToggle)))
+  }
+  @html.button(
+    type_="button",
+    disabled=scope.disabled,
+    attrs=trigger_attrs,
+    style=[
+      UiBoxSizing,
+      UiFontSans,
+      UiTextRendering,
+      UiTransition,
+      ButtonBaseStyle,
+      button_variant_style(Ghost),
+      button_size_style(IconXs),
+      "flex:none;--rui-button-base-fg:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:1rem",
+      ui_disabled_style(scope.disabled),
+    ],
+    combobox_trigger_icon(),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_list(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).role("presentation").data_set("slot", "combobox-list"),
+    style=ui_styles(["min-height:0;overflow-y:auto;padding:0.25rem"], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_item(
+  scope~ : ComboboxScope,
+  value~ : String,
+  disabled? : Bool,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let index = combobox_option_index(scope.options, value)
+  let option_disabled = if disabled is Some(disabled) {
+    disabled
+  } else if index >= 0 {
+    scope.options[index].disabled
+  } else {
+    false
+  }
+  let selected = combobox_contains(scope.model.values, value)
+  let active = scope.model.open && index >= 0 && scope.model.active == index
+  let item_attrs = ui_attrs(attrs)
+    .role("option")
+    .aria_selected(ui_bool(selected))
+    .aria_disabled(ui_bool(option_disabled))
+    .data_set("slot", "combobox-item")
+    .data_set("value", value)
+    .data_set("state", if selected { "checked" } else { "unchecked" })
+    .data_set("highlighted", ui_bool(active))
+    .tabindex(-1)
+  if option_disabled {
+    ignore(item_attrs.data_set("disabled", ""))
+  } else if index >= 0 {
+    ignore(item_attrs.on_click(_ => (scope.emit)(ComboboxChoose(index))))
+    ignore(
+      item_attrs.on_mouseenter(_ => (scope.emit)(ComboboxHighlight(index))),
+    )
+  }
+  @html.button(
+    id=id.unwrap_or(
+      if index >= 0 {
+        combobox_item_id(scope, index)
+      } else {
+        ""
+      },
+    ),
+    class?,
+    title?,
+    type_="button",
+    disabled=option_disabled,
+    attrs=item_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        ComboboxItemStyle,
+        if active {
+          "--rui-menu-item-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-menu-item-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+        } else {
+          ""
+        },
+        ui_disabled_visual_style(option_disabled),
+      ],
+      style,
+    ),
+    [
+      @html.span(
+        style=["min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis"],
+        children,
+      ),
+      if selected {
+        @html.span(
+          attrs=@html.Attrs::build()
+            .aria_hidden("true")
+            .data_set("slot", "combobox-item-indicator"),
+          style=[
+            "position:absolute;inset-inline-end:0.5rem;display:inline-flex;width:1rem;height:1rem;align-items:center;justify-content:center",
+          ],
+          ui_check_icon(),
+        )
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_group(
+  label_id? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let group_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "combobox-group")
+  if label_id is Some(label_id) {
+    ignore(group_attrs.aria_labelledby(label_id))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=group_attrs,
+    style=ui_styles(["padding:0.125rem 0"], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_label(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "combobox-label"),
+    style=ui_styles(
+      [
+        "padding:0.375rem 0.5rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;font-weight:500",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_collection(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "combobox-collection"),
+    style=ui_styles(["display:contents"], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_empty(
+  visible? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    hidden=!visible,
+    attrs=ui_attrs(attrs).role("status").data_set("slot", "combobox-empty"),
+    style=ui_styles(
+      [
+        "padding:1.5rem 0.75rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;text-align:center",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn combobox_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .role("separator")
+      .data_set("slot", "combobox-separator"),
+    style=ui_styles(
+      [
+        "height:1px;margin:0.25rem -0.25rem;background:var(--rui-border,oklch(0.922 0 0));pointer-events:none",
+      ],
+      style,
+    ),
+    "",
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_chips(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "combobox-chips"),
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTransition, ComboboxChipsStyle],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_chip(
+  scope~ : ComboboxScope,
+  value~ : String,
+  removable? : Bool = true,
+  remove_label? : String = "Remove",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "combobox-chip")
+      .data_set("value", value),
+    style=ui_styles(
+      [
+        "display:inline-flex;max-width:100%;height:1.5rem;align-items:center;gap:0.25rem;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-secondary,oklch(0.97 0 0));padding:0 0.375rem;color:var(--rui-secondary-foreground,oklch(0.205 0 0));font-size:0.75rem;line-height:1rem",
+      ],
+      style,
+    ),
+    [
+      @html.span(
+        style=["min-width:0;overflow:hidden;text-overflow:ellipsis"],
+        children,
+      ),
+      if removable {
+        @html.button(
+          type_="button",
+          disabled=scope.disabled,
+          attrs=@html.Attrs::build()
+            .aria_label("\{remove_label}: \{value}")
+            .data_set("slot", "combobox-chip-remove")
+            .data_set("variant", button_variant_value(Ghost))
+            .data_set("size", button_size_value(IconXs))
+            .on_click(_ => (scope.emit)(ComboboxRemove(value))),
+          style=ui_styles(
+            [
+              UiBoxSizing,
+              UiFontSans,
+              UiTransition,
+              ButtonBaseStyle,
+              button_variant_style(Ghost),
+              button_size_style(IconXs),
+              "margin-inline-start:-0.25rem;--rui-button-base-fg:inherit;opacity:var(--rui-chip-remove-opacity,0.5);font-size:0.875rem",
+              ui_disabled_style(scope.disabled),
+            ],
+            [],
+          ),
+          ui_x_icon(),
+        )
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] combobox_content(
+  scope~ : ComboboxScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let resolved_id = id.unwrap_or("\{scope.id}-content")
+  scope.content_id.val = resolved_id
+  let content_attrs = popup_state_attrs(
+      attrs,
+      "combobox-content",
+      scope.model.open,
+    )
+    .popover("auto")
+    .role("listbox")
+    .aria_multiselectable(ui_bool(scope.multiple))
+    .aria_required(ui_bool(scope.required))
+    .aria_invalid(ui_bool(scope.invalid))
+    .data_set("trigger-id", scope.anchor_id.val)
+    .data_set("requested-side", popup_side_value(scope.side))
+    .data_set("requested-align", popup_align_value(scope.align))
+    .data_set("side", popup_side_value(scope.side))
+    .data_set("align", popup_align_value(scope.align))
+    .data_set("side-offset", "\{scope.side_offset}")
+    .data_set("align-offset", "\{scope.align_offset}")
+  @html.div(
+    id=resolved_id,
+    class?,
+    title?,
+    attrs=content_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        ComboboxContentStyle,
+        PopupTransition100Style,
+        popup_floating_anchor_style(
+          scope.anchor_id.val,
+          scope.side,
+          scope.align,
+          scope.side_offset,
+          scope.align_offset,
+        ),
+        popup_state_style(scope.model.open),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+fn combobox_default_items(scope : ComboboxScope) -> @html.Html {
+  let items : Array[@html.Html] = []
+  let filter_query = combobox_filter_query(
+    scope.options,
+    scope.model.values,
+    scope.multiple,
+    scope.model.query,
+  )
+  for option in scope.options {
+    if combobox_matches(option, filter_query) {
+      items.push(combobox_item(scope~, value=option.value, option.label))
+    }
+  }
+  combobox_list([
+    combobox_empty(visible=items.length() == 0, scope.empty_text),
+    @html.fragment(items),
+  ])
+}
+
+///|
+fn combobox_default_view(scope : ComboboxScope) -> @html.Html {
+  let chips : Array[@html.Html] = []
+  if scope.multiple {
+    for value in scope.model.values {
+      let index = combobox_option_index(scope.options, value)
+      if index >= 0 {
+        chips.push(combobox_chip(scope~, value~, scope.options[index].label))
+      }
+    }
+  }
+  let action = if scope.model.values.length() > 0 || scope.model.query != "" {
+    combobox_clear(scope~)
+  } else {
+    combobox_default_trigger(scope)
+  }
+  let control_children : Array[@html.Html] = if scope.multiple {
+    [
+      combobox_chips(style=[input_invalid_style(scope.invalid)], [
+        @html.fragment(chips),
+        combobox_chips_input(scope~),
+        action,
+      ]),
+    ]
+  } else {
+    [combobox_input(scope~), action]
+  }
+  let control_id = "\{scope.id}-control"
+  scope.anchor_id.val = control_id
+  let control = @html.div(
+    id=control_id,
+    attrs=@html.Attrs::build().data_set("slot", "combobox-control"),
+    style=[
+      UiBoxSizing,
+      if scope.multiple {
+        ComboboxControlLayoutStyle
+      } else {
+        ComboboxControlStyle
+      },
+      if scope.multiple {
+        ""
+      } else {
+        input_invalid_style(scope.invalid)
+      },
+      popup_anchor_style(control_id),
+    ],
+    control_children,
+  )
+  @html.fragment([
+    control,
+    combobox_content(scope~, combobox_default_items(scope)),
+  ])
+}
+
+///|
+fn combobox_hidden_inputs(scope : ComboboxScope) -> @html.Html {
+  if scope.name is Some(name) {
+    let controls : Array[@html.Html] = []
+    if scope.model.values.length() == 0 {
+      controls.push(
+        @html.input(
+          input_type=@html.Hidden,
+          name~,
+          value="",
+          attrs=@html.Attrs::build().disabled(scope.disabled),
+        ),
+      )
+    } else {
+      for value in scope.model.values {
+        controls.push(
+          @html.input(
+            input_type=@html.Hidden,
+            name~,
+            value~,
+            attrs=@html.Attrs::build().disabled(scope.disabled),
+          ),
+        )
+      }
+    }
+    @html.fragment(controls)
+  } else {
+    @html.nothing
+  }
+}
+
+///|
+fn combobox_render(
+  scope : ComboboxScope,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  render : ((ComboboxScope) -> @html.Html)?,
+) -> @html.Html {
+  @html.div(
+    id="\{scope.id}-root",
+    class?,
+    title?,
+    attrs=combobox_root_attrs(scope, attrs),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        ComboboxRootStyle,
+        ui_disabled_visual_style(scope.disabled),
+      ],
+      style,
+    ),
+    [
+      combobox_hidden_inputs(scope),
+      if render is Some(render) {
+        // Discover a custom popup id before rendering an earlier input or
+        // trigger so their aria-controls references the actual listbox.
+        ignore(render(scope))
+        render(scope)
+      } else {
+        combobox_default_view(scope)
+      },
+    ],
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn combobox(
+  id~ : String,
+  options~ : Array[ComboboxOption],
+  default_value? : String,
+  default_values? : Array[String] = [],
+  multiple? : Bool = false,
+  default_open? : Bool = false,
+  placeholder? : String = "Select an option",
+  empty_text? : String = "No results found.",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  required? : Bool = false,
+  name? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  on_value_change? : @cmd.Emit[String],
+  on_values_change? : @cmd.Emit[Array[String]],
+  on_query_change? : @cmd.Emit[String],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render? : (ComboboxScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let requested = default_values.copy()
+  if default_value is Some(value) && !combobox_contains(requested, value) {
+    requested.push(value)
+  }
+  let values = combobox_normalize_values(options, requested, multiple)
+  let initial_query = combobox_selected_input_value(options, values, multiple)
+  let initial : ComboboxModel = {
+    open: default_open && !disabled,
+    query: initial_query,
+    values,
+    active: -1,
+  }
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        @cmd.batch([
+          ui_listbox_bind_sync_cmd(
+            id,
+            "combobox-content",
+            emit.map(value => ComboboxNativeChanged(value)),
+          ),
+          combobox_bind_events_cmd(id, emit),
+          if initial.open {
+            combobox_popup_cmd(id, Some(true), false)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(_, message, current) => {
+      match message {
+        ComboboxOpen =>
+          if disabled || current.open {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, open: true, active: -1 },
+              @cmd.batch([
+                combobox_popup_cmd(id, Some(true), false),
+                combobox_notify_open(on_open_change, true),
+              ]),
+            )
+          }
+        ComboboxToggle =>
+          if disabled {
+            (current, @cmd.none)
+          } else {
+            let open = !current.open
+            let query = if open {
+              current.query
+            } else {
+              combobox_selected_input_value(options, current.values, multiple)
+            }
+            (
+              { ..current, open, query, active: -1 },
+              @cmd.batch([
+                combobox_popup_cmd(id, Some(open), true),
+                if query != current.query {
+                  combobox_notify_query(on_query_change, query)
+                } else {
+                  @cmd.none
+                },
+                combobox_notify_open(on_open_change, open),
+              ]),
+            )
+          }
+        ComboboxNativeChanged(open) =>
+          if current.open == open {
+            (current, @cmd.none)
+          } else if open {
+            (
+              { ..current, open: true, active: -1 },
+              combobox_notify_open(on_open_change, true),
+            )
+          } else {
+            let query = combobox_selected_input_value(
+              options,
+              current.values,
+              multiple,
+            )
+            (
+              { ..current, open: false, query, active: -1 },
+              @cmd.batch([
+                combobox_notify_open(on_open_change, false),
+                if query != current.query {
+                  combobox_notify_query(on_query_change, query)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        ComboboxSetQuery(query) => {
+          let clearing_selection = !multiple &&
+            query == "" &&
+            current.values.length() > 0
+          let values = if clearing_selection { [] } else { current.values }
+          (
+            { open: true, query, values, active: -1 },
+            @cmd.batch([
+              combobox_popup_cmd(id, Some(true), false),
+              if current.open {
+                @cmd.none
+              } else {
+                combobox_notify_open(on_open_change, true)
+              },
+              if clearing_selection {
+                combobox_notify_values(
+                  on_value_change, on_values_change, values,
+                )
+              } else {
+                @cmd.none
+              },
+              combobox_notify_query(on_query_change, query),
+            ]),
+          )
+        }
+        ComboboxMove(direction) => {
+          let filter_query = combobox_filter_query(
+            options,
+            current.values,
+            multiple,
+            current.query,
+          )
+          let active = combobox_next_match(
+            options,
+            filter_query,
+            current.active,
+            direction,
+          )
+          (
+            { ..current, open: true, active },
+            @cmd.batch([
+              combobox_popup_cmd(id, Some(true), false),
+              if current.open {
+                @cmd.none
+              } else {
+                combobox_notify_open(on_open_change, true)
+              },
+            ]),
+          )
+        }
+        ComboboxFirst => {
+          let filter_query = combobox_filter_query(
+            options,
+            current.values,
+            multiple,
+            current.query,
+          )
+          let active = combobox_first_match(options, filter_query, false)
+          ({ ..current, active, }, @cmd.none)
+        }
+        ComboboxLast => {
+          let filter_query = combobox_filter_query(
+            options,
+            current.values,
+            multiple,
+            current.query,
+          )
+          let active = combobox_first_match(options, filter_query, true)
+          ({ ..current, active, }, @cmd.none)
+        }
+        ComboboxHighlight(index) => ({ ..current, active: index }, @cmd.none)
+        ComboboxChoose(requested_index) => {
+          let index = if requested_index < 0 {
+            current.active
+          } else {
+            requested_index
+          }
+          if index < 0 ||
+            index >= options.length() ||
+            options[index].disabled ||
+            !combobox_matches(
+              options[index],
+              combobox_filter_query(
+                options,
+                current.values,
+                multiple,
+                current.query,
+              ),
+            ) {
+            (current, @cmd.none)
+          } else {
+            let values = combobox_toggle_value(
+              current.values,
+              options[index].value,
+              multiple,
+            )
+            let open = multiple
+            let query = combobox_selected_input_value(options, values, multiple)
+            (
+              { values, open, query, active: if multiple { index } else { -1 } },
+              @cmd.batch([
+                combobox_notify_values(
+                  on_value_change, on_values_change, values,
+                ),
+                combobox_notify_query(on_query_change, query),
+                combobox_popup_cmd(
+                  id,
+                  if multiple {
+                    None
+                  } else {
+                    Some(false)
+                  },
+                  true,
+                ),
+                if multiple {
+                  @cmd.none
+                } else {
+                  combobox_notify_open(on_open_change, false)
+                },
+              ]),
+            )
+          }
+        }
+        ComboboxRemove(value) => {
+          let values = combobox_remove_value(current.values, value)
+          (
+            { ..current, values, },
+            combobox_notify_values(on_value_change, on_values_change, values),
+          )
+        }
+        ComboboxClear =>
+          (
+            { ..current, values: [], query: "", active: -1 },
+            @cmd.batch([
+              combobox_notify_values(on_value_change, on_values_change, []),
+              combobox_notify_query(on_query_change, ""),
+              combobox_popup_cmd(id, None, true),
+            ]),
+          )
+        ComboboxClose =>
+          if current.open {
+            let query = combobox_selected_input_value(
+              options,
+              current.values,
+              multiple,
+            )
+            (
+              { ..current, open: false, query, active: -1 },
+              @cmd.batch([
+                combobox_popup_cmd(id, Some(false), false),
+                combobox_notify_open(on_open_change, false),
+                if query != current.query {
+                  combobox_notify_query(on_query_change, query)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        ComboboxDismiss =>
+          if current.open {
+            let query = combobox_selected_input_value(
+              options,
+              current.values,
+              multiple,
+            )
+            (
+              { ..current, open: false, query, active: -1 },
+              @cmd.batch([
+                combobox_popup_cmd(id, Some(false), false),
+                combobox_notify_open(on_open_change, false),
+                if query != current.query {
+                  combobox_notify_query(on_query_change, query)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+      }
+    },
+  )
+  model.view(model => {
+    combobox_render(
+      {
+        id,
+        options,
+        model,
+        multiple,
+        placeholder,
+        empty_text,
+        disabled,
+        invalid,
+        required,
+        name,
+        side,
+        align,
+        side_offset,
+        align_offset,
+        emit,
+        content_id: Ref("\{id}-content"),
+        anchor_id: Ref("\{id}-input"),
+        has_input: Ref(false),
+      },
+      class,
+      title,
+      attrs,
+      style,
+      render,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn combobox(
+  id~ : String,
+  options~ : Array[ComboboxOption],
+  default_value? : String,
+  default_values? : Array[String] = [],
+  multiple? : Bool = false,
+  default_open? : Bool = false,
+  placeholder? : String = "Select an option",
+  empty_text? : String = "No results found.",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  required? : Bool = false,
+  name? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  on_value_change? : @cmd.Emit[String],
+  on_values_change? : @cmd.Emit[Array[String]],
+  on_query_change? : @cmd.Emit[String],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render? : (ComboboxScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_change, on_values_change, on_query_change, on_open_change))
+  let requested = default_values.copy()
+  if default_value is Some(value) && !combobox_contains(requested, value) {
+    requested.push(value)
+  }
+  let model : ComboboxModel = {
+    open: default_open && !disabled,
+    query: combobox_selected_input_value(
+      options,
+      combobox_normalize_values(options, requested, multiple),
+      multiple,
+    ),
+    values: combobox_normalize_values(options, requested, multiple),
+    active: -1,
+  }
+  @rabbita.Val::constant(
+    combobox_render(
+      {
+        id,
+        options,
+        model,
+        multiple,
+        placeholder,
+        empty_text,
+        disabled,
+        invalid,
+        required,
+        name,
+        side,
+        align,
+        side_offset,
+        align_offset,
+        emit: @cmd.Emit(_ => @cmd.none),
+        content_id: Ref("\{id}-content"),
+        anchor_id: Ref("\{id}-input"),
+        has_input: Ref(false),
+      },
+      class,
+      title,
+      attrs,
+      style,
+      render,
+    ),
+  )
+}

--- a/rui/command.mbt
+++ b/rui/command.mbt
@@ -1,0 +1,1425 @@
+///|
+priv struct CommandModel {
+  query : String
+  active : Int
+  open : Bool
+  generation : Int
+} derive(Eq)
+
+///|
+priv enum CommandMessage {
+  CommandSetQuery(String, Int)
+  CommandSetActive(Int)
+  CommandSelect(String, @cmd.Cmd)
+  CommandOpen
+  CommandRequestClose
+  CommandFinalizeClose(Int)
+  CommandDidClose(String)
+}
+
+///|
+priv struct CommandEntry {
+  value : String
+  keywords : Array[String]
+  disabled : Bool
+  force_mount : Bool
+  id : String?
+  select_command : @cmd.Cmd
+}
+
+///|
+/// Opaque state supplied to every compound command part.
+///
+/// The scope deliberately replaces a global context: query, active option,
+/// filtering, dialog state, and commands stay local to one Rabbita value.
+struct CommandScope {
+  root_id : String
+  dialog_id : String?
+  model : CommandModel
+  catalog : Array[CommandEntry]
+  collecting : Bool
+  cursor : Ref[Int]
+  group_cursor : Ref[Int]
+  list_id : Ref[String]
+  filter : (String, String, Array[String]) -> Bool
+  should_filter : Bool
+  dialog : Bool
+  close_on_escape : Bool
+  emit : @cmd.Emit[CommandMessage]
+  open_command : @cmd.Cmd
+  close_command : @cmd.Cmd
+  native_open : Bool?
+  native_on_close : @cmd.Emit[String]?
+  native_on_cancel : @cmd.Cmd?
+}
+
+///|
+const CommandRootStyle : String = "display:flex;width:100%;min-width:0;flex-direction:column;overflow:hidden;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem);background:var(--rui-popover,var(--rui-background,oklch(1 0 0)));color:var(--rui-popover-foreground,var(--rui-foreground,oklch(0.145 0 0)));box-shadow:0 1px 2px rgb(0 0 0 / 0.05)"
+
+///|
+const CommandDialogRootStyle : String = "border:0;border-radius:inherit;padding:0.25rem;box-shadow:none"
+
+///|
+const CommandDialogOverlayStyle : String = "background:rgb(0 0 0 / 0.1);-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px)"
+
+///|
+const CommandDialogContentStyle : String = "position:relative;width:min(100%,32rem);max-height:calc(100vh - 2rem);overflow:hidden;border:0;border-radius:calc(var(--rui-radius,0.625rem) + 0.25rem);background:var(--rui-popover,var(--rui-background,oklch(1 0 0)));color:var(--rui-popover-foreground,var(--rui-foreground,oklch(0.145 0 0)));box-shadow:0 0 0 1px color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);opacity:var(--rui-dialog-content-opacity,1);transform:var(--rui-dialog-content-transform,translateY(0) scale(1));pointer-events:auto;transition:opacity 200ms ease,transform 200ms ease"
+
+///|
+const CommandInputWrapperStyle : String = "display:flex;min-width:0;align-items:center;gap:0.625rem;border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));padding-inline:0.75rem"
+
+///|
+const CommandInputStyle : String = "width:100%;min-width:0;height:3rem;border:0;background:transparent;padding:0;color:inherit;font-size:0.875rem;line-height:1.25rem;outline:none;appearance:none;-webkit-appearance:none"
+
+///|
+const CommandListStyle : String = "min-height:0;max-height:18.75rem;overflow-x:hidden;overflow-y:auto;padding:0.25rem"
+
+///|
+const CommandEmptyStyle : String = "padding:1.5rem 0.75rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem;text-align:center"
+
+///|
+const CommandGroupStyle : String = "min-width:0;padding:0.25rem"
+
+///|
+const CommandGroupHeadingStyle : String = "padding:0.375rem 0.5rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;font-weight:500"
+
+///|
+const CommandItemStyle : String = "position:relative;display:flex;width:100%;min-width:0;min-height:2rem;align-items:center;gap:0.5rem;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent));padding:0.375rem 0.5rem;color:var(--rui-menu-item-fg,var(--rui-menu-item-base-fg,inherit));font-size:0.875rem;line-height:1.25rem;text-align:start;outline:none;cursor:default;user-select:none"
+
+///|
+const CommandItemActiveStyle : String = "--rui-menu-item-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-menu-item-base-fg:var(--rui-accent-foreground,var(--rui-foreground,oklch(0.145 0 0)))"
+
+///|
+const CommandSeparatorStyle : String = "height:1px;margin:0.25rem -0.25rem;background:var(--rui-border,oklch(0.922 0 0));pointer-events:none"
+
+///|
+const CommandShortcutStyle : String = "margin-inline-start:auto;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;letter-spacing:0.08em"
+
+///|
+fn command_default_filter(
+  query : String,
+  value : String,
+  keywords : Array[String],
+) -> Bool {
+  if query == "" {
+    return true
+  }
+  let needle = query.to_lower()
+  if value.to_lower().contains(needle) {
+    return true
+  }
+  for keyword in keywords {
+    if keyword.to_lower().contains(needle) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn command_entry_matches(
+  entry : CommandEntry,
+  query : String,
+  should_filter : Bool,
+  filter : (String, String, Array[String]) -> Bool,
+) -> Bool {
+  entry.force_mount ||
+  !should_filter ||
+  filter(query, entry.value, entry.keywords)
+}
+
+///|
+fn command_match_count(scope : CommandScope) -> Int {
+  let mut count = 0
+  for entry in scope.catalog {
+    if command_entry_matches(
+        entry,
+        scope.model.query,
+        scope.should_filter,
+        scope.filter,
+      ) {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+fn command_entry_enabled(scope : CommandScope, index : Int) -> Bool {
+  index >= 0 &&
+  index < scope.catalog.length() &&
+  !scope.catalog[index].disabled &&
+  command_entry_matches(
+    scope.catalog[index],
+    scope.model.query,
+    scope.should_filter,
+    scope.filter,
+  )
+}
+
+///|
+fn command_first_match(
+  catalog : Array[CommandEntry],
+  query : String,
+  reverse : Bool,
+  should_filter : Bool,
+  filter : (String, String, Array[String]) -> Bool,
+) -> Int {
+  if reverse {
+    let mut index = catalog.length() - 1
+    while index >= 0 {
+      let entry = catalog[index]
+      if !entry.disabled &&
+        command_entry_matches(entry, query, should_filter, filter) {
+        return index
+      }
+      index -= 1
+    }
+  } else {
+    for index, entry in catalog {
+      if !entry.disabled &&
+        command_entry_matches(entry, query, should_filter, filter) {
+        return index
+      }
+    }
+  }
+  -1
+}
+
+///|
+fn command_next_match(scope : CommandScope, direction : Int) -> Int {
+  let length = scope.catalog.length()
+  if length == 0 {
+    return -1
+  }
+  let mut index = scope.model.active
+  let mut remaining = length
+  while remaining > 0 {
+    index = if direction < 0 {
+      if index <= 0 {
+        length - 1
+      } else {
+        index - 1
+      }
+    } else if index < 0 || index >= length - 1 {
+      0
+    } else {
+      index + 1
+    }
+    if command_entry_enabled(scope, index) {
+      return index
+    }
+    remaining -= 1
+  }
+  -1
+}
+
+///|
+fn command_item_id(scope : CommandScope, index : Int) -> String {
+  if index >= 0 &&
+    index < scope.catalog.length() &&
+    scope.catalog[index].id is Some(id) {
+    id
+  } else {
+    "\{scope.root_id}-item-\{index}"
+  }
+}
+
+///|
+fn command_input_id(scope : CommandScope) -> String {
+  "\{scope.root_id}-input"
+}
+
+///|
+fn command_list_id(scope : CommandScope) -> String {
+  scope.list_id.val
+}
+
+///|
+fn command_notify_string(
+  notify : @cmd.Emit[String]?,
+  value : String,
+) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn command_notify_bool(notify : @cmd.Emit[Bool]?, value : Bool) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn command_scroll_active_now(root_id : String, index : Int) -> Unit {
+  guard ui_element_by_id(root_id) is Some(root) else { return }
+  guard root.query_selector("[data-command-index=\"\{index}\"]") is Some(option) else {
+    return
+  }
+  option.scroll_into_view_with_options(block="nearest")
+}
+
+///|
+#cfg(target="js")
+fn command_scroll_active(root_id : String, index : Int) -> @cmd.Cmd {
+  if index < 0 {
+    return @cmd.none
+  }
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    command_scroll_active_now(root_id, index)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn command_scroll_active(root_id : String, index : Int) -> @cmd.Cmd {
+  ignore((root_id, index))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn command_keyboard_attrs(
+  scope : CommandScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  let root_attrs = ui_attrs(attrs)
+    .data_set("slot", "command")
+    .data_set("state", if scope.model.open { "open" } else { "closed" })
+    .data_set("filtered-count", "\{command_match_count(scope)}")
+  ignore(
+    root_attrs.on_keydown(event => {
+      if event.alt_key() ||
+        event.ctrl_key() ||
+        event.meta_key() ||
+        event.is_composing() {
+        return @cmd.none
+      }
+      let key = event.key()
+      if key == "ArrowDown" {
+        event.prevent_default()
+        (scope.emit)(CommandSetActive(command_next_match(scope, 1)))
+      } else if key == "ArrowUp" {
+        event.prevent_default()
+        (scope.emit)(CommandSetActive(command_next_match(scope, -1)))
+      } else if key == "Home" {
+        event.prevent_default()
+        (scope.emit)(
+          CommandSetActive(
+            command_first_match(
+              scope.catalog,
+              scope.model.query,
+              false,
+              scope.should_filter,
+              scope.filter,
+            ),
+          ),
+        )
+      } else if key == "End" {
+        event.prevent_default()
+        (scope.emit)(
+          CommandSetActive(
+            command_first_match(
+              scope.catalog,
+              scope.model.query,
+              true,
+              scope.should_filter,
+              scope.filter,
+            ),
+          ),
+        )
+      } else if key == "Enter" &&
+        command_entry_enabled(scope, scope.model.active) {
+        event.prevent_default()
+        let entry = scope.catalog[scope.model.active]
+        (scope.emit)(CommandSelect(entry.value, entry.select_command))
+      } else if key == "Escape" && scope.dialog && scope.close_on_escape {
+        event.prevent_default()
+        scope.close_command
+      } else if key == "Escape" && !scope.dialog && scope.model.query != "" {
+        event.prevent_default()
+        (scope.emit)(
+          CommandSetQuery(
+            "",
+            command_first_match(
+              scope.catalog,
+              "",
+              false,
+              scope.should_filter,
+              scope.filter,
+            ),
+          ),
+        )
+      } else {
+        @cmd.none
+      }
+    }),
+  )
+  root_attrs
+}
+
+///|
+#cfg(not(target="js"))
+fn command_keyboard_attrs(
+  scope : CommandScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  ui_attrs(attrs)
+  .data_set("slot", "command")
+  .data_set("state", if scope.model.open { "open" } else { "closed" })
+  .data_set("filtered-count", "\{command_match_count(scope)}")
+}
+
+///|
+#cfg(not(target="js"))
+fn command_noop_emit() -> @cmd.Emit[CommandMessage] {
+  @cmd.Emit(_ => @cmd.none)
+}
+
+///|
+fn command_scope(
+  root_id : String,
+  dialog_id : String?,
+  model : CommandModel,
+  catalog : Array[CommandEntry],
+  collecting : Bool,
+  filter : (String, String, Array[String]) -> Bool,
+  should_filter : Bool,
+  dialog : Bool,
+  close_on_escape : Bool,
+  emit : @cmd.Emit[CommandMessage],
+  native_open : Bool?,
+  native_on_close : @cmd.Emit[String]?,
+  native_on_cancel : @cmd.Cmd?,
+  list_id : Ref[String],
+) -> CommandScope {
+  {
+    root_id,
+    dialog_id,
+    model,
+    catalog,
+    collecting,
+    cursor: Ref(0),
+    group_cursor: Ref(0),
+    list_id,
+    filter,
+    should_filter,
+    dialog,
+    close_on_escape,
+    emit,
+    open_command: emit(CommandOpen),
+    close_command: emit(CommandRequestClose),
+    native_open,
+    native_on_close,
+    native_on_cancel,
+  }
+}
+
+///|
+fn command_effective_model(
+  model : CommandModel,
+  catalog : Array[CommandEntry],
+  should_filter : Bool,
+  filter : (String, String, Array[String]) -> Bool,
+) -> CommandModel {
+  let active = if model.active >= 0 &&
+    model.active < catalog.length() &&
+    !catalog[model.active].disabled &&
+    command_entry_matches(
+      catalog[model.active],
+      model.query,
+      should_filter,
+      filter,
+    ) {
+    model.active
+  } else {
+    command_first_match(catalog, model.query, false, should_filter, filter)
+  }
+  { ..model, active, }
+}
+
+///|
+fn command_surface(
+  root_id : String,
+  dialog_id : String?,
+  model : CommandModel,
+  filter : (String, String, Array[String]) -> Bool,
+  should_filter : Bool,
+  dialog : Bool,
+  close_on_escape : Bool,
+  emit : @cmd.Emit[CommandMessage],
+  native_open : Bool?,
+  native_on_close : @cmd.Emit[String]?,
+  native_on_cancel : @cmd.Cmd?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (CommandScope) -> @html.Html,
+) -> (@html.Html, CommandScope) {
+  // The first pure pass records item metadata. The second pass can therefore
+  // render CommandEmpty and aria-activedescendant correctly regardless of the
+  // order in which compound parts appear.
+  let catalog : Array[CommandEntry] = []
+  let list_id = Ref("\{root_id}-list")
+  let collecting_scope = command_scope(
+    root_id, dialog_id, model, catalog, true, filter, should_filter, dialog, close_on_escape,
+    emit, native_open, native_on_close, native_on_cancel, list_id,
+  )
+  ignore(children(collecting_scope))
+  let effective_model = command_effective_model(
+    model, catalog, should_filter, filter,
+  )
+  let scope = command_scope(
+    root_id, dialog_id, effective_model, catalog, false, filter, should_filter, dialog,
+    close_on_escape, emit, native_open, native_on_close, native_on_cancel, list_id,
+  )
+  let content = children(scope)
+  let root_styles = if dialog {
+    [
+      UiBoxSizing,
+      UiFontSans,
+      UiTextRendering,
+      CommandRootStyle,
+      CommandDialogRootStyle,
+    ]
+  } else {
+    [UiBoxSizing, UiFontSans, UiTextRendering, CommandRootStyle]
+  }
+  let html = @html.div(
+    style=ui_styles(root_styles, style),
+    id=root_id,
+    class?,
+    title?,
+    attrs=command_keyboard_attrs(scope, attrs),
+    content,
+  )
+  (html, scope)
+}
+
+///|
+/// Read the current normalized query without exposing the scope representation.
+pub fn command_query(scope : CommandScope) -> String {
+  scope.model.query
+}
+
+///|
+pub fn command_is_open(scope : CommandScope) -> Bool {
+  scope.model.open
+}
+
+///|
+/// Return commands for custom dialog triggers or dismiss controls.
+pub fn command_open(scope : CommandScope) -> @cmd.Cmd {
+  scope.open_command
+}
+
+///|
+pub fn command_close(scope : CommandScope) -> @cmd.Cmd {
+  scope.close_command
+}
+
+///|
+/// Render the ARIA combobox input that owns focus while options use
+/// `aria-activedescendant`.
+pub fn command_input(
+  scope~ : CommandScope,
+  placeholder? : String = "Type a command or search...",
+  aria_label? : String = "Search commands",
+  auto_complete? : @html.AutoComplete = @html.Off,
+  disabled? : Bool = false,
+  on_input? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  input_style? : Array[String] = [],
+) -> @html.Html {
+  if scope.collecting {
+    return @html.nothing
+  }
+  let input_attrs = ui_attrs(attrs)
+    .data_set("slot", "command-input")
+    .role("combobox")
+    .aria_label(aria_label)
+    .aria_autocomplete("list")
+    .aria_expanded(ui_bool(if scope.dialog { scope.model.open } else { true }))
+    .aria_controls(command_list_id(scope))
+  if scope.model.active >= 0 {
+    ignore(
+      input_attrs.aria_activedescendant(
+        command_item_id(scope, scope.model.active),
+      ),
+    )
+  }
+  if disabled {
+    ignore(input_attrs.disabled(true).aria_disabled("true"))
+  }
+  let set_query = @cmd.Emit(query => {
+    let active = command_first_match(
+      scope.catalog,
+      query,
+      false,
+      scope.should_filter,
+      scope.filter,
+    )
+    @cmd.batch([
+      if on_input is Some(notify) {
+        notify(query)
+      } else {
+        @cmd.none
+      },
+      (scope.emit)(CommandSetQuery(query, active)),
+    ])
+  })
+  @html.div(
+    style=ui_styles([UiBoxSizing, CommandInputWrapperStyle], style),
+    attrs=@html.Attrs::build().data_set("slot", "command-input-wrapper"),
+    [
+      @html.span(
+        style=[
+          UiBoxSizing,
+          "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:1rem",
+        ],
+        attrs=@html.Attrs::build()
+          .data_set("slot", "command-input-icon")
+          .aria_hidden("true"),
+        ui_search_icon(),
+      ),
+      @html.input(
+        input_type=@html.Text,
+        value=scope.model.query,
+        placeholder~,
+        auto_complete~,
+        style=ui_styles(
+          [
+            UiBoxSizing,
+            UiFontSans,
+            UiTextRendering,
+            CommandInputStyle,
+            ui_disabled_style(disabled),
+          ],
+          input_style,
+        ),
+        id=id.unwrap_or(command_input_id(scope)),
+        class?,
+        title?,
+        on_input=set_query,
+        attrs=input_attrs,
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] command_list(
+  scope~ : CommandScope,
+  aria_label? : String = "Commands",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  if scope.collecting {
+    scope.list_id.val = id.unwrap_or("\{scope.root_id}-list")
+    return @html.nothing
+  }
+  @html.div(
+    style=ui_styles([UiBoxSizing, CommandListStyle], style),
+    id=id.unwrap_or(command_list_id(scope)),
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "command-list")
+      .data_set("count", "\{command_match_count(scope)}")
+      .role("listbox")
+      .aria_label(aria_label),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] command_empty(
+  scope~ : CommandScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  if scope.collecting {
+    return @html.nothing
+  }
+  let visible = command_match_count(scope) == 0
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        CommandEmptyStyle,
+        if visible {
+          ""
+        } else {
+          "display:none"
+        },
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden=!visible,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "command-empty")
+      .data_set("state", if visible { "visible" } else { "hidden" })
+      .role("status")
+      .aria_live("polite"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] command_group(
+  scope~ : CommandScope,
+  heading? : String,
+  heading_id? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  heading_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  if scope.collecting {
+    return @html.nothing
+  }
+  let group_index = scope.group_cursor.val
+  scope.group_cursor.val += 1
+  let resolved_heading_id = heading_id.unwrap_or(
+    "\{scope.root_id}-group-\{group_index}-heading",
+  )
+  let group_attrs = ui_attrs(attrs)
+    .data_set("slot", "command-group")
+    .role("group")
+  if heading is Some(_) {
+    ignore(group_attrs.aria_labelledby(resolved_heading_id))
+  }
+  @html.div(
+    style=ui_styles([UiBoxSizing, CommandGroupStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=group_attrs,
+    [
+      if heading is Some(heading) {
+        @html.div(
+          style=ui_styles(
+            [UiBoxSizing, CommandGroupHeadingStyle],
+            heading_style,
+          ),
+          id=resolved_heading_id,
+          attrs=@html.Attrs::build().data_set("slot", "command-group-heading"),
+          heading,
+        )
+      } else {
+        @html.nothing
+      },
+      @html.div(
+        style=[UiBoxSizing, "display:contents"],
+        attrs=@html.Attrs::build().data_set("slot", "command-group-items"),
+        children,
+      ),
+    ],
+  )
+}
+
+///|
+pub fn command_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, CommandSeparatorStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "command-separator")
+      .role("separator")
+      .aria_orientation("horizontal"),
+    @html.nothing,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] command_item(
+  scope~ : CommandScope,
+  value~ : String,
+  keywords? : Array[String] = [],
+  disabled? : Bool = false,
+  force_mount? : Bool = false,
+  on_select? : @cmd.Emit[String],
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let commands : Array[@cmd.Cmd] = []
+  if on_click is Some(command) {
+    commands.push(command)
+  }
+  if on_select is Some(notify) {
+    commands.push(notify(value))
+  }
+  let entry : CommandEntry = {
+    value,
+    keywords,
+    disabled,
+    force_mount,
+    id,
+    select_command: @cmd.batch(commands),
+  }
+  if scope.collecting {
+    scope.catalog.push(entry)
+    return @html.nothing
+  }
+  let index = scope.cursor.val
+  scope.cursor.val += 1
+  let visible = command_entry_matches(
+    entry,
+    scope.model.query,
+    scope.should_filter,
+    scope.filter,
+  )
+  let active = visible && !disabled && scope.model.active == index
+  let item_attrs = ui_attrs(attrs)
+    .data_set("slot", "command-item")
+    .data_set("value", value)
+    .data_set("keywords", keywords.join(" "))
+    .data_set("command-index", "\{index}")
+    .data_set("state", if active { "active" } else { "inactive" })
+    .data_set("selected", ui_bool(active))
+    .role("option")
+    .aria_selected(ui_bool(active))
+    .aria_disabled(ui_bool(disabled))
+    .tabindex(-1)
+  if disabled {
+    ignore(item_attrs.data_set("disabled", ""))
+  } else if visible {
+    ignore(
+      item_attrs
+      .on_click(_ => (scope.emit)(CommandSelect(value, entry.select_command)))
+      .on_mouseenter(_ => (scope.emit)(CommandSetActive(index))),
+    )
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        CommandItemStyle,
+        if active {
+          CommandItemActiveStyle
+        } else {
+          ""
+        },
+        if visible {
+          ""
+        } else {
+          "display:none"
+        },
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id=id.unwrap_or(command_item_id(scope, index)),
+    class?,
+    title?,
+    hidden=!visible,
+    attrs=item_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] command_shortcut(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles([UiBoxSizing, CommandShortcutStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "command-shortcut"),
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn command_update(
+  emit : @cmd.Emit[CommandMessage],
+  root_id : String,
+  dialog_id : String?,
+  dialog : Bool,
+  close_on_select : Bool,
+  on_value_select : @cmd.Emit[String]?,
+  on_query_change : @cmd.Emit[String]?,
+  on_open_change : @cmd.Emit[Bool]?,
+  on_close : @cmd.Emit[String]?,
+  message : CommandMessage,
+  current : CommandModel,
+) -> (CommandModel, @cmd.Cmd) {
+  match message {
+    CommandSetQuery(query, active) =>
+      (
+        { ..current, query, active },
+        @cmd.batch([
+          command_notify_string(on_query_change, query),
+          command_scroll_active(root_id, active),
+        ]),
+      )
+    CommandSetActive(active) =>
+      ({ ..current, active, }, command_scroll_active(root_id, active))
+    CommandSelect(value, item_command) => {
+      let selection = @cmd.batch([
+        command_notify_string(on_value_select, value),
+        item_command,
+      ])
+      if dialog && close_on_select && current.open && dialog_id is Some(_) {
+        let generation = current.generation + 1
+        (
+          { query: "", active: -1, open: false, generation },
+          @cmd.batch([
+            selection,
+            command_notify_string(on_query_change, ""),
+            command_notify_bool(on_open_change, false),
+            @rabbita.delay(
+              emit(CommandFinalizeClose(generation)),
+              DialogExitDurationMs,
+            ),
+          ]),
+        )
+      } else {
+        (current, selection)
+      }
+    }
+    CommandOpen =>
+      if !dialog || current.open {
+        (current, @cmd.none)
+      } else if dialog_id is Some(id) {
+        (
+          {
+            query: "",
+            active: -1,
+            open: true,
+            generation: current.generation + 1,
+          },
+          @cmd.batch([
+            ui_dialog_show(id, true),
+            command_notify_bool(on_open_change, true),
+          ]),
+        )
+      } else {
+        (current, @cmd.none)
+      }
+    CommandRequestClose =>
+      if dialog && current.open && dialog_id is Some(_) {
+        let generation = current.generation + 1
+        (
+          { ..current, open: false, generation },
+          @cmd.batch([
+            command_notify_bool(on_open_change, false),
+            @rabbita.delay(
+              emit(CommandFinalizeClose(generation)),
+              DialogExitDurationMs,
+            ),
+          ]),
+        )
+      } else if !dialog && current.query != "" {
+        (
+          { ..current, query: "", active: -1 },
+          command_notify_string(on_query_change, ""),
+        )
+      } else {
+        (current, @cmd.none)
+      }
+    CommandFinalizeClose(generation) =>
+      if dialog &&
+        !current.open &&
+        current.generation == generation &&
+        dialog_id is Some(id) {
+        (current, ui_dialog_close(id))
+      } else {
+        (current, @cmd.none)
+      }
+    CommandDidClose(value) =>
+      if dialog {
+        (
+          {
+            query: "",
+            active: -1,
+            open: false,
+            generation: current.generation + 1,
+          },
+          @cmd.batch([
+            if current.open {
+              command_notify_bool(on_open_change, false)
+            } else {
+              @cmd.none
+            },
+            command_notify_string(on_close, value),
+          ]),
+        )
+      } else {
+        (current, @cmd.none)
+      }
+  }
+}
+
+///|
+/// Create a self-contained command palette with Rabbita-owned query,
+/// filtering, and active-option state.
+#cfg(target="js")
+pub fn command(
+  id~ : String,
+  default_query? : String = "",
+  should_filter? : Bool = true,
+  filter? : (String, String, Array[String]) -> Bool,
+  on_value_select? : @cmd.Emit[String],
+  on_query_change? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (CommandScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let matcher = filter.unwrap_or(command_default_filter)
+  let initial : CommandModel = {
+    query: default_query,
+    active: -1,
+    open: true,
+    generation: 0,
+  }
+  let (model, emit) = @rabbita.create_state(initial, update=fn(
+    emit,
+    message,
+    current,
+  ) {
+    command_update(
+      emit,
+      id,
+      None,
+      false,
+      false,
+      on_value_select,
+      on_query_change,
+      None,
+      None,
+      message,
+      current,
+    )
+  })
+  model.view(model => {
+    command_surface(
+      id,
+      None,
+      model,
+      matcher,
+      should_filter,
+      false,
+      true,
+      emit,
+      None,
+      None,
+      None,
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    ).0
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn command(
+  id~ : String,
+  default_query? : String = "",
+  should_filter? : Bool = true,
+  filter? : (String, String, Array[String]) -> Bool,
+  on_value_select? : @cmd.Emit[String],
+  on_query_change? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (CommandScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_select, on_query_change))
+  let matcher = filter.unwrap_or(command_default_filter)
+  @rabbita.Val::constant(
+    command_surface(
+      id,
+      None,
+      { query: default_query, active: -1, open: true, generation: 0 },
+      matcher,
+      should_filter,
+      false,
+      true,
+      command_noop_emit(),
+      None,
+      None,
+      None,
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    ).0,
+  )
+}
+
+///|
+/// Default trigger for a CommandDialog. Supply it through the dialog's
+/// `trigger` callback so it remains outside the native dialog top layer.
+pub fn[C : @html.IsChildren] command_dialog_trigger(
+  scope~ : CommandScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let trigger_attrs = ui_attrs(attrs)
+    .data_set("slot", "command-dialog-trigger")
+    .data_set("state", if scope.model.open { "open" } else { "closed" })
+    .aria_haspopup("dialog")
+    .aria_expanded(ui_bool(scope.model.open))
+  if scope.dialog_id is Some(dialog_id) {
+    ignore(trigger_attrs.aria_controls(dialog_id))
+  }
+  dialog_control_button(
+    slot="command-dialog-trigger",
+    command=scope.open_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(trigger_attrs),
+    style~,
+    children,
+  )
+}
+
+///|
+fn command_dialog_view(
+  dialog_id : String,
+  model : CommandModel,
+  filter : (String, String, Array[String]) -> Bool,
+  should_filter : Bool,
+  close_on_escape : Bool,
+  emit : @cmd.Emit[CommandMessage],
+  native_open : Bool?,
+  native_on_close : @cmd.Emit[String]?,
+  native_on_cancel : @cmd.Cmd?,
+  aria_label : String,
+  close_on_overlay : Bool,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  overlay_attrs : @html.Attrs?,
+  overlay_style : Array[String],
+  native_attrs : @html.Attrs?,
+  native_style : Array[String],
+  trigger : ((CommandScope) -> @html.Html)?,
+  children : (CommandScope) -> @html.Html,
+) -> @html.Html {
+  let root_id = "\{dialog_id}-command"
+  let surface_result = command_surface(
+    root_id,
+    Some(dialog_id),
+    model,
+    filter,
+    should_filter,
+    true,
+    close_on_escape,
+    emit,
+    native_open,
+    native_on_close,
+    native_on_cancel,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+  let surface = surface_result.0
+  let scope = surface_result.1
+  let native_element_attrs = dialog_state_attrs(
+      native_attrs,
+      "command-dialog-native",
+      model.open,
+    )
+    .aria_modal("true")
+    .aria_label(aria_label)
+  let overlay_element_attrs = dialog_state_attrs(
+    overlay_attrs,
+    "command-dialog-overlay",
+    model.open,
+  )
+  if close_on_overlay {
+    ignore(
+      overlay_element_attrs.on_click(_ => {
+        if ui_dialog_should_close_outside() {
+          scope.close_command
+        } else {
+          @cmd.none
+        }
+      }),
+    )
+  }
+  let positioner_attrs = dialog_state_attrs(
+    None,
+    "command-dialog-positioner",
+    model.open,
+  )
+  let content_attrs = dialog_state_attrs(
+    None,
+    "command-dialog-content",
+    model.open,
+  )
+  let closedby = if close_on_overlay {
+    "any"
+  } else if close_on_escape {
+    "closerequest"
+  } else {
+    "none"
+  }
+  let open = scope.native_open
+  let on_close = scope.native_on_close
+  let on_cancel = scope.native_on_cancel
+  @html.fragment([
+    if trigger is Some(render_trigger) {
+      render_trigger(scope)
+    } else {
+      @html.nothing
+    },
+    @html.dialog(
+      style=ui_styles([UiBoxSizing, DialogNativeStyle], native_style),
+      id=dialog_id,
+      open?,
+      closedby~,
+      on_close?,
+      on_cancel?,
+      attrs=native_element_attrs,
+      [
+        @html.div(
+          style=ui_styles(
+            [
+              UiBoxSizing,
+              DialogOverlayStyle,
+              CommandDialogOverlayStyle,
+              dialog_overlay_motion_style(model.open),
+            ],
+            overlay_style,
+          ),
+          attrs=overlay_element_attrs,
+          @html.nothing,
+        ),
+        @html.div(
+          style=[UiBoxSizing, DialogPositionerStyle],
+          attrs=positioner_attrs,
+          @html.div(
+            style=[
+              UiBoxSizing,
+              CommandDialogContentStyle,
+              dialog_content_motion_style(model.open),
+            ],
+            attrs=content_attrs,
+            surface,
+          ),
+        ),
+      ],
+    ),
+  ])
+}
+
+///|
+/// Create a modal command palette backed by native `<dialog>` semantics.
+/// Focus trapping, Escape, top-layer stacking, and focus restoration are
+/// supplied by the browser rather than a hidden runtime or stylesheet.
+#cfg(target="js")
+pub fn command_dialog(
+  id~ : String,
+  default_open? : Bool = false,
+  default_query? : String = "",
+  should_filter? : Bool = true,
+  filter? : (String, String, Array[String]) -> Bool,
+  close_on_select? : Bool = true,
+  close_on_escape? : Bool = true,
+  close_on_overlay? : Bool = true,
+  aria_label? : String = "Command menu",
+  on_value_select? : @cmd.Emit[String],
+  on_query_change? : @cmd.Emit[String],
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  native_attrs? : @html.Attrs,
+  native_style? : Array[String] = [],
+  trigger? : (CommandScope) -> @html.Html,
+  children : (CommandScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let matcher = filter.unwrap_or(command_default_filter)
+  let initial : CommandModel = {
+    query: default_query,
+    active: -1,
+    open: default_open,
+    generation: 0,
+  }
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=fn(_) {
+      (initial, if default_open { ui_dialog_show(id, true) } else { @cmd.none })
+    },
+    update=fn(emit, message, current) {
+      command_update(
+        emit,
+        "\{id}-command",
+        Some(id),
+        true,
+        close_on_select,
+        on_value_select,
+        on_query_change,
+        on_open_change,
+        on_close,
+        message,
+        current,
+      )
+    },
+  )
+  model.view(model => {
+    command_dialog_view(
+      id,
+      model,
+      matcher,
+      should_filter,
+      close_on_escape,
+      emit,
+      None,
+      Some(emit.map(value => CommandDidClose(value))),
+      Some(if close_on_escape { emit(CommandRequestClose) } else { @cmd.none }),
+      aria_label,
+      close_on_overlay,
+      class,
+      title,
+      attrs,
+      style,
+      overlay_attrs,
+      overlay_style,
+      native_attrs,
+      native_style,
+      trigger,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn command_dialog(
+  id~ : String,
+  default_open? : Bool = false,
+  default_query? : String = "",
+  should_filter? : Bool = true,
+  filter? : (String, String, Array[String]) -> Bool,
+  close_on_select? : Bool = true,
+  close_on_escape? : Bool = true,
+  close_on_overlay? : Bool = true,
+  aria_label? : String = "Command menu",
+  on_value_select? : @cmd.Emit[String],
+  on_query_change? : @cmd.Emit[String],
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  native_attrs? : @html.Attrs,
+  native_style? : Array[String] = [],
+  trigger? : (CommandScope) -> @html.Html,
+  children : (CommandScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore(
+    (
+      close_on_select, on_value_select, on_query_change, on_open_change, on_close,
+    ),
+  )
+  let matcher = filter.unwrap_or(command_default_filter)
+  @rabbita.Val::constant(
+    command_dialog_view(
+      id,
+      { query: default_query, active: -1, open: default_open, generation: 0 },
+      matcher,
+      should_filter,
+      close_on_escape,
+      command_noop_emit(),
+      Some(default_open),
+      None,
+      None,
+      aria_label,
+      close_on_overlay,
+      class,
+      title,
+      attrs,
+      style,
+      overlay_attrs,
+      overlay_style,
+      native_attrs,
+      native_style,
+      trigger,
+      children,
+    ),
+  )
+}

--- a/rui/command_test.mbt
+++ b/rui/command_test.mbt
@@ -1,0 +1,292 @@
+///|
+#cfg(target="js")
+extern "js" fn install_command_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #|   if (typeof globalThis.document === "undefined") {
+  #|     globalThis.document = { getElementById: () => null };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_command_value(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  install_command_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_command_value(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn command_test_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected command HTML to contain `\{expected}`; got `\{actual}`")
+  }
+}
+
+///|
+fn command_test_not_contains(
+  actual : String,
+  unexpected : String,
+) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail(
+      "expected command HTML not to contain `\{unexpected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+#cfg(target="native")
+fn command_test_dialog_open(html : String) -> Unit raise {
+  command_test_contains(html, " open")
+}
+
+///|
+#cfg(target="js")
+fn command_test_dialog_open(html : String) -> Unit raise {
+  // JS opens the top-layer dialog through showModal after render, so the
+  // serialized virtual tree carries state rather than an `open` attribute.
+  command_test_contains(
+    html, "data-slot=\"command-dialog-native\" data-state=\"open\"",
+  )
+}
+
+///|
+test "command filters compound items and exposes active descendant semantics" {
+  let html = render_command_value(() => {
+    @rui.command(id="workspace-command", default_query="theme", scope => {
+      @html.fragment([
+        @rui.command_input(scope~, style=["background:rebeccapurple"]),
+        @rui.command_list(scope~, [
+          @rui.command_empty(scope~, "No results found."),
+          @rui.command_group(scope~, heading="Actions", [
+            @rui.command_item(
+              scope~,
+              value="Open calendar",
+              keywords=["schedule"],
+              "Open calendar",
+            ),
+            @rui.command_item(
+              scope~,
+              value="Change theme",
+              keywords=["appearance", "colors"],
+              [@html.span("Change theme"), @rui.command_shortcut("⌘T")],
+            ),
+            @rui.command_separator(),
+            @rui.command_item(
+              scope~,
+              value="Emoji picker",
+              disabled=true,
+              "Emoji picker",
+            ),
+          ]),
+        ]),
+      ])
+    })
+  })
+  command_test_contains(html, "id=\"workspace-command\"")
+  command_test_contains(html, "data-slot=\"command\"")
+  command_test_contains(
+    html, "border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem)",
+  )
+  command_test_contains(html, "box-shadow:0 1px 2px rgb(0 0 0 / 0.05)")
+  command_test_not_contains(
+    html, "border:0;border-radius:inherit;padding:0.25rem;box-shadow:none",
+  )
+  command_test_not_contains(html, "backdrop-filter")
+  command_test_contains(html, "data-filtered-count=\"1\"")
+  command_test_contains(html, "data-slot=\"command-input-wrapper\"")
+  command_test_contains(html, "data-slot=\"command-input-icon\"")
+  command_test_contains(html, "<svg")
+  command_test_not_contains(html, ">⌕<")
+  command_test_contains(html, "data-slot=\"command-input\"")
+  command_test_contains(html, "role=\"combobox\"")
+  command_test_contains(html, "aria-autocomplete=\"list\"")
+  command_test_contains(html, "aria-controls=\"workspace-command-list\"")
+  command_test_contains(
+    html, "aria-activedescendant=\"workspace-command-item-1\"",
+  )
+  command_test_contains(html, "value=\"theme\"")
+  command_test_contains(html, "background:rebeccapurple")
+  command_test_contains(html, "data-slot=\"command-list\"")
+  command_test_contains(html, "role=\"listbox\"")
+  command_test_contains(html, "data-slot=\"command-empty\"")
+  command_test_contains(html, "data-state=\"hidden\"")
+  command_test_contains(html, "data-slot=\"command-group\"")
+  command_test_contains(html, "role=\"group\"")
+  command_test_contains(html, "data-slot=\"command-group-heading\"")
+  command_test_contains(html, ">Actions</div>")
+  command_test_contains(html, "data-slot=\"command-item\"")
+  command_test_contains(
+    html, "background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent))",
+  )
+  command_test_contains(html, "--rui-menu-item-base-bg:var(--rui-accent")
+  command_test_contains(html, "id=\"workspace-command-item-1\"")
+  command_test_contains(html, "role=\"option\"")
+  command_test_contains(html, "aria-selected=\"true\"")
+  command_test_contains(html, "data-command-index=\"1\"")
+  command_test_contains(html, "data-slot=\"command-separator\"")
+  command_test_contains(html, "data-slot=\"command-shortcut\"")
+  command_test_contains(html, "aria-disabled=\"true\"")
+  command_test_contains(html, "display:none")
+}
+
+///|
+test "command empty is correct even when declared before its items" {
+  let html = render_command_value(() => {
+    @rui.command(id="empty-command", default_query="missing", scope => {
+      @html.fragment([
+        @rui.command_input(scope~),
+        @rui.command_list(scope~, [
+          @rui.command_empty(scope~, "Nothing matched."),
+          @rui.command_group(
+            scope~,
+            @rui.command_item(scope~, value="Settings", "Settings"),
+          ),
+        ]),
+      ])
+    })
+  })
+  command_test_contains(html, "data-filtered-count=\"0\"")
+  command_test_contains(
+    html, "data-slot=\"command-empty\" data-state=\"visible\"",
+  )
+  command_test_contains(html, ">Nothing matched.</div>")
+  command_test_not_contains(html, "aria-activedescendant")
+}
+
+///|
+test "command does not mutate caller attrs" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  ignore(
+    render_command_value(() => {
+      @rui.command(id="copy-command", attrs~, scope => {
+        @rui.command_list(
+          scope~,
+          @rui.command_item(scope~, value="Copy", "Copy"),
+        )
+      })
+    }),
+  )
+  let original = render_command_value(() => {
+    @rabbita.Val::constant(@html.div(attrs~, @html.nothing))
+  })
+  command_test_contains(original, "data-owner=\"caller\"")
+  command_test_not_contains(original, "data-slot")
+  command_test_not_contains(original, "data-state")
+}
+
+///|
+test "command dialog composes trigger and native modal semantics" {
+  let html = render_command_value(() => {
+    @rui.command_dialog(
+      id="global-command",
+      default_open=true,
+      aria_label="Global command menu",
+      overlay_attrs=@html.Attrs::build().data_set("owner", "overlay"),
+      trigger=scope => @rui.command_dialog_trigger(scope~, "Open command menu"),
+      scope => {
+        @html.fragment([
+          @rui.command_input(scope~),
+          @rui.command_list(scope~, [
+            @rui.command_empty(scope~, "No commands."),
+            @rui.command_group(
+              scope~,
+              heading="Navigation",
+              @rui.command_item(scope~, value="Dashboard", "Dashboard"),
+            ),
+          ]),
+        ])
+      },
+    )
+  })
+  command_test_contains(html, "data-slot=\"command-dialog-trigger\"")
+  command_test_contains(html, "aria-haspopup=\"dialog\"")
+  command_test_contains(html, "aria-controls=\"global-command\"")
+  command_test_contains(html, "aria-expanded=\"true\"")
+  command_test_contains(html, "<dialog")
+  command_test_contains(html, "id=\"global-command\"")
+  command_test_dialog_open(html)
+  command_test_contains(html, "closedby=\"any\"")
+  command_test_contains(html, "aria-modal=\"true\"")
+  command_test_contains(html, "aria-label=\"Global command menu\"")
+  command_test_contains(html, "data-slot=\"command-dialog-overlay\"")
+  command_test_contains(html, "data-owner=\"overlay\"")
+  command_test_contains(
+    html, "background:rgb(0 0 0 / 0.1);-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px)",
+  )
+  command_test_contains(html, "data-slot=\"command-dialog-positioner\"")
+  command_test_contains(html, "data-slot=\"command-dialog-content\"")
+  command_test_contains(
+    html, "overflow:hidden;border:0;border-radius:calc(var(--rui-radius,0.625rem) + 0.25rem)",
+  )
+  command_test_contains(
+    html, "box-shadow:0 0 0 1px color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent)",
+  )
+  command_test_contains(html, "id=\"global-command-command\"")
+  command_test_contains(
+    html, "border:0;border-radius:inherit;padding:0.25rem;box-shadow:none",
+  )
+  command_test_contains(html, "pointer-events:auto")
+  command_test_contains(
+    html, "transition:opacity 200ms ease,transform 200ms ease",
+  )
+  command_test_contains(html, "--rui-dialog-overlay-opacity:1")
+  command_test_contains(html, "--rui-dialog-content-opacity:1")
+}
+
+///|
+test "closed command dialog retains exit-motion state without opening native dialog" {
+  let html = render_command_value(() => {
+    @rui.command_dialog(id="closed-command", scope => {
+      @rui.command_list(
+        scope~,
+        @rui.command_item(scope~, value="Settings", "Settings"),
+      )
+    })
+  })
+  command_test_contains(html, "data-slot=\"command-dialog-native\"")
+  command_test_contains(html, "data-state=\"closed\"")
+  command_test_contains(html, "--rui-dialog-overlay-opacity:0")
+  command_test_contains(html, "--rui-dialog-content-opacity:0")
+  command_test_contains(
+    html, "--rui-dialog-content-transform:translateY(-0.5rem) scale(0.95)",
+  )
+  command_test_not_contains(html, "aria-expanded=\"true\"")
+}
+
+///|
+test "command ARIA references honor custom list and item ids" {
+  let html = render_command_value(() => {
+    @rui.command(id="custom-id-command", scope => {
+      @html.fragment([
+        @rui.command_input(scope~),
+        @rui.command_list(
+          scope~,
+          id="actual-command-list",
+          @rui.command_item(
+            scope~,
+            value="Settings",
+            id="actual-command-item",
+            "Settings",
+          ),
+        ),
+      ])
+    })
+  })
+  command_test_contains(html, "aria-controls=\"actual-command-list\"")
+  command_test_contains(html, "aria-activedescendant=\"actual-command-item\"")
+  command_test_contains(html, "id=\"actual-command-list\"")
+  command_test_contains(html, "id=\"actual-command-item\"")
+  command_test_not_contains(html, "aria-controls=\"custom-id-command-list\"")
+}

--- a/rui/command_wbtest.mbt
+++ b/rui/command_wbtest.mbt
@@ -1,0 +1,339 @@
+///|
+#cfg(target="js")
+fn command_test_update(
+  message : CommandMessage,
+  current : CommandModel,
+) -> CommandModel {
+  let (next, _) = command_update(
+    @cmd.Emit(_ => @cmd.none),
+    "command-root",
+    Some("command-dialog"),
+    true,
+    true,
+    None,
+    None,
+    None,
+    None,
+    message,
+    current,
+  )
+  next
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_reset_command_event_fixture() -> Unit =
+  #| () => {
+  #|   globalThis.__ruiCommandEventFixture = { trace: [], overlayCloses: 0 }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_note_command_caller_keydown() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCommandEventFixture ||= {
+  #|     trace: [],
+  #|     overlayCloses: 0,
+  #|   }
+  #|   fixture.trace.push("caller")
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_note_command_internal_keydown() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCommandEventFixture ||= {
+  #|     trace: [],
+  #|     overlayCloses: 0,
+  #|   }
+  #|   fixture.trace.push("internal")
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_command_event_trace() -> String =
+  #| () => globalThis.__ruiCommandEventFixture?.trace?.join(",") || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_note_command_overlay_close() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiCommandEventFixture ||= {
+  #|     trace: [],
+  #|     overlayCloses: 0,
+  #|   }
+  #|   fixture.overlayCloses += 1
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_command_overlay_closes() -> Int =
+  #| () => globalThis.__ruiCommandEventFixture?.overlayCloses || 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_command_keydown(
+  attrs : @html.Attrs,
+  key : String,
+) -> Bool =
+  #| (attrs, key) => {
+  #|   const props = attrs?.handlers ? attrs : attrs?._0
+  #|   const entry = props?.handlers?.entries?.find(
+  #|     item => item && item.key === "keydown",
+  #|   )
+  #|   if (!entry) return false
+  #|   const hadKeyboardEvent = Object.prototype.hasOwnProperty.call(
+  #|     globalThis,
+  #|     "KeyboardEvent",
+  #|   )
+  #|   const previousKeyboardEvent = globalThis.KeyboardEvent
+  #|   class FakeKeyboardEvent {
+  #|     constructor(value) {
+  #|       this.key = value
+  #|       this.altKey = false
+  #|       this.ctrlKey = false
+  #|       this.metaKey = false
+  #|       this.isComposing = false
+  #|       this.defaultPrevented = false
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|   }
+  #|   globalThis.KeyboardEvent = FakeKeyboardEvent
+  #|   const event = new FakeKeyboardEvent(key)
+  #|   let scheduler
+  #|   const run = command => {
+  #|     if (!command) return
+  #|     if (command.$tag === 0) {
+  #|       for (const child of command._0 || []) run(child)
+  #|     } else if (command.$tag === 1) {
+  #|       command._1(scheduler)
+  #|     } else if (command.$tag === 3) {
+  #|       command._0(scheduler)
+  #|     }
+  #|   }
+  #|   scheduler = {
+  #|     self: null,
+  #|     method_table: { method_3: (_self, command) => run(command) },
+  #|   }
+  #|   try {
+  #|     entry.value(event, scheduler)
+  #|     return event.defaultPrevented
+  #|   } finally {
+  #|     if (hadKeyboardEvent) globalThis.KeyboardEvent = previousKeyboardEvent
+  #|     else delete globalThis.KeyboardEvent
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_command_dialog_overlay_click(
+  html : @html.Html,
+  nested_floating : Bool,
+) -> Bool =
+  #| (html, nestedFloating) => {
+  #|   const mapGet = (map, key) => map?.entries?.find(
+  #|     item => item && item.key === key,
+  #|   )?.value
+  #|   const findOverlay = node => {
+  #|     if (!node) return null
+  #|     if (node.$tag === 0) {
+  #|       if (mapGet(node._1?.attrs, "data-slot") === "command-dialog-overlay") {
+  #|         return node
+  #|       }
+  #|       if (node._2?.$tag === 0) {
+  #|         for (const child of node._2._0 || []) {
+  #|           const found = findOverlay(child)
+  #|           if (found) return found
+  #|         }
+  #|       }
+  #|     } else if (node.$tag === 2) {
+  #|       for (const child of node._0 || []) {
+  #|         const found = findOverlay(child)
+  #|         if (found) return found
+  #|       }
+  #|     } else if (node.$tag === 3) {
+  #|       return findOverlay(node._1())
+  #|     }
+  #|     return null
+  #|   }
+  #|   const root = html?.$tag === undefined && html?._0?.$tag !== undefined
+  #|     ? html._0
+  #|     : html
+  #|   const overlay = findOverlay(root)
+  #|   const entry = overlay
+  #|     ? overlay._1?.handlers?.entries?.find(
+  #|         item => item && item.key === "click",
+  #|       )
+  #|     : null
+  #|   if (!entry) return false
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const hadDocument = own("document")
+  #|   const previousDocument = globalThis.document
+  #|   const hadMouseEvent = own("MouseEvent")
+  #|   const previousMouseEvent = globalThis.MouseEvent
+  #|   const hadFloatingStack = own("__ruiFloatingStack")
+  #|   const previousFloatingStack = globalThis.__ruiFloatingStack
+  #|   const hadOutsidePress = own("__ruiDialogOutsidePressHadFloating")
+  #|   const previousOutsidePress = globalThis.__ruiDialogOutsidePressHadFloating
+  #|   class FakeMouseEvent {}
+  #|   globalThis.MouseEvent = FakeMouseEvent
+  #|   globalThis.__ruiFloatingStack = []
+  #|   globalThis.__ruiDialogOutsidePressHadFloating = false
+  #|   globalThis.document = {
+  #|     querySelector: selector => selector === ":popover-open" && nestedFloating
+  #|       ? {}
+  #|       : null,
+  #|     getElementById: () => null,
+  #|   }
+  #|   let scheduler
+  #|   const run = command => {
+  #|     if (!command) return
+  #|     if (command.$tag === 0) {
+  #|       for (const child of command._0 || []) run(child)
+  #|     } else if (command.$tag === 1) {
+  #|       command._1(scheduler)
+  #|     } else if (command.$tag === 3) {
+  #|       command._0(scheduler)
+  #|     }
+  #|   }
+  #|   scheduler = {
+  #|     self: null,
+  #|     method_table: { method_3: (_self, command) => run(command) },
+  #|   }
+  #|   try {
+  #|     entry.value(new FakeMouseEvent(), scheduler)
+  #|     return true
+  #|   } finally {
+  #|     if (hadDocument) globalThis.document = previousDocument
+  #|     else delete globalThis.document
+  #|     if (hadMouseEvent) globalThis.MouseEvent = previousMouseEvent
+  #|     else delete globalThis.MouseEvent
+  #|     if (hadFloatingStack) globalThis.__ruiFloatingStack = previousFloatingStack
+  #|     else delete globalThis.__ruiFloatingStack
+  #|     if (hadOutsidePress) {
+  #|       globalThis.__ruiDialogOutsidePressHadFloating = previousOutsidePress
+  #|     } else {
+  #|       delete globalThis.__ruiDialogOutsidePressHadFloating
+  #|     }
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+test "command root composes caller keydown with keyboard navigation" {
+  let scope = command_scope(
+    "command-keydown",
+    None,
+    { query: "", active: -1, open: true, generation: 0 },
+    [],
+    false,
+    command_default_filter,
+    true,
+    false,
+    true,
+    @cmd.Emit(_ => {
+      ffi_note_command_internal_keydown()
+      @cmd.none
+    }),
+    None,
+    None,
+    None,
+    Ref("command-keydown-list"),
+  )
+  let caller_attrs = @html.Attrs::build().on_keydown(_ => {
+    ffi_note_command_caller_keydown()
+    @cmd.none
+  })
+  let attrs = command_keyboard_attrs(scope, Some(caller_attrs))
+  ffi_reset_command_event_fixture()
+  assert_true(ffi_fire_command_keydown(attrs, "ArrowDown"))
+  assert_eq(ffi_command_event_trace(), "caller,internal")
+}
+
+///|
+#cfg(target="js")
+test "command dialog overlay preserves a nested floating layer" {
+  let emit = @cmd.Emit(message => {
+    match message {
+      CommandRequestClose =>
+        @cmd.custom_cmd(_ => ffi_note_command_overlay_close())
+      _ => @cmd.none
+    }
+  })
+  let html = command_dialog_view(
+    "layered-command",
+    { query: "", active: -1, open: true, generation: 0 },
+    command_default_filter,
+    true,
+    true,
+    emit,
+    Some(true),
+    None,
+    None,
+    "Commands",
+    true,
+    None,
+    None,
+    None,
+    [],
+    None,
+    [],
+    None,
+    [],
+    None,
+    _ => @html.nothing,
+  )
+  ffi_reset_command_event_fixture()
+  dialog_outside_press_had_floating.val = true
+  assert_true(ffi_fire_command_dialog_overlay_click(html, true))
+  assert_eq(ffi_command_overlay_closes(), 0)
+  dialog_outside_press_had_floating.val = false
+  assert_true(ffi_fire_command_dialog_overlay_click(html, false))
+  assert_eq(ffi_command_overlay_closes(), 1)
+}
+
+///|
+#cfg(target="js")
+test "command dialog close state survives its exit window and stale finalize" {
+  let open : CommandModel = {
+    query: "set",
+    active: 2,
+    open: true,
+    generation: 4,
+  }
+  let closing = command_test_update(CommandRequestClose, open)
+  assert_true(!closing.open)
+  assert_eq(closing.query, "set")
+  assert_eq(closing.active, 2)
+  assert_eq(closing.generation, 5)
+  let reopened = command_test_update(CommandOpen, closing)
+  assert_true(reopened.open)
+  assert_eq(reopened.query, "")
+  assert_eq(reopened.active, -1)
+  assert_eq(reopened.generation, 6)
+  let after_stale_finalize = command_test_update(
+    CommandFinalizeClose(5),
+    reopened,
+  )
+  assert_true(after_stale_finalize.open)
+  assert_eq(after_stale_finalize.generation, 6)
+}
+
+///|
+#cfg(target="js")
+test "command selection enters closed state before native removal" {
+  let open : CommandModel = {
+    query: "dash",
+    active: 0,
+    open: true,
+    generation: 8,
+  }
+  let closing = command_test_update(CommandSelect("Dashboard", @cmd.none), open)
+  assert_true(!closing.open)
+  assert_eq(closing.query, "")
+  assert_eq(closing.active, -1)
+  assert_eq(closing.generation, 9)
+  let idempotent = command_test_update(CommandRequestClose, closing)
+  assert_eq(idempotent.generation, 9)
+  assert_true(!idempotent.open)
+}

--- a/rui/components_test.mbt
+++ b/rui/components_test.mbt
@@ -1,0 +1,175 @@
+///|
+test "input exposes native field state and caller override" {
+  let html = render(
+    @rui.input(
+      id="email",
+      value="hello@example.com",
+      placeholder="you@example.com",
+      required=true,
+      invalid=true,
+      style=["background:rebeccapurple", "height:3rem"],
+    ),
+  )
+  assert_contains(html, "<input")
+  assert_contains(html, "id=\"email\"")
+  assert_contains(html, "aria-invalid=\"true\"")
+  assert_contains(html, "required")
+  assert_contains(
+    html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)))",
+  )
+  assert_contains(
+    html, "border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))))",
+  )
+  assert_contains(html, "background:rebeccapurple;height:3rem")
+  assert_contains(html, "height:3rem")
+}
+
+///|
+test "textarea SSR value is text content" {
+  let html = render(@rui.textarea(value="one < two & three"))
+  assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)))",
+  )
+  assert_contains(html, ">one &lt; two &amp; three</textarea>")
+  assert_not_contains(html, "value=\"one")
+}
+
+///|
+test "card composition carries shadcn slots" {
+  let html = render(
+    @rui.card([
+      @rui.card_header([
+        @rui.card_title("Account"),
+        @rui.card_description("Profile details"),
+      ]),
+      @rui.card_content("Content"),
+      @rui.card_footer("Footer"),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"card\"")
+  assert_contains(html, "data-slot=\"card-header\"")
+  assert_contains(html, "data-slot=\"card-title\"")
+  assert_contains(html, "data-slot=\"card-description\"")
+  assert_contains(html, "data-slot=\"card-content\"")
+  assert_contains(html, "data-slot=\"card-footer\"")
+}
+
+///|
+test "checkbox exposes mixed state and native ARIA semantics" {
+  let html = render_incremental(() => {
+    @rui.checkbox(
+      default_indeterminate=true,
+      invalid=true,
+      aria_label="Select all",
+    )
+  })
+  assert_contains(html, "<button")
+  assert_contains(html, "type=\"button\"")
+  assert_contains(html, "role=\"checkbox\"")
+  assert_contains(html, "aria-checked=\"mixed\"")
+  assert_contains(html, "aria-invalid=\"true\"")
+  assert_contains(html, "data-slot=\"checkbox\"")
+  assert_contains(html, "data-state=\"indeterminate\"")
+  assert_contains(html, "data-indeterminate=\"\"")
+  assert_contains(
+    html, "--rui-control-base-bg:var(--rui-primary,oklch(0.205 0 0))",
+  )
+  assert_contains(
+    html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)))",
+  )
+  assert_contains(
+    html, "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)))",
+  )
+}
+
+///|
+test "switch and toggle expose black-box initial state" {
+  let switch_html = render_incremental(() => {
+    @rui.switch(
+      default_checked=true,
+      size=@rui.Sm,
+      aria_label="Notifications",
+      style=["outline-offset:4px"],
+    )
+  })
+  assert_contains(switch_html, "role=\"switch\"")
+  assert_contains(switch_html, "aria-checked=\"true\"")
+  assert_contains(switch_html, "data-slot=\"switch\"")
+  assert_contains(switch_html, "data-size=\"sm\"")
+  assert_contains(switch_html, "data-checked=\"\"")
+  assert_contains(switch_html, "width:1.5rem")
+  assert_contains(switch_html, "outline-offset:4px")
+  assert_contains(
+    switch_html, "--rui-control-base-bg:var(--rui-primary,oklch(0.205 0 0))",
+  )
+  assert_contains(
+    switch_html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-switch-unchecked,var(--rui-input,oklch(0.922 0 0)))))",
+  )
+
+  let toggle_html = render_incremental(() => {
+    @rui.toggle(default_pressed=true, variant=@rui.Outline, "Bold")
+  })
+  assert_contains(toggle_html, "aria-pressed=\"true\"")
+  assert_contains(toggle_html, "data-slot=\"toggle\"")
+  assert_contains(toggle_html, "data-variant=\"outline\"")
+  assert_contains(toggle_html, "data-pressed=\"\"")
+  assert_contains(toggle_html, "data-state=\"on\"")
+  assert_contains(
+    toggle_html, "background:var(--rui-toggle-bg,var(--rui-toggle-base-bg,transparent))",
+  )
+  assert_contains(
+    toggle_html, "--rui-toggle-base-bg:var(--rui-accent,oklch(0.97 0 0))",
+  )
+  assert_contains(toggle_html, ">Bold</button>")
+}
+
+///|
+test "switch thumb keeps the Vega checked endpoint at both sizes" {
+  let default_checked = render_incremental(() => {
+    @rui.switch(default_checked=true, aria_label="Default switch")
+  })
+  assert_contains(default_checked, "width:2rem;height:1.15rem")
+  assert_contains(default_checked, "width:1rem;height:1rem")
+  assert_contains(default_checked, "transform:translateX(calc(100% - 2px))")
+  assert_not_contains(default_checked, "background-clip:padding-box")
+
+  let small_checked = render_incremental(() => {
+    @rui.switch(default_checked=true, size=@rui.Sm, aria_label="Small switch")
+  })
+  assert_contains(small_checked, "width:1.5rem;height:0.875rem")
+  assert_contains(small_checked, "width:0.75rem;height:0.75rem")
+  assert_contains(small_checked, "transform:translateX(calc(100% - 2px))")
+
+  let unchecked = render_incremental(() => {
+    @rui.switch(aria_label="Unchecked switch")
+  })
+  assert_contains(unchecked, "transform:translateX(0)")
+}
+
+///|
+test "components do not mutate caller attrs" {
+  let attrs = @html.Attrs::build().aria_label("Shared")
+  ignore(render_incremental(() => @rui.checkbox(attrs~)))
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "aria-label=\"Shared\"")
+  assert_not_contains(original, "role=\"checkbox\"")
+  assert_not_contains(original, "aria-checked")
+}
+
+///|
+test "alert and separator expose semantic roles" {
+  let alert_html = render(
+    @rui.alert([
+      @rui.alert_title("Heads up"),
+      @rui.alert_description("Something changed"),
+    ]),
+  )
+  assert_contains(alert_html, "role=\"alert\"")
+  assert_contains(alert_html, "data-slot=\"alert-title\"")
+
+  let separator_html = render(
+    @rui.separator(orientation=@rui.Vertical, decorative=false),
+  )
+  assert_contains(separator_html, "role=\"separator\"")
+  assert_contains(separator_html, "aria-orientation=\"vertical\"")
+}

--- a/rui/context_menu.mbt
+++ b/rui/context_menu.mbt
@@ -1,0 +1,1076 @@
+///|
+struct ContextMenuScope {
+  menu : MenuScope
+  point_x : Int
+  point_y : Int
+}
+
+///|
+struct ContextMenuRadioGroupScope {
+  menu : MenuScope
+  group : String
+}
+
+///|
+struct ContextMenuSubScope {
+  menu : MenuScope
+  key : String
+}
+
+///|
+#cfg(target="js")
+priv struct ContextMenuModel {
+  menu : MenuCoreModel
+  x : Int
+  y : Int
+  point_x : Int
+  point_y : Int
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum ContextMenuMsg {
+  ContextOpenAt(Int, Int, Int, Int)
+  ContextSetOpen(Bool)
+  ContextNativeOpen(Bool)
+  ContextSetActive(Int)
+  ContextToggleChecked(String)
+  ContextSetRadio(String, String)
+  ContextSetSubmenu(MenuSubmenuChange)
+}
+
+///|
+fn context_menu_point_id(trigger_id : String) -> String {
+  trigger_id + "-point"
+}
+
+///|
+const ContextMenuPointStyle : String = "position:absolute;width:0;height:0;pointer-events:none"
+
+///|
+#cfg(target="js")
+priv struct ContextMenuTriggerBinding {
+  element : @dom.Element
+  open_at : Ref[(Int, Int, Int, Int) -> Unit]
+}
+
+///|
+#cfg(target="js")
+let context_menu_trigger_bindings : Map[String, ContextMenuTriggerBinding] = Map([],
+)
+
+///|
+#cfg(target="js")
+fn context_menu_open_from_point(
+  binding : ContextMenuTriggerBinding,
+  client_x : Double,
+  client_y : Double,
+) -> Unit {
+  let trigger = binding.element
+  let rect = trigger.get_bounding_client_rect()
+  let width = if trigger.get_client_width() > 0.0 {
+    trigger.get_client_width()
+  } else {
+    rect.get_width()
+  }
+  let height = if trigger.get_client_height() > 0.0 {
+    trigger.get_client_height()
+  } else {
+    rect.get_height()
+  }
+  let point_x = (client_x - rect.get_left() - trigger.get_client_left())
+    .max(0.0)
+    .min(width)
+  let point_y = (client_y - rect.get_top() - trigger.get_client_top())
+    .max(0.0)
+    .min(height)
+  (binding.open_at.val)(
+    client_x.round().to_int(),
+    client_y.round().to_int(),
+    point_x.round().to_int(),
+    point_y.round().to_int(),
+  )
+}
+
+///|
+#cfg(target="js")
+fn bind_context_menu_trigger(
+  id : String,
+  open_at : (Int, Int, Int, Int) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(trigger) else { return }
+  if context_menu_trigger_bindings.get(id) is Some(binding) &&
+    binding.element.is_same_node(trigger.as_node()) {
+    binding.open_at.val = open_at
+    return
+  }
+  let binding : ContextMenuTriggerBinding = {
+    element: trigger,
+    open_at: Ref(open_at),
+  }
+  context_menu_trigger_bindings[id] = binding
+  trigger.add_event_listener("contextmenu", event => {
+    if event.get_default_prevented() {
+      return
+    }
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    event.prevent_default()
+    context_menu_open_from_point(
+      binding,
+      mouse.get_client_x().to_double(),
+      mouse.get_client_y().to_double(),
+    )
+  })
+  trigger.add_event_listener("keydown", event => {
+    if event.get_default_prevented() {
+      return
+    }
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    let key = keyboard.key()
+    if key != "ContextMenu" && !(keyboard.shift_key() && key == "F10") {
+      return
+    }
+    event.prevent_default()
+    let rect = trigger.get_bounding_client_rect()
+    context_menu_open_from_point(
+      binding,
+      rect.get_left() + 8.0,
+      rect.get_top() + 8.0,
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn show_context_menu(
+  id : String,
+  x : Int,
+  y : Int,
+  point_x : Int,
+  point_y : Int,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(popup) else { return }
+  guard popup.to_html_element() is Some(html) else { return }
+  context_menu_cancel_exit(id)
+  let trigger_id = popup.get_attribute("data-trigger-id").unwrap_or("")
+  let point = ui_element_by_id(context_menu_point_id(trigger_id))
+  if point is Some(point_element) &&
+    point_element.to_html_element() is Some(point_html) {
+    point_html.get_style().set_property("left", "\{point_x}px")
+    point_html.get_style().set_property("top", "\{point_y}px")
+  }
+  let style = html.get_style()
+  let position_area = style.get_property_value("position-area")
+  let css_anchored = point is Some(_) &&
+    @dom.CSS::supports("anchor-name", "--rui-anchor") &&
+    @dom.CSS::supports("position-anchor", "--rui-anchor") &&
+    @dom.CSS::supports("position-area", position_area) &&
+    @dom.CSS::supports("position-try-fallbacks", "flip-inline")
+  if css_anchored {
+    ignore(style.remove_property("--rui-floating-left"))
+    ignore(style.remove_property("--rui-floating-top"))
+    popup.set_attribute("data-positioning", "css-anchor")
+    popup.set_attribute("data-positioned", "true")
+  } else {
+    style.set_property("--rui-floating-left", "\{x.max(8)}px")
+    style.set_property("--rui-floating-top", "\{y.max(8)}px")
+    popup.set_attribute("data-positioning", "javascript-fallback")
+  }
+  popup.remove_attribute("hidden")
+  if floating_live_layer(id) is None {
+    bind_floating_sync(id, _ => ())
+  }
+  let already_open = if floating_live_layer(id) is Some(layer) {
+    floating_layer_is_open(layer)
+  } else {
+    false
+  }
+  if !already_open && ui_has_window() {
+    ignore(
+      @dom.window().get_computed_style(popup).get_property_value("opacity"),
+    )
+  }
+  ignore(set_floating_open(id, true))
+  // The zero-size point inside the trigger is the primary anchor. It keeps the
+  // pointer-relative placement attached during ancestor scrolling.
+  if css_anchored {
+    return
+  }
+  let rect = popup.get_bounding_client_rect()
+  let (viewport_left, viewport_top, viewport_width, viewport_height) = if ui_has_window() &&
+    @dom.window().get_visual_viewport() is Some(viewport) {
+    (
+      viewport.get_offset_left(),
+      viewport.get_offset_top(),
+      viewport.get_width(),
+      viewport.get_height(),
+    )
+  } else if @dom.document().get_document_element() is Some(root) {
+    (0.0, 0.0, root.get_client_width(), root.get_client_height())
+  } else {
+    (0.0, 0.0, 0.0, 0.0)
+  }
+  let clip_left = viewport_left + 8.0
+  let clip_top = viewport_top + 8.0
+  let clip_right = viewport_left + viewport_width - 8.0
+  let clip_bottom = viewport_top + viewport_height - 8.0
+  let left = x
+    .to_double()
+    .max(clip_left)
+    .min((clip_right - rect.get_width()).max(clip_left))
+  let top = y
+    .to_double()
+    .max(clip_top)
+    .min((clip_bottom - rect.get_height()).max(clip_top))
+  style.set_property("--rui-floating-left", "\{left.round().to_int()}px")
+  style.set_property("--rui-floating-top", "\{top.round().to_int()}px")
+  popup.set_attribute("data-positioned", "true")
+}
+
+///|
+#cfg(target="js")
+fn bind_context_menu_close(id : String, request_close : () -> Unit) -> Unit {
+  if ui_element_by_id(id) is Some(_) {
+    floating_set_request_close(id, request_close)
+  }
+}
+
+///|
+#cfg(target="js")
+priv struct ContextMenuExitBinding {
+  element : @dom.Element
+  listener : Ref[@dom.Listener?]
+  timeout : Ref[Int?]
+}
+
+///|
+#cfg(target="js")
+let context_menu_exit_bindings : Map[String, ContextMenuExitBinding] = Map([])
+
+///|
+#cfg(target="js")
+fn context_menu_cancel_exit(id : String) -> Unit {
+  guard context_menu_exit_bindings.get(id) is Some(binding) else { return }
+  if binding.listener.val is Some(listener) {
+    binding.element.remove_event_listener("transitionend", listener)
+    binding.listener.val = None
+  }
+  if binding.timeout.val is Some(timeout) && ui_has_window() {
+    @dom.window().clear_timeout(timeout)
+    binding.timeout.val = None
+  }
+}
+
+///|
+#cfg(target="js")
+fn context_menu_css_time_ms(value : String) -> Double {
+  let text = "\{value.trim()}"
+  let milliseconds = text.has_suffix("ms")
+  let number_text = if milliseconds {
+    text.replace(old="ms", new="")
+  } else {
+    text.replace(old="s", new="")
+  }
+  let parsed = ui_parse_double_or(number_text, 0.0)
+  if milliseconds {
+    parsed
+  } else {
+    parsed * 1000.0
+  }
+}
+
+///|
+#cfg(target="js")
+fn context_menu_transition_duration(element : @dom.Element) -> Double {
+  guard ui_has_window() else { return 0.0 }
+  if @dom.window().match_media("(prefers-reduced-motion: reduce)").get_matches() {
+    return 0.0
+  }
+  let style = @dom.window().get_computed_style(element)
+  let durations : Array[Double] = []
+  let delays : Array[Double] = []
+  for duration in style.get_property_value("transition-duration").split(",") {
+    durations.push(context_menu_css_time_ms("\{duration}"))
+  }
+  for delay in style.get_property_value("transition-delay").split(",") {
+    delays.push(context_menu_css_time_ms("\{delay}"))
+  }
+  let mut total = 0.0
+  for index, duration in durations {
+    let delay = if delays.length() == 0 {
+      0.0
+    } else {
+      delays[index % delays.length()]
+    }
+    total = total.max(duration + delay)
+  }
+  total
+}
+
+///|
+#cfg(target="js")
+fn hide_context_menu_after_transition(id : String) -> Unit {
+  guard ui_element_by_id(id) is Some(popup) else { return }
+  context_menu_cancel_exit(id)
+  let binding : ContextMenuExitBinding = {
+    element: popup,
+    listener: Ref(None),
+    timeout: Ref(None),
+  }
+  context_menu_exit_bindings[id] = binding
+  fn finish() -> Unit {
+    if popup.get_attribute("data-state").unwrap_or("") == "open" {
+      return
+    }
+    context_menu_cancel_exit(id)
+    ignore(set_floating_open(id, false))
+  }
+
+  let duration = context_menu_transition_duration(popup)
+  if duration <= 0.0 || !ui_has_window() {
+    finish()
+    return
+  }
+  let listener : @dom.Listener = event => {
+    guard event.target().to_node() is Some(target) else { return }
+    if !popup.is_same_node(target) {
+      return
+    }
+    guard ui_transition_event(event) is Some(transition) else { return }
+    let property = transition.get_property_name()
+    if property == "opacity" || property == "transform" {
+      finish()
+    }
+  }
+  binding.listener.val = Some(listener)
+  popup.add_event_listener("transitionend", listener)
+  binding.timeout.val = Some(
+    @dom.window().set_timeout(finish, duration.ceil().to_int() + 34),
+  )
+}
+
+///|
+#cfg(target="js")
+fn context_bind_trigger_cmd(
+  trigger_id : String,
+  content_id : String,
+  open_at : @cmd.Emit[(Int, Int, Int, Int)],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      trigger_id,
+      () => {
+        bind_context_menu_trigger(trigger_id, (x, y, point_x, point_y) => {
+          show_context_menu(content_id, x, y, point_x, point_y)
+          scheduler.add(open_at((x, y, point_x, point_y)))
+        })
+      },
+      purpose="context-menu-trigger-bind",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn context_bind_close_cmd(
+  content_id : String,
+  request_close : @cmd.Cmd,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      content_id,
+      () => {
+        bind_context_menu_close(content_id, () => scheduler.add(request_close))
+      },
+      purpose="context-menu-close-bind",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn context_hide_after_transition_cmd(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    ui_after_mount(
+      id,
+      () => hide_context_menu_after_transition(id),
+      purpose="context-menu-exit-transition",
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn context_bind_close_cmd(
+  content_id : String,
+  request_close : @cmd.Cmd,
+) -> @cmd.Cmd {
+  ignore((content_id, request_close))
+  @cmd.none
+}
+
+///|
+#cfg(not(target="js"))
+fn context_hide_after_transition_cmd(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn context_show_cmd(
+  id : String,
+  x : Int,
+  y : Int,
+  point_x : Int,
+  point_y : Int,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    ui_after_mount(
+      id,
+      () => show_context_menu(id, x, y, point_x, point_y),
+      purpose="context-menu-show",
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn context_show_cmd(
+  id : String,
+  x : Int,
+  y : Int,
+  point_x : Int,
+  point_y : Int,
+) -> @cmd.Cmd {
+  ignore((id, x, y, point_x, point_y))
+  @cmd.none
+}
+
+///|
+fn context_scope(
+  id : String,
+  model : MenuCoreModel,
+  point_x : Int,
+  point_y : Int,
+  set_open : @cmd.Emit[Bool],
+  set_active : @cmd.Emit[Int],
+  toggle_checked : @cmd.Emit[String],
+  set_radio : @cmd.Emit[(String, String)],
+  set_submenu : @cmd.Emit[MenuSubmenuChange],
+) -> ContextMenuScope {
+  {
+    point_x,
+    point_y,
+    menu: {
+      id,
+      content_id: id + "-content",
+      trigger_id: id + "-trigger",
+      model,
+      counter: Ref(0),
+      open_command: set_open(true),
+      close_command: set_open(false),
+      toggle_command: set_open(!model.open),
+      set_active,
+      toggle_checked,
+      set_radio,
+      set_submenu,
+    },
+  }
+}
+
+///|
+/// Stateful context menu opened at the native `contextmenu` pointer position.
+#cfg(target="js")
+pub fn context_menu(
+  id~ : String,
+  default_open? : Bool = false,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ContextMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let initial : ContextMenuModel = {
+    menu: menu_core_model(
+      default_open, default_checked_values, default_radio_values,
+    ),
+    x: 8,
+    y: 8,
+    point_x: 0,
+    point_y: 0,
+  }
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      let set_active = emit.map(index => ContextSetActive(index))
+      let set_submenu = emit.map(value => ContextSetSubmenu(value))
+      (
+        initial,
+        @cmd.batch([
+          floating_bind_sync_cmd(
+            id + "-content",
+            emit.map(open => ContextNativeOpen(open)),
+          ),
+          context_bind_close_cmd(id + "-content", emit(ContextSetOpen(false))),
+          context_bind_trigger_cmd(
+            id + "-trigger",
+            id + "-content",
+            emit.map(pair => ContextOpenAt(pair.0, pair.1, pair.2, pair.3)),
+          ),
+          menu_bind_surface_cmd(
+            id + "-root",
+            set_active,
+            emit(ContextSetOpen(false)),
+            set_submenu,
+          ),
+          if default_open {
+            context_show_cmd(id + "-content", 8, 8, 0, 0)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(emit, msg, current) => {
+      match msg {
+        ContextOpenAt(x, y, point_x, point_y) => {
+          let next = {
+            menu: { ..current.menu, open: true, active: -1, submenus: [] },
+            x,
+            y,
+            point_x,
+            point_y,
+          }
+          (
+            next,
+            @cmd.batch([
+              menu_position_submenus_cmd(id + "-root"),
+              menu_focus_first_cmd(
+                id + "-root",
+                emit.map(index => ContextSetActive(index)),
+              ),
+              if current.menu.open {
+                @cmd.none
+              } else {
+                dropdown_notify(on_open_change, true)
+              },
+            ]),
+          )
+        }
+        ContextSetOpen(open) =>
+          if open == current.menu.open {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, menu: { ..current.menu, open, submenus: [] } },
+              @cmd.batch([
+                if open {
+                  context_show_cmd(
+                    id + "-content",
+                    current.x,
+                    current.y,
+                    current.point_x,
+                    current.point_y,
+                  )
+                } else {
+                  @cmd.batch([
+                    context_hide_after_transition_cmd(id + "-content"),
+                    ui_focus_id(id + "-trigger"),
+                  ])
+                },
+                if open {
+                  @cmd.none
+                } else {
+                  menu_position_submenus_cmd(id + "-root")
+                },
+                dropdown_notify(on_open_change, open),
+              ]),
+            )
+          }
+        ContextNativeOpen(open) =>
+          if open == current.menu.open {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, menu: { ..current.menu, open, submenus: [] } },
+              @cmd.batch([
+                if open {
+                  @cmd.none
+                } else {
+                  menu_position_submenus_cmd(id + "-root")
+                },
+                dropdown_notify(on_open_change, open),
+              ]),
+            )
+          }
+        ContextSetActive(index) =>
+          if current.menu.active == index {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, menu: { ..current.menu, active: index } },
+              menu_focus_item_cmd(id + "-root", index),
+            )
+          }
+        ContextToggleChecked(value) =>
+          (
+            {
+              ..current,
+              menu: {
+                ..current.menu,
+                checked: menu_toggle_value(current.menu.checked, value),
+              },
+            },
+            @cmd.none,
+          )
+        ContextSetRadio(group, value) =>
+          (
+            {
+              ..current,
+              menu: {
+                ..current.menu,
+                radios: menu_set_radio_value(current.menu.radios, group, value),
+              },
+            },
+            @cmd.none,
+          )
+        ContextSetSubmenu(change) => {
+          let submenus = menu_update_submenus(current.menu.submenus, change)
+          if submenus == current.menu.submenus {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, menu: { ..current.menu, submenus, } },
+              menu_position_submenus_cmd(id + "-root"),
+            )
+          }
+        }
+      }
+    },
+  )
+  model.view(model => {
+    let scope = context_scope(
+      id,
+      model.menu,
+      model.point_x,
+      model.point_y,
+      emit.map(open => ContextSetOpen(open)),
+      emit.map(index => ContextSetActive(index)),
+      emit.map(value => ContextToggleChecked(value)),
+      emit.map(pair => ContextSetRadio(pair.0, pair.1)),
+      emit.map(value => ContextSetSubmenu(value)),
+    )
+    menu_root_surface(
+      "context-menu",
+      id + "-root",
+      model.menu.open,
+      attrs,
+      style,
+      children(scope),
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn context_menu(
+  id~ : String,
+  default_open? : Bool = false,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ContextMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_open_change)
+  let scope = context_scope(
+    id,
+    menu_core_model(default_open, default_checked_values, default_radio_values),
+    0,
+    0,
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+  )
+  @rabbita.Val::constant(
+    menu_root_surface(
+      "context-menu",
+      id + "-root",
+      default_open,
+      attrs,
+      style,
+      children(scope),
+    ),
+  )
+}
+
+///|
+/// Explicit Root spelling matching the compound-component API.
+pub fn context_menu_root(
+  id~ : String,
+  default_open? : Bool = false,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ContextMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  context_menu(
+    id~,
+    default_open~,
+    default_checked_values~,
+    default_radio_values~,
+    on_open_change?,
+    attrs?,
+    style~,
+    children,
+  )
+}
+
+///|
+/// Zero-DOM Portal adapter for shadcn-compatible compound composition.
+/// Content already uses the native Popover top layer, so this adapter adds no
+/// wrapper element and requires no registration or portal runtime.
+pub fn context_menu_portal(children : Array[@html.Html]) -> @html.Html {
+  @html.fragment(children)
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_trigger(
+  scope : ContextMenuScope,
+  tabindex? : Int = 0,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, "position:relative"], style),
+    id=scope.menu.trigger_id,
+    class?,
+    title?,
+    attrs=menu_state_attrs(attrs, "context-menu-trigger", scope.menu.model.open)
+      .tabindex(tabindex)
+      .aria_haspopup("menu")
+      .aria_expanded(ui_bool(scope.menu.model.open))
+      .aria_controls(scope.menu.content_id),
+    [
+      @html.div(style=[UiBoxSizing, "display:contents"], children),
+      @html.span(
+        style=[
+          UiBoxSizing,
+          ContextMenuPointStyle,
+          "left:\{scope.point_x}px;top:\{scope.point_y}px",
+          popup_anchor_style(context_menu_point_id(scope.menu.trigger_id)),
+        ],
+        id=context_menu_point_id(scope.menu.trigger_id),
+        attrs=@html.Attrs::build()
+          .data_set("slot", "context-menu-anchor")
+          .aria_hidden("true"),
+        @html.nothing,
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_content(
+  scope : ContextMenuScope,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_content_surface(
+    "context-menu-content",
+    scope.menu,
+    Bottom,
+    Start,
+    0,
+    0,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_group(
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_group_surface(
+    "context-menu-group", aria_label, class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_item(
+  scope : ContextMenuScope,
+  disabled? : Bool = false,
+  inset? : Bool = false,
+  destructive? : Bool = false,
+  close_on_select? : Bool = true,
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_item_surface(
+    "context-menu-item",
+    scope.menu,
+    "menuitem",
+    None,
+    MenuIndicatorInlineStart,
+    disabled,
+    inset,
+    destructive,
+    None,
+    close_on_select,
+    None,
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_checkbox_item(
+  scope : ContextMenuScope,
+  value~ : String,
+  disabled? : Bool = false,
+  close_on_select? : Bool = false,
+  on_checked_change? : @cmd.Emit[Bool],
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let checked = menu_contains(scope.menu.model.checked, value)
+  let notify = if on_checked_change is Some(notify) {
+    notify(!checked)
+  } else {
+    @cmd.none
+  }
+  menu_item_surface(
+    "context-menu-checkbox-item",
+    scope.menu,
+    "menuitemcheckbox",
+    Some(checked),
+    MenuIndicatorInlineEnd,
+    disabled,
+    false,
+    false,
+    None,
+    close_on_select,
+    Some(@cmd.batch([notify, (scope.menu.toggle_checked)(value)])),
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_radio_group(
+  scope : ContextMenuScope,
+  value~ : String,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ContextMenuRadioGroupScope) -> C,
+) -> @html.Html {
+  menu_group_surface(
+    "context-menu-radio-group",
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children({ menu: scope.menu, group: value }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_radio_item(
+  scope : ContextMenuRadioGroupScope,
+  value~ : String,
+  disabled? : Bool = false,
+  close_on_select? : Bool = false,
+  on_value_change? : @cmd.Emit[String],
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let checked = menu_radio_value(scope.menu.model.radios, scope.group) ==
+    Some(value)
+  let notify = if on_value_change is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+  menu_item_surface(
+    "context-menu-radio-item",
+    scope.menu,
+    "menuitemradio",
+    Some(checked),
+    MenuIndicatorInlineEnd,
+    disabled,
+    false,
+    false,
+    None,
+    close_on_select,
+    Some(@cmd.batch([notify, (scope.menu.set_radio)((scope.group, value))])),
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_label(
+  inset? : Bool = false,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_label_surface(
+    "context-menu-label", inset, class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn context_menu_separator(
+  class? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  menu_separator_surface("context-menu-separator", class, attrs, style)
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_shortcut(
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_shortcut_surface(
+    "context-menu-shortcut", class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_sub(
+  scope : ContextMenuScope,
+  value~ : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ContextMenuSubScope) -> C,
+) -> @html.Html {
+  let key = menu_submenu_key(scope.menu, value)
+  let open = menu_submenu_open(scope.menu.model.submenus, key)
+  menu_sub_root_surface(
+    "context-menu-sub",
+    open,
+    attrs,
+    style,
+    children({ menu: scope.menu, key }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_sub_trigger(
+  scope : ContextMenuSubScope,
+  disabled? : Bool = false,
+  inset? : Bool = false,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_item_surface(
+    "context-menu-sub-trigger",
+    scope.menu,
+    "menuitem",
+    None,
+    MenuIndicatorInlineStart,
+    disabled,
+    inset,
+    false,
+    Some(scope.key),
+    false,
+    None,
+    None,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] context_menu_sub_content(
+  scope : ContextMenuSubScope,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_sub_content_surface(
+    "context-menu-sub-content",
+    scope.key,
+    menu_submenu_open(scope.menu.model.submenus, scope.key),
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}

--- a/rui/data_display_test.mbt
+++ b/rui/data_display_test.mbt
@@ -1,0 +1,166 @@
+///|
+test "avatar exposes Vega composition, sizing, and caller overrides" {
+  let html = render(
+    @rui.avatar_group([
+      @rui.avatar(size=Lg, style=["width:3rem"], [
+        @rui.avatar_fallback("YK"),
+        @rui.avatar_image(src="/avatar.png", alt="Yorkin", loading="lazy"),
+        @rui.avatar_badge(@html.nothing),
+      ]),
+      @rui.avatar_group_count(size=Lg, "+3"),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"avatar-group\"")
+  assert_contains(html, "data-slot=\"avatar\"")
+  assert_contains(html, "data-size=\"lg\"")
+  assert_contains(html, "data-slot=\"avatar-image\"")
+  assert_contains(html, "src=\"/avatar.png\"")
+  assert_contains(html, "alt=\"Yorkin\"")
+  assert_contains(html, "data-slot=\"avatar-fallback\"")
+  assert_contains(html, "data-slot=\"avatar-badge\"")
+  assert_contains(html, "data-slot=\"avatar-group-count\"")
+  assert_contains(html, "--rui-avatar-size:2.5rem")
+  assert_contains(html, "--rui-avatar-badge-size:0.75rem")
+  assert_contains(html, "width:3rem")
+}
+
+///|
+test "avatar black-box owns image loading and fallback state" {
+  let html = render_incremental(() => {
+    @rui.avatar_with_fallback(
+      id="profile-avatar",
+      src="/profile.png",
+      alt="Profile",
+      "PF",
+    )
+  })
+  assert_contains(html, "data-slot=\"avatar\"")
+  assert_contains(html, "data-image-state=\"loading\"")
+  assert_contains(html, "data-slot=\"avatar-fallback\"")
+  assert_contains(html, ">PF</span>")
+  assert_contains(html, "id=\"profile-avatar-image\"")
+  assert_contains(html, "src=\"/profile.png\"")
+  assert_contains(html, "hidden")
+
+  let missing = render_incremental(() => {
+    @rui.avatar_with_fallback(id="missing-avatar", src="", "NA")
+  })
+  assert_contains(missing, "data-image-state=\"error\"")
+}
+
+///|
+test "progress clamps determinate values and exposes native state" {
+  let html = render(
+    @rui.progress(
+      value=125,
+      min=0,
+      max=100,
+      labelledby="upload-label",
+      style=["gap:1rem"],
+      children=[
+        @rui.progress_label(value=125, id="upload-label", "Upload"),
+        @rui.progress_value(value=125),
+      ],
+    ),
+  )
+  assert_contains(html, "role=\"progressbar\"")
+  assert_contains(html, "aria-labelledby=\"upload-label\"")
+  assert_contains(html, "aria-valuemin=\"0\"")
+  assert_contains(html, "aria-valuemax=\"100\"")
+  assert_contains(html, "aria-valuenow=\"100\"")
+  assert_contains(html, "aria-valuetext=\"100%\"")
+  assert_contains(html, "data-state=\"complete\"")
+  assert_contains(html, "data-complete=\"\"")
+  assert_contains(html, "data-slot=\"progress-track\"")
+  assert_contains(html, "data-slot=\"progress-indicator\"")
+  assert_contains(html, "width:100%")
+  assert_contains(html, "gap:1rem")
+  assert_contains(html, ">100%</span>")
+}
+
+///|
+test "progress indeterminate state omits aria-valuenow" {
+  let html = render(@rui.progress(aria_label="Loading"))
+  assert_contains(html, "data-state=\"indeterminate\"")
+  assert_contains(html, "data-indeterminate=\"\"")
+  assert_contains(html, "aria-valuetext=\"indeterminate progress\"")
+  assert_contains(html, "inline-size:40%")
+  assert_contains(html, "inset-inline-start:-40%")
+  assert_contains(html, "@keyframes rui-progress-indeterminate")
+  assert_contains(html, "@media (prefers-reduced-motion:reduce)")
+  assert_not_contains(html, "aria-valuenow")
+  let indicator_html = render(@rui.progress_indicator())
+  assert_not_contains(indicator_html, "width:")
+}
+
+///|
+test "progress normalizes a maximum below its minimum" {
+  let html = render(@rui.progress(value=7, min=10, max=5))
+  assert_contains(html, "aria-valuemin=\"10\"")
+  assert_contains(html, "aria-valuemax=\"10\"")
+  assert_contains(html, "aria-valuenow=\"10\"")
+  assert_contains(html, "aria-valuetext=\"100%\"")
+  assert_contains(html, "data-state=\"complete\"")
+  assert_contains(html, "width:100%")
+}
+
+///|
+test "table preserves native semantics and composable slots" {
+  let html = render(
+    @rui.table(style=["font-size:1rem"], container_style=["max-width:40rem"], [
+      @rui.table_caption("Recent invoices"),
+      @rui.table_header(
+        @rui.table_row([@rui.table_head("Invoice"), @rui.table_head("Amount")]),
+      ),
+      @rui.table_body(
+        @rui.table_row(selected=true, [
+          @rui.table_cell("INV-001"),
+          @rui.table_cell("$250.00"),
+        ]),
+      ),
+      @rui.table_footer(
+        @rui.table_row(@rui.table_cell(colspan=2, "Total $250.00")),
+      ),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"table-container\"")
+  assert_contains(html, "data-slot=\"table\"")
+  assert_contains(html, "data-slot=\"table-header\"")
+  assert_contains(html, "data-slot=\"table-body\"")
+  assert_contains(html, "data-slot=\"table-footer\"")
+  assert_contains(html, "data-slot=\"table-caption\"")
+  assert_contains(html, "<th")
+  assert_contains(html, "scope=\"col\"")
+  assert_contains(html, "<td")
+  assert_contains(html, "colspan=\"2\"")
+  assert_contains(html, "data-state=\"selected\"")
+  assert_contains(
+    html, "background:var(--rui-table-row-bg,var(--rui-table-row-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "--rui-table-row-base-bg:var(--rui-muted,oklch(0.97 0 0))",
+  )
+  assert_contains(html, "font-size:1rem")
+  assert_contains(html, "max-width:40rem")
+
+  let expanded_html = render(
+    @rui.table_row(expanded=true, @rui.table_cell("Details")),
+  )
+  assert_contains(expanded_html, "data-expanded=\"\"")
+  assert_contains(
+    expanded_html, "--rui-table-row-base-bg:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent)",
+  )
+  assert_not_contains(expanded_html, "aria-expanded")
+}
+
+///|
+test "data-display components clone caller attrs" {
+  let attrs = @html.Attrs::build().aria_label("Shared")
+  ignore(@rui.avatar(attrs~, "A"))
+  ignore(@rui.progress(attrs~))
+  ignore(@rui.table(attrs~, @rui.table_body(([] : Array[@html.Html]))))
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "aria-label=\"Shared\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "role=\"progressbar\"")
+}

--- a/rui/data_table.mbt
+++ b/rui/data_table.mbt
@@ -1,0 +1,977 @@
+///|
+/// One typed column in a black-box `data_table`.
+///
+/// `value` supplies the searchable and sortable text. `render`, when present,
+/// only changes the visual cell content, so formatting never breaks table
+/// operations.
+struct DataTableColumn[T] {
+  key : String
+  label : String
+  value : (T) -> String
+  render : ((T) -> @html.Html)?
+  sortable : Bool
+  searchable : Bool
+  hideable : Bool
+  numeric : Bool
+}
+
+///|
+priv struct DataTableModel {
+  query : String
+  sort_key : String?
+  sort_descending : Bool
+  page : Int
+  selected : Array[String]
+  hidden_columns : Array[String]
+  columns_open : Bool
+} derive(Eq)
+
+///|
+priv enum DataTableMsg {
+  DataTableSetQuery(String)
+  DataTableSort(String)
+  DataTableSetPage(Int)
+  DataTableSetSelection(Array[String])
+  DataTableToggleColumn(String)
+  DataTableToggleColumns
+  DataTableCloseColumns
+}
+
+///|
+#cfg(target="js")
+priv suberror DataTableColumnsSubscription {
+  WatchDataTableColumns(String, @cmd.Cmd)
+}
+
+///|
+const DataTableRootStyle : String = "position:relative;display:flex;width:100%;min-width:0;flex-direction:column;gap:1rem;color:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const DataTableToolbarStyle : String = "position:relative;z-index:2;display:flex;width:100%;min-width:0;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:0.75rem"
+
+///|
+const DataTableSearchStyle : String = "width:min(20rem,100%)"
+
+///|
+const DataTableColumnsWrapStyle : String = "position:relative;display:inline-flex;margin-inline-start:auto"
+
+///|
+const DataTableColumnsMenuStyle : String = "position:absolute;inset-block-start:calc(100% + 0.375rem);inset-inline-end:0;z-index:20;display:flex;min-width:11rem;flex-direction:column;gap:0.125rem;border:1px solid color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:0.25rem;color:var(--rui-popover-foreground,oklch(0.145 0 0));box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1);transform-origin:top right;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const DataTableColumnsMenuOpenStyle : String = "visibility:visible;opacity:1;pointer-events:auto;transform:scale(1)"
+
+///|
+const DataTableColumnsMenuClosedStyle : String = "visibility:hidden;opacity:0;pointer-events:none;transform:scale(0.96)"
+
+///|
+const DataTableColumnOptionStyle : String = "display:flex;width:100%;min-height:2rem;align-items:center;gap:0.5rem;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);padding:0.375rem 0.5rem;font-size:0.875rem;line-height:1.25rem;text-transform:capitalize;white-space:nowrap"
+
+///|
+const DataTableSurfaceStyle : String = "overflow:hidden;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem)"
+
+///|
+const DataTableSortButtonStyle : String = "height:2rem;margin-inline-start:-0.25rem;padding-inline:0.5rem"
+
+///|
+const DataTableSortIconStyle : String = "display:inline-flex;width:1rem;height:1rem;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+
+///|
+const DataTableEmptyStyle : String = "height:7rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));text-align:center"
+
+///|
+const DataTableFooterStyle : String = "display:flex;width:100%;min-width:0;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:0.75rem"
+
+///|
+const DataTableSummaryStyle : String = "color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.8125rem;line-height:1.25rem"
+
+///|
+const DataTablePagerStyle : String = "display:flex;align-items:center;gap:0.5rem"
+
+///|
+const DataTablePageLabelStyle : String = "min-width:5.5rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.8125rem;line-height:1.25rem;text-align:center"
+
+///|
+/// Construct a typed column for `data_table`.
+pub fn[T] data_table_column(
+  key~ : String,
+  label~ : String,
+  value~ : (T) -> String,
+  render? : (T) -> @html.Html,
+  sortable? : Bool = true,
+  searchable? : Bool = true,
+  hideable? : Bool = true,
+  numeric? : Bool = false,
+) -> DataTableColumn[T] {
+  { key, label, value, render, sortable, searchable, hideable, numeric }
+}
+
+///|
+fn data_table_contains(values : Array[String], value : String) -> Bool {
+  for current in values {
+    if current == value {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn data_table_remove(values : Array[String], value : String) -> Array[String] {
+  let result : Array[String] = []
+  for current in values {
+    if current != value {
+      result.push(current)
+    }
+  }
+  result
+}
+
+///|
+fn data_table_toggle(values : Array[String], value : String) -> Array[String] {
+  if data_table_contains(values, value) {
+    data_table_remove(values, value)
+  } else {
+    let result = values.copy()
+    result.push(value)
+    result
+  }
+}
+
+///|
+fn[T] data_table_column_index(
+  columns : Array[DataTableColumn[T]],
+  key : String,
+) -> Int {
+  for index, column in columns {
+    if column.key == key {
+      return index
+    }
+  }
+  -1
+}
+
+///|
+fn[T] data_table_row_matches(
+  row : T,
+  columns : Array[DataTableColumn[T]],
+  query : String,
+) -> Bool {
+  if query == "" {
+    return true
+  }
+  let needle = query.to_lower()
+  for column in columns {
+    if column.searchable && (column.value)(row).to_lower().contains(needle) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn[T] data_table_visible_indices(
+  rows : Array[T],
+  columns : Array[DataTableColumn[T]],
+  model : DataTableModel,
+) -> Array[Int] {
+  let indices : Array[Int] = []
+  for index, row in rows {
+    if data_table_row_matches(row, columns, model.query) {
+      indices.push(index)
+    }
+  }
+  if model.sort_key is Some(key) {
+    let column_index = data_table_column_index(columns, key)
+    if column_index >= 0 && columns[column_index].sortable {
+      let column = columns[column_index]
+      indices.sort_by((left, right) => {
+        let order = (column.value)(rows[left]).compare(
+          (column.value)(rows[right]),
+        )
+        if model.sort_descending {
+          -order
+        } else {
+          order
+        }
+      })
+    }
+  }
+  indices
+}
+
+///|
+fn data_table_page_count(row_count : Int, page_size : Int) -> Int {
+  if row_count == 0 {
+    1
+  } else {
+    (row_count + page_size - 1) / page_size
+  }
+}
+
+///|
+fn data_table_effective_page(page : Int, page_count : Int) -> Int {
+  if page < 0 {
+    0
+  } else if page >= page_count {
+    page_count - 1
+  } else {
+    page
+  }
+}
+
+///|
+fn data_table_command(
+  emit : @cmd.Emit[DataTableMsg]?,
+  message : DataTableMsg,
+) -> @cmd.Cmd? {
+  if emit is Some(emit) {
+    Some(emit(message))
+  } else {
+    None
+  }
+}
+
+///|
+fn data_table_value_emit(
+  emit : @cmd.Emit[DataTableMsg]?,
+  wrap : (String) -> DataTableMsg,
+) -> @cmd.Emit[String]? {
+  if emit is Some(emit) {
+    Some(emit.map(wrap))
+  } else {
+    None
+  }
+}
+
+///|
+fn data_table_bool_emit(
+  emit : @cmd.Emit[DataTableMsg]?,
+  wrap : (Bool) -> DataTableMsg,
+) -> @cmd.Emit[Bool]? {
+  if emit is Some(emit) {
+    Some(emit.map(wrap))
+  } else {
+    None
+  }
+}
+
+///|
+#cfg(target="js")
+fn data_table_columns_contains_related_target(
+  id : String,
+  event : @dom.FocusEvent,
+) -> Bool {
+  guard ui_element_by_id(id + "-columns") is Some(columns) else { return false }
+  event.related_target() is Some(related) &&
+  ui_element_contains_target(columns, related)
+}
+
+///|
+#cfg(target="js")
+fn data_table_focus_columns_trigger(id : String) -> Unit {
+  guard ui_element_by_id(id + "-columns") is Some(columns) else { return }
+  guard ui_find_descendant_by_attribute(
+      columns, "data-slot", "data-table-columns-trigger",
+    )
+    is Some(trigger) else {
+    return
+  }
+  ui_focus_element(trigger)
+}
+
+///|
+#cfg(target="js")
+fn data_table_columns_event_is_outside(id : String, event : @dom.Event) -> Bool {
+  if ui_element_by_id(id + "-columns") is Some(columns) {
+    !ui_element_contains_target(columns, event.target())
+  } else {
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+fn data_table_add_columns_listener(
+  event : String,
+  listener : @dom.Listener,
+) -> Unit {
+  @dom.document().add_event_listener_with_options(event, listener, capture=true)
+}
+
+///|
+#cfg(target="js")
+fn data_table_remove_columns_listener(
+  event : String,
+  listener : @dom.Listener,
+) -> Unit {
+  @dom.document().remove_event_listener_with_options(
+    event,
+    listener,
+    capture=true,
+  )
+}
+
+///|
+#cfg(target="js")
+fn data_table_columns_subscription_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    WatchDataTableColumns(id, close) => {
+      let mut close_command = close
+      let listener : @dom.Listener = event => {
+        if data_table_columns_event_is_outside(id, event) {
+          scheduler.add(close_command)
+        }
+      }
+      data_table_add_columns_listener("pointerdown", listener)
+      data_table_add_columns_listener("focusin", listener)
+      Some({
+        unload: _ => {
+          data_table_remove_columns_listener("pointerdown", listener)
+          data_table_remove_columns_listener("focusin", listener)
+        },
+        update_tagger: payload => {
+          if payload is WatchDataTableColumns(_, next_close) {
+            close_command = next_close
+          }
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+#cfg(target="js")
+fn data_table_columns_dismiss_subscription(
+  id : String,
+  close : @cmd.Cmd,
+) -> @sub.Sub {
+  @sub.custom_sub(
+    "data-table-columns-dismiss:\{id}",
+    @sub.Local,
+    WatchDataTableColumns(id, close),
+    @sub.SubLoader(data_table_columns_subscription_loader),
+  )
+}
+
+///|
+#cfg(target="js")
+fn data_table_bind_columns_control_dismiss(
+  attrs : @html.Attrs,
+  id : String,
+  close : @cmd.Cmd?,
+  open : Bool,
+) -> Unit {
+  if open && close is Some(close) {
+    ignore(
+      attrs
+      .on_blur(event => {
+        if data_table_columns_contains_related_target(id, event) {
+          @cmd.none
+        } else {
+          close
+        }
+      })
+      .on_keydown(event => {
+        if event.key() == "Escape" {
+          event.prevent_default()
+          event.stop_propagation()
+          data_table_focus_columns_trigger(id)
+          close
+        } else {
+          @cmd.none
+        }
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn data_table_bind_columns_control_dismiss(
+  attrs : @html.Attrs,
+  id : String,
+  close : @cmd.Cmd?,
+  open : Bool,
+) -> Unit {
+  ignore((attrs, id, close, open))
+}
+
+///|
+fn[T] data_table_render_cell(
+  column : DataTableColumn[T],
+  row : T,
+) -> @html.Html {
+  if column.render is Some(render) {
+    render(row)
+  } else {
+    @html.text((column.value)(row))
+  }
+}
+
+///|
+fn[T] render_data_table(
+  id : String,
+  rows : Array[T],
+  columns : Array[DataTableColumn[T]],
+  row_key : (T) -> String,
+  model : DataTableModel,
+  page_size : Int,
+  searchable : Bool,
+  selectable : Bool,
+  show_columns : Bool,
+  search_placeholder : String,
+  empty_text : String,
+  aria_label : String,
+  emit : @cmd.Emit[DataTableMsg]?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let visible_indices = data_table_visible_indices(rows, columns, model)
+  let page_count = data_table_page_count(visible_indices.length(), page_size)
+  let page = data_table_effective_page(model.page, page_count)
+  let page_start = page * page_size
+  let page_end = if page_start + page_size < visible_indices.length() {
+    page_start + page_size
+  } else {
+    visible_indices.length()
+  }
+  let page_keys : Array[String] = []
+  for position, row_index in visible_indices {
+    if position >= page_start && position < page_end {
+      page_keys.push(row_key(rows[row_index]))
+    }
+  }
+  let selected_on_page = page_keys.fold(init=0, (count, key) => {
+    if data_table_contains(model.selected, key) {
+      count + 1
+    } else {
+      count
+    }
+  })
+  let selected_visible = visible_indices.fold(init=0, (count, row_index) => {
+    if data_table_contains(model.selected, row_key(rows[row_index])) {
+      count + 1
+    } else {
+      count
+    }
+  })
+  let all_page_selected = page_keys.length() > 0 &&
+    selected_on_page == page_keys.length()
+  let some_page_selected = selected_on_page > 0 && !all_page_selected
+  let header_cells : Array[@html.Html] = []
+  if selectable {
+    let next_selection = if all_page_selected {
+      model.selected.filter(key => !data_table_contains(page_keys, key))
+    } else {
+      let selected = model.selected.copy()
+      for key in page_keys {
+        if !data_table_contains(selected, key) {
+          selected.push(key)
+        }
+      }
+      selected
+    }
+    let on_checked_change = data_table_bool_emit(emit, _ => {
+      DataTableSetSelection(next_selection)
+    })
+    header_cells.push(
+      table_head(
+        style=["width:2.75rem;padding-inline:0.75rem"],
+        render_checkbox(
+          checked=all_page_selected,
+          indeterminate=some_page_selected,
+          disabled=page_keys.length() == 0,
+          aria_label="Select all rows on this page",
+          on_checked_change?,
+        ),
+      ),
+    )
+  }
+  for column in columns {
+    if !data_table_contains(model.hidden_columns, column.key) {
+      let active = model.sort_key == Some(column.key)
+      let sort_attrs = @html.Attrs::build()
+        .data_set("slot", "data-table-sort-trigger")
+        .data_set("column", column.key)
+      let on_click = data_table_command(emit, DataTableSort(column.key))
+      let head_attrs = @html.Attrs::build()
+      if active {
+        ignore(
+          head_attrs.aria_sort(
+            if model.sort_descending {
+              "descending"
+            } else {
+              "ascending"
+            },
+          ),
+        )
+      } else if column.sortable {
+        ignore(head_attrs.aria_sort("none"))
+      }
+      let heading = if column.sortable {
+        button(
+          variant=Ghost,
+          size=Sm,
+          on_click?,
+          attrs=sort_attrs,
+          style=[DataTableSortButtonStyle],
+          slot="data-table-sort-trigger",
+          [
+            @html.span(column.label),
+            @html.span(
+              attrs=@html.Attrs::build()
+                .data_set("slot", "data-table-sort-icon")
+                .aria_hidden("true"),
+              style=[
+                DataTableSortIconStyle,
+                if active {
+                  "opacity:1"
+                } else {
+                  "opacity:0.35"
+                },
+              ],
+              if active && model.sort_descending {
+                ui_chevron_down_icon()
+              } else {
+                ui_chevron_up_icon()
+              },
+            ),
+          ],
+        )
+      } else {
+        @html.text(column.label)
+      }
+      header_cells.push(
+        table_head(
+          attrs=head_attrs,
+          style=[if column.numeric { "text-align:end" } else { "" }],
+          heading,
+        ),
+      )
+    }
+  }
+  let body_rows : Array[@html.Html] = []
+  for position, row_index in visible_indices {
+    if position >= page_start && position < page_end {
+      let row = rows[row_index]
+      let key = row_key(row)
+      let selected = data_table_contains(model.selected, key)
+      let cells : Array[@html.Html] = []
+      if selectable {
+        let next = if selected {
+          data_table_remove(model.selected, key)
+        } else {
+          let selected = model.selected.copy()
+          selected.push(key)
+          selected
+        }
+        let on_checked_change = data_table_bool_emit(emit, _ => {
+          DataTableSetSelection(next)
+        })
+        cells.push(
+          table_cell(
+            style=["width:2.75rem;padding-inline:0.75rem"],
+            render_checkbox(
+              checked=selected,
+              aria_label="Select row \{key}",
+              on_checked_change?,
+            ),
+          ),
+        )
+      }
+      for column in columns {
+        if !data_table_contains(model.hidden_columns, column.key) {
+          cells.push(
+            table_cell(
+              style=[if column.numeric { "text-align:end" } else { "" }],
+              data_table_render_cell(column, row),
+            ),
+          )
+        }
+      }
+      body_rows.push(
+        table_row(
+          selected~,
+          attrs=@html.Attrs::build()
+            .data_set("data-table-row", "")
+            .data_set("row-key", key),
+          cells,
+        ),
+      )
+    }
+  }
+  if body_rows.length() == 0 {
+    let visible_column_count = columns.fold(init=0, (count, column) => {
+      if data_table_contains(model.hidden_columns, column.key) {
+        count
+      } else {
+        count + 1
+      }
+    })
+    let colspan = visible_column_count + (if selectable { 1 } else { 0 })
+    body_rows.push(
+      table_row(table_cell(colspan~, style=[DataTableEmptyStyle], empty_text)),
+    )
+  }
+  let toolbar_children : Array[@html.Html] = []
+  if searchable {
+    let on_input = data_table_value_emit(emit, query => DataTableSetQuery(query))
+    toolbar_children.push(
+      input(
+        input_type=@html.Search,
+        value=model.query,
+        placeholder=search_placeholder,
+        on_input?,
+        attrs=@html.Attrs::build().aria_label("Filter rows"),
+        style=[DataTableSearchStyle],
+        slot="data-table-search",
+      ),
+    )
+  }
+  if show_columns {
+    let menu_items : Array[@html.Html] = []
+    let close_columns = data_table_command(emit, DataTableCloseColumns)
+    for column in columns {
+      if column.hideable {
+        let visible = !data_table_contains(model.hidden_columns, column.key)
+        let on_checked_change = data_table_bool_emit(emit, _ => {
+          DataTableToggleColumn(column.key)
+        })
+        let option_attrs = @html.Attrs::build()
+        data_table_bind_columns_control_dismiss(
+          option_attrs,
+          id,
+          close_columns,
+          model.columns_open,
+        )
+        menu_items.push(
+          @html.label(style=[DataTableColumnOptionStyle], [
+            render_checkbox(
+              checked=visible,
+              aria_label="Toggle \{column.label} column",
+              on_checked_change?,
+              attrs=option_attrs,
+            ),
+            @html.span(column.label),
+          ]),
+        )
+      }
+    }
+    let toggle_columns = data_table_command(emit, DataTableToggleColumns)
+    let trigger_attrs = @html.Attrs::build()
+      .data_set("slot", "data-table-columns-trigger")
+      .aria_haspopup("menu")
+      .aria_expanded(ui_bool(model.columns_open))
+      .aria_controls("\{id}-columns-menu")
+    data_table_bind_columns_control_dismiss(
+      trigger_attrs,
+      id,
+      close_columns,
+      model.columns_open,
+    )
+    toolbar_children.push(
+      @html.div(
+        id="\{id}-columns",
+        attrs=@html.Attrs::build()
+          .data_set("slot", "data-table-columns-wrap")
+          .data_set("state", if model.columns_open { "open" } else { "closed" }),
+        style=[DataTableColumnsWrapStyle],
+        [
+          button(
+            variant=Outline,
+            size=Sm,
+            on_click?=toggle_columns,
+            attrs=trigger_attrs,
+            slot="data-table-columns-trigger",
+            [@html.span("Columns"), ui_chevron_down_icon()],
+          ),
+          @html.div(
+            id="\{id}-columns-menu",
+            attrs=@html.Attrs::build()
+              .data_set("slot", "data-table-columns-menu")
+              .data_set(
+                "state",
+                if model.columns_open {
+                  "open"
+                } else {
+                  "closed"
+                },
+              )
+              .role("menu")
+              .aria_hidden(ui_bool(!model.columns_open)),
+            style=[
+              DataTableColumnsMenuStyle,
+              if model.columns_open {
+                DataTableColumnsMenuOpenStyle
+              } else {
+                DataTableColumnsMenuClosedStyle
+              },
+            ],
+            menu_items,
+          ),
+        ],
+      ),
+    )
+  }
+  let previous = data_table_command(emit, DataTableSetPage(page - 1))
+  let next = data_table_command(emit, DataTableSetPage(page + 1))
+  let root_attrs = ui_attrs(attrs)
+    .data_set("slot", "data-table")
+    .data_set("page", "\{page + 1}")
+    .data_set("page-count", "\{page_count}")
+    .data_set("row-count", "\{visible_indices.length()}")
+  @html.div(
+    id~,
+    class?,
+    title?,
+    attrs=root_attrs,
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, DataTableRootStyle],
+      style,
+    ),
+    [
+      if toolbar_children.length() > 0 {
+        @html.div(
+          attrs=@html.Attrs::build().data_set("slot", "data-table-toolbar"),
+          style=[DataTableToolbarStyle],
+          toolbar_children,
+        )
+      } else {
+        @html.nothing
+      },
+      @html.div(
+        attrs=@html.Attrs::build().data_set("slot", "data-table-surface"),
+        style=[DataTableSurfaceStyle],
+        table(attrs=@html.Attrs::build().aria_label(aria_label), [
+          table_header(table_row(header_cells)),
+          table_body(body_rows),
+        ]),
+      ),
+      @html.div(
+        attrs=@html.Attrs::build().data_set("slot", "data-table-footer"),
+        style=[DataTableFooterStyle],
+        [
+          @html.div(
+            attrs=@html.Attrs::build().data_set(
+              "slot", "data-table-selection-summary",
+            ),
+            style=[DataTableSummaryStyle],
+            if selectable {
+              "\{selected_visible} of \{visible_indices.length()} row(s) selected."
+            } else {
+              "\{visible_indices.length()} row(s)."
+            },
+          ),
+          @html.div(style=[DataTablePagerStyle], [
+            button(
+              variant=Outline,
+              size=Sm,
+              disabled=page == 0,
+              on_click?=previous,
+              attrs=@html.Attrs::build().data_set("slot", "data-table-previous"),
+              slot="data-table-previous",
+              "Previous",
+            ),
+            @html.span(
+              attrs=@html.Attrs::build()
+                .data_set("slot", "data-table-page-label")
+                .aria_live("polite"),
+              style=[DataTablePageLabelStyle],
+              "Page \{page + 1} of \{page_count}",
+            ),
+            button(
+              variant=Outline,
+              size=Sm,
+              disabled=page >= page_count - 1,
+              on_click?=next,
+              attrs=@html.Attrs::build().data_set("slot", "data-table-next"),
+              slot="data-table-next",
+              "Next",
+            ),
+          ]),
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+fn data_table_update(
+  message : DataTableMsg,
+  model : DataTableModel,
+) -> DataTableModel {
+  match message {
+    DataTableSetQuery(query) => { ..model, query, page: 0 }
+    DataTableSort(key) =>
+      if model.sort_key == Some(key) {
+        { ..model, sort_descending: !model.sort_descending, page: 0 }
+      } else {
+        { ..model, sort_key: Some(key), sort_descending: false, page: 0 }
+      }
+    DataTableSetPage(page) => { ..model, page, }
+    DataTableSetSelection(selected) => { ..model, selected, }
+    DataTableToggleColumn(key) =>
+      { ..model, hidden_columns: data_table_toggle(model.hidden_columns, key) }
+    DataTableToggleColumns => { ..model, columns_open: !model.columns_open }
+    DataTableCloseColumns => { ..model, columns_open: false }
+  }
+}
+
+///|
+fn data_table_initial_model(
+  default_sort_key : String?,
+  default_sort_descending : Bool,
+  default_selected : Array[String],
+  default_hidden_columns : Array[String],
+) -> DataTableModel {
+  {
+    query: "",
+    sort_key: default_sort_key,
+    sort_descending: default_sort_descending,
+    page: 0,
+    selected: default_selected.copy(),
+    hidden_columns: default_hidden_columns.copy(),
+    columns_open: false,
+  }
+}
+
+///|
+/// Build a typed, self-contained data table with local filter, sort,
+/// pagination, row-selection, and column-visibility state.
+#cfg(target="js")
+pub fn[T] data_table(
+  id~ : String,
+  rows~ : Array[T],
+  columns~ : Array[DataTableColumn[T]],
+  row_key~ : (T) -> String,
+  page_size? : Int = 5,
+  searchable? : Bool = true,
+  selectable? : Bool = true,
+  show_columns? : Bool = true,
+  search_placeholder? : String = "Filter rows…",
+  empty_text? : String = "No results.",
+  aria_label? : String = "Data table",
+  default_sort_key? : String,
+  default_sort_descending? : Bool = false,
+  default_selected? : Array[String] = [],
+  default_hidden_columns? : Array[String] = [],
+  on_selection_change? : @cmd.Emit[Array[String]],
+  on_query_change? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = data_table_initial_model(
+    default_sort_key, default_sort_descending, default_selected, default_hidden_columns,
+  )
+  let page_size = if page_size < 1 { 1 } else { page_size }
+  let (model, emit) = @rabbita.create_state(
+    initial,
+    update=fn(_, message, current) {
+      let next = data_table_update(message, current)
+      let commands : Array[@cmd.Cmd] = []
+      match message {
+        DataTableSetSelection(_) =>
+          if on_selection_change is Some(notify) {
+            commands.push(notify(next.selected))
+          }
+        DataTableSetQuery(_) =>
+          if on_query_change is Some(notify) {
+            commands.push(notify(next.query))
+          }
+        _ => ()
+      }
+      (next, @cmd.batch(commands))
+    },
+    subscriptions=(emit, current) => {
+      if show_columns && current.columns_open {
+        data_table_columns_dismiss_subscription(id, emit(DataTableCloseColumns))
+      } else {
+        @sub.none
+      }
+    },
+  )
+  model.view(model => {
+    render_data_table(
+      id,
+      rows,
+      columns,
+      row_key,
+      model,
+      page_size,
+      searchable,
+      selectable,
+      show_columns,
+      search_placeholder,
+      empty_text,
+      aria_label,
+      Some(emit),
+      class,
+      title,
+      attrs,
+      style,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: render the requested initial table state as a
+/// constant incremental value.
+#cfg(not(target="js"))
+pub fn[T] data_table(
+  id~ : String,
+  rows~ : Array[T],
+  columns~ : Array[DataTableColumn[T]],
+  row_key~ : (T) -> String,
+  page_size? : Int = 5,
+  searchable? : Bool = true,
+  selectable? : Bool = true,
+  show_columns? : Bool = true,
+  search_placeholder? : String = "Filter rows…",
+  empty_text? : String = "No results.",
+  aria_label? : String = "Data table",
+  default_sort_key? : String,
+  default_sort_descending? : Bool = false,
+  default_selected? : Array[String] = [],
+  default_hidden_columns? : Array[String] = [],
+  on_selection_change? : @cmd.Emit[Array[String]],
+  on_query_change? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_selection_change, on_query_change))
+  let page_size = if page_size < 1 { 1 } else { page_size }
+  @rabbita.Val::constant(
+    render_data_table(
+      id,
+      rows,
+      columns,
+      row_key,
+      data_table_initial_model(
+        default_sort_key, default_sort_descending, default_selected, default_hidden_columns,
+      ),
+      page_size,
+      searchable,
+      selectable,
+      show_columns,
+      search_placeholder,
+      empty_text,
+      aria_label,
+      None,
+      class,
+      title,
+      attrs,
+      style,
+    ),
+  )
+}

--- a/rui/data_table_test.mbt
+++ b/rui/data_table_test.mbt
@@ -1,0 +1,97 @@
+///|
+priv struct DataTableTestRow {
+  id : String
+  status : String
+  email : String
+  amount : Int
+}
+
+///|
+fn data_table_test_rows() -> Array[DataTableTestRow] {
+  [
+    { id: "inv-001", status: "success", email: "ada@example.com", amount: 316 },
+    {
+      id: "inv-002",
+      status: "processing",
+      email: "grace@example.com",
+      amount: 242,
+    },
+    { id: "inv-003", status: "failed", email: "linus@example.com", amount: 837 },
+  ]
+}
+
+///|
+fn data_table_test_columns() -> Array[@rui.DataTableColumn[DataTableTestRow]] {
+  [
+    @rui.data_table_column(key="status", label="Status", value=row => row.status),
+    @rui.data_table_column(key="email", label="Email", value=row => row.email),
+    @rui.data_table_column(
+      key="amount",
+      label="Amount",
+      value=row => "\{row.amount}",
+      numeric=true,
+      render=row => @html.strong("$\{row.amount}"),
+    ),
+  ]
+}
+
+///|
+test "data table renders typed cells and black-box controls" {
+  let html = render_incremental(() => {
+    @rui.data_table(
+      id="payments",
+      rows=data_table_test_rows(),
+      columns=data_table_test_columns(),
+      row_key=row => row.id,
+      page_size=2,
+      default_sort_key="amount",
+      default_selected=["inv-002", "missing-row"],
+      style=["max-width:64rem"],
+    )
+  })
+  assert_contains(html, "data-slot=\"data-table\"")
+  assert_contains(html, "data-page=\"1\"")
+  assert_contains(html, "data-page-count=\"2\"")
+  assert_contains(html, "data-row-count=\"3\"")
+  assert_contains(html, "data-slot=\"data-table-search\"")
+  assert_contains(html, "data-slot=\"data-table-columns-trigger\"")
+  assert_contains(html, "id=\"payments-columns\"")
+  assert_contains(html, "data-slot=\"data-table-columns-wrap\"")
+  assert_contains(html, "data-state=\"closed\"")
+  assert_contains(html, "aria-haspopup=\"menu\"")
+  assert_contains(html, "aria-sort=\"ascending\"")
+  assert_contains(html, "data-table-row=\"\"")
+  assert_contains(html, "role=\"checkbox\"")
+  assert_contains(html, "1 of 3 row(s) selected.")
+  assert_contains(html, "Page 1 of 2")
+  assert_contains(html, "<strong>$242</strong>")
+  assert_contains(html, "max-width:64rem")
+  assert_contains(
+    html, "height:2rem;margin-inline-start:-0.25rem;padding-inline:0.5rem",
+  )
+  assert_not_contains(html, "margin-inline-start:-0.5rem")
+}
+
+///|
+test "data table honors hidden columns and caller style order" {
+  let html = render_incremental(() => {
+    @rui.data_table(
+      id="compact-payments",
+      rows=data_table_test_rows(),
+      columns=data_table_test_columns(),
+      row_key=row => row.id,
+      default_hidden_columns=["email"],
+      selectable=false,
+      searchable=false,
+      show_columns=false,
+      style=["gap:3rem"],
+    )
+  })
+  assert_contains(html, "data-slot=\"data-table\"")
+  assert_not_contains(html, "data-slot=\"data-table-search\"")
+  assert_not_contains(html, "data-slot=\"data-table-columns-trigger\"")
+  assert_not_contains(html, ">Email</")
+  assert_contains(html, "3 row(s).")
+  assert_contains(html, "gap:1rem")
+  assert_contains(html, "gap:3rem")
+}

--- a/rui/data_table_wbtest.mbt
+++ b/rui/data_table_wbtest.mbt
@@ -1,0 +1,11 @@
+///|
+#cfg(target="js")
+test "data table columns close message is idempotent" {
+  let initial = data_table_initial_model(None, false, [], [])
+  let open = data_table_update(DataTableToggleColumns, initial)
+  let closed = data_table_update(DataTableCloseColumns, open)
+  let closed_again = data_table_update(DataTableCloseColumns, closed)
+  assert_true(open.columns_open)
+  assert_false(closed.columns_open)
+  assert_false(closed_again.columns_open)
+}

--- a/rui/date_picker.mbt
+++ b/rui/date_picker.mbt
@@ -1,0 +1,1163 @@
+///|
+/// A caller-defined quick choice rendered inside [`date_picker`].
+struct DatePickerPreset {
+  label : String
+  value : CalendarDate
+} derive(Debug, Eq)
+
+///|
+pub fn date_picker_preset(
+  label~ : String,
+  value~ : CalendarDate,
+) -> DatePickerPreset {
+  { label, value }
+}
+
+///|
+/// An opaque range value. `end()` is `None` while the user is choosing the
+/// second boundary.
+struct DateRange {
+  start : CalendarDate
+  end : CalendarDate?
+} derive(Debug, Eq)
+
+///|
+/// Construct a normalized date range. If `end` precedes `start`, the two
+/// boundaries are exchanged.
+pub fn date_range(start~ : CalendarDate, end? : CalendarDate) -> DateRange {
+  if end is Some(end) && calendar_compare_dates(end, start) < 0 {
+    { start: end, end: Some(start) }
+  } else {
+    { start, end }
+  }
+}
+
+///|
+pub fn DateRange::start(self : DateRange) -> CalendarDate {
+  self.start
+}
+
+///|
+pub fn DateRange::end(self : DateRange) -> CalendarDate? {
+  self.end
+}
+
+///|
+priv struct DatePickerModel {
+  open : Bool
+  visible : CalendarDate
+  value : CalendarDate?
+  focused : CalendarDate
+} derive(Eq)
+
+///|
+priv struct DateRangePickerModel {
+  open : Bool
+  visible : CalendarDate
+  value : DateRange?
+  focused : CalendarDate
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum DatePickerMsg {
+  DatePickerToggle
+  DatePickerNativeChanged(Bool)
+  DatePickerNavigate(Int)
+  DatePickerChoose(CalendarDate)
+  DatePickerSetFocused(CalendarDate)
+  DatePickerMoveFocus(CalendarDate)
+}
+
+///|
+#cfg(target="js")
+priv enum DateRangePickerMsg {
+  DateRangePickerToggle
+  DateRangePickerNativeChanged(Bool)
+  DateRangePickerNavigate(Int)
+  DateRangePickerChoose(CalendarDate)
+  DateRangePickerSetFocused(CalendarDate)
+  DateRangePickerMoveFocus(CalendarDate)
+}
+
+///|
+const DatePickerRootStyle : String = "position:relative;display:inline-flex;width:fit-content;max-width:100%;min-width:0"
+
+///|
+const DatePickerTriggerStyle : String = "width:17.5rem;max-width:100%;justify-content:flex-start;gap:0.5rem;font-weight:400;text-align:left"
+
+///|
+const DatePickerTriggerLabelStyle : String = "min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"
+
+///|
+const DatePickerPlaceholderStyle : String = "color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+
+///|
+const DatePickerContentStyle : String = "width:15.5rem;min-width:0;max-width:calc(100vw - 1rem);gap:0;overflow:hidden;padding:0;box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1),0 2px 4px -2px rgb(0 0 0 / 0.1),0 0 0 1px color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent)"
+
+///|
+const DateRangePickerContentStyle : String = "width:var(--rui-date-range-picker-width,32rem);min-width:0;max-width:calc(100vw - 1rem);max-height:var(--rui-date-range-picker-max-height,none);position-try-order:most-height;gap:0;overflow-x:hidden;overflow-y:var(--rui-date-range-picker-overflow-y,hidden);padding:0;box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1),0 2px 4px -2px rgb(0 0 0 / 0.1),0 0 0 1px color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent)"
+
+///|
+const DatePickerContentInnerStyle : String = "display:flex;min-width:0;flex-direction:column"
+
+///|
+const DateRangePickerContentInnerStyle : String = "display:flex;width:100%;min-width:0;max-width:100%;flex-wrap:wrap;align-items:flex-start;justify-content:center;gap:1rem"
+
+///|
+const DatePickerPresetsStyle : String = "display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:0.25rem;border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));padding:0.5rem"
+
+///|
+const DatePickerPresetStyle : String = "width:100%;justify-content:flex-start"
+
+///|
+const DatePickerCalendarStyle : String = "width:15.5rem;min-width:0;max-width:100%;border-radius:0"
+
+///|
+const DateRangePickerCalendarStyle : String = "width:15.5rem;min-width:0;max-width:100%;flex:0 1 15.5rem;border-radius:0"
+
+///|
+fn date_picker_part_styles(
+  base : String,
+  overrides : Array[String],
+) -> Array[String] {
+  let styles = [base]
+  for custom_style in overrides {
+    styles.push(custom_style)
+  }
+  styles
+}
+
+///|
+fn date_picker_initial_model(
+  default_open : Bool,
+  disabled : Bool,
+  default_month : CalendarDate?,
+  default_value : CalendarDate?,
+  today : CalendarDate?,
+) -> DatePickerModel {
+  let calendar = calendar_initial_model(default_month, default_value, today)
+  {
+    open: default_open && !disabled,
+    visible: calendar.visible,
+    value: default_value,
+    focused: calendar.focused,
+  }
+}
+
+///|
+fn date_range_picker_initial_model(
+  default_open : Bool,
+  disabled : Bool,
+  default_month : CalendarDate?,
+  default_value : DateRange?,
+  today : CalendarDate?,
+) -> DateRangePickerModel {
+  let selected = default_value.map(value => value.start)
+  let calendar = calendar_initial_model(default_month, selected, today)
+  {
+    open: default_open && !disabled,
+    visible: calendar.visible,
+    value: default_value,
+    focused: calendar.focused,
+  }
+}
+
+///|
+fn date_picker_label(
+  value : CalendarDate?,
+  placeholder : String,
+  format_value : ((CalendarDate) -> String)?,
+) -> String {
+  if value is Some(value) {
+    if format_value is Some(format) {
+      format(value)
+    } else {
+      calendar_date_label(value)
+    }
+  } else {
+    placeholder
+  }
+}
+
+///|
+fn date_range_picker_default_label(value : DateRange) -> String {
+  let start = calendar_date_label(value.start)
+  if value.end is Some(end) {
+    "\{start} – \{calendar_date_label(end)}"
+  } else {
+    start
+  }
+}
+
+///|
+fn date_range_picker_label(
+  value : DateRange?,
+  placeholder : String,
+  format_value : ((DateRange) -> String)?,
+) -> String {
+  if value is Some(value) {
+    if format_value is Some(format) {
+      format(value)
+    } else {
+      date_range_picker_default_label(value)
+    }
+  } else {
+    placeholder
+  }
+}
+
+///|
+fn date_picker_trigger(
+  id : String,
+  open : Bool,
+  has_value : Bool,
+  disabled : Bool,
+  invalid : Bool,
+  aria_label : String?,
+  label : String,
+  on_toggle : @cmd.Cmd?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let trigger_id = "\{id}-trigger"
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "date-picker-trigger")
+    .data_set("variant", "outline")
+    .data_set("size", "default")
+    .data_set("state", if open { "open" } else { "closed" })
+    .data_set("placeholder", ui_bool(!has_value))
+    .aria_haspopup("dialog")
+    .aria_expanded(ui_bool(open))
+    .aria_controls(id)
+    .aria_disabled(ui_bool(disabled))
+  if aria_label is Some(aria_label) {
+    ignore(element_attrs.aria_label(aria_label))
+  }
+  if open {
+    ignore(element_attrs.data_set("open", ""))
+  }
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  } else if on_toggle is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  if invalid {
+    ignore(element_attrs.data_set("invalid", "").aria_invalid("true"))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(Outline),
+        button_size_style(Default),
+        DatePickerTriggerStyle,
+        if invalid {
+          InputInvalidStyle
+        } else {
+          ""
+        },
+        ui_disabled_style(disabled),
+        popup_anchor_style(trigger_id),
+      ],
+      style,
+    ),
+    id=trigger_id,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    [
+      ui_calendar_icon(),
+      @html.span(
+        style=ui_styles(
+          [
+            UiBoxSizing,
+            DatePickerTriggerLabelStyle,
+            if has_value {
+              ""
+            } else {
+              DatePickerPlaceholderStyle
+            },
+          ],
+          [],
+        ),
+        label,
+      ),
+    ],
+  )
+}
+
+///|
+fn date_picker_presets(
+  presets : Array[DatePickerPreset],
+  disabled : Bool,
+  choose : @cmd.Emit[CalendarDate]?,
+  style : Array[String],
+) -> @html.Html {
+  if presets.length() == 0 {
+    @html.nothing
+  } else {
+    let items = presets.map(preset => {
+      let command = choose.map(choose => choose(preset.value))
+      button(
+        variant=Ghost,
+        size=Sm,
+        disabled~,
+        on_click?=command,
+        attrs=@html.Attrs::build().data_set(
+          "preset-value",
+          preset.value.to_iso_string(),
+        ),
+        style=date_picker_part_styles(DatePickerPresetStyle, style),
+        slot="date-picker-preset",
+        preset.label,
+      )
+    })
+    @html.div(
+      style=[UiBoxSizing, DatePickerPresetsStyle],
+      attrs=@html.Attrs::build()
+        .data_set("slot", "date-picker-presets")
+        .aria_label("Date presets"),
+      items,
+    )
+  }
+}
+
+///|
+fn date_picker_root_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  open : Bool,
+  disabled : Bool,
+  invalid : Bool,
+) -> @html.Attrs {
+  let root_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("state", if open { "open" } else { "closed" })
+    .data_set("disabled", ui_bool(disabled))
+    .data_set("invalid", ui_bool(invalid))
+  if open {
+    ignore(root_attrs.data_set("open", ""))
+  }
+  root_attrs
+}
+
+///|
+fn render_date_picker(
+  id : String,
+  model : DatePickerModel,
+  today : CalendarDate?,
+  show_outside_days : Bool,
+  placeholder : String,
+  disabled : Bool,
+  invalid : Bool,
+  aria_label : String?,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+  presets : Array[DatePickerPreset],
+  format_value : ((CalendarDate) -> String)?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  trigger_attrs : @html.Attrs?,
+  trigger_style : Array[String],
+  content_attrs : @html.Attrs?,
+  content_style : Array[String],
+  calendar_attrs : @html.Attrs?,
+  calendar_style : Array[String],
+  day_attrs : @html.Attrs?,
+  day_style : Array[String],
+  preset_style : Array[String],
+  on_toggle : @cmd.Cmd?,
+  on_navigate : @cmd.Emit[Int]?,
+  on_choose : @cmd.Emit[CalendarDate]?,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+) -> @html.Html {
+  let label = date_picker_label(model.value, placeholder, format_value)
+  let root_attrs = date_picker_root_attrs(
+    attrs,
+    "date-picker",
+    model.open,
+    disabled,
+    invalid,
+  )
+  if model.value is Some(value) {
+    ignore(root_attrs.data_set("value", value.to_iso_string()))
+  }
+  let previous = on_navigate.map(navigate => navigate(-1))
+  let next = on_navigate.map(navigate => navigate(1))
+  let calendar_id = "\{id}-calendar"
+  let selected = model.value
+  @html.span(
+    style=ui_styles([UiBoxSizing, DatePickerRootStyle], style),
+    id="\{id}-root",
+    class?,
+    title?,
+    attrs=root_attrs,
+    [
+      date_picker_trigger(
+        id,
+        model.open,
+        model.value is Some(_),
+        disabled,
+        invalid,
+        aria_label,
+        label,
+        on_toggle,
+        trigger_attrs,
+        trigger_style,
+      ),
+      popover_content(
+        id~,
+        trigger_id="\{id}-trigger",
+        open=model.open,
+        initial_focus=true,
+        restore_focus=true,
+        final_focus_id="\{id}-trigger",
+        side~,
+        align~,
+        side_offset~,
+        align_offset~,
+        attrs?=content_attrs,
+        style=date_picker_part_styles(DatePickerContentStyle, content_style),
+        @html.div(
+          style=[UiBoxSizing, DatePickerContentInnerStyle],
+          attrs=@html.Attrs::build().data_set("slot", "date-picker-content"),
+          [
+            date_picker_presets(presets, disabled, on_choose, preset_style),
+            render_calendar(
+              month=model.visible,
+              selected?,
+              today?,
+              focused=model.focused,
+              show_outside_days~,
+              disabled~,
+              aria_label="Date picker calendar",
+              on_previous?=previous,
+              on_next?=next,
+              on_select?=on_choose,
+              on_focus_change?,
+              on_focus_move?,
+              id=calendar_id,
+              attrs?=calendar_attrs,
+              day_attrs?,
+              style=date_picker_part_styles(
+                DatePickerCalendarStyle,
+                calendar_style,
+              ),
+              day_style~,
+            ),
+          ],
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn render_date_range_picker(
+  id : String,
+  model : DateRangePickerModel,
+  today : CalendarDate?,
+  show_outside_days : Bool,
+  placeholder : String,
+  disabled : Bool,
+  invalid : Bool,
+  aria_label : String?,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+  format_value : ((DateRange) -> String)?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  trigger_attrs : @html.Attrs?,
+  trigger_style : Array[String],
+  content_attrs : @html.Attrs?,
+  content_style : Array[String],
+  calendar_attrs : @html.Attrs?,
+  calendar_style : Array[String],
+  day_attrs : @html.Attrs?,
+  day_style : Array[String],
+  on_toggle : @cmd.Cmd?,
+  on_navigate : @cmd.Emit[Int]?,
+  on_choose : @cmd.Emit[CalendarDate]?,
+  on_focus_change : @cmd.Emit[CalendarDate]?,
+  on_focus_move : @cmd.Emit[CalendarDate]?,
+) -> @html.Html {
+  let label = date_range_picker_label(model.value, placeholder, format_value)
+  let root_attrs = date_picker_root_attrs(
+    attrs,
+    "date-range-picker",
+    model.open,
+    disabled,
+    invalid,
+  )
+  let range_start = model.value.map(value => value.start)
+  let range_end = if model.value is Some(value) { value.end } else { None }
+  if range_start is Some(start) {
+    ignore(root_attrs.data_set("range-start", start.to_iso_string()))
+  }
+  if range_end is Some(end) {
+    ignore(root_attrs.data_set("range-end", end.to_iso_string()))
+  }
+  let previous = on_navigate.map(navigate => navigate(-1))
+  let next = on_navigate.map(navigate => navigate(1))
+  let following_month = calendar_shift_month(model.visible, 1)
+  let range_calendar_style = date_picker_part_styles(
+    DateRangePickerCalendarStyle,
+    calendar_style,
+  )
+  let range_content_attrs = ui_attrs(content_attrs).data_set(
+    "date-range-picker-popup", "",
+  )
+  @html.span(
+    style=ui_styles([UiBoxSizing, DatePickerRootStyle], style),
+    id="\{id}-root",
+    class?,
+    title?,
+    attrs=root_attrs,
+    [
+      date_picker_trigger(
+        id,
+        model.open,
+        model.value is Some(_),
+        disabled,
+        invalid,
+        aria_label,
+        label,
+        on_toggle,
+        trigger_attrs,
+        trigger_style,
+      ),
+      popover_content(
+        id~,
+        trigger_id="\{id}-trigger",
+        open=model.open,
+        initial_focus=true,
+        restore_focus=true,
+        final_focus_id="\{id}-trigger",
+        side~,
+        align~,
+        side_offset~,
+        align_offset~,
+        attrs=range_content_attrs,
+        style=date_picker_part_styles(
+          DateRangePickerContentStyle,
+          content_style,
+        ),
+        @html.div(
+          style=[UiBoxSizing, DateRangePickerContentInnerStyle],
+          attrs=@html.Attrs::build().data_set(
+            "slot", "date-range-picker-content",
+          ),
+          [
+            render_calendar(
+              month=model.visible,
+              selection_mode=CalendarRangeSelection,
+              range_start?,
+              range_end?,
+              today?,
+              focused=model.focused,
+              show_outside_days~,
+              hide_outside_after=true,
+              disabled~,
+              aria_label="Date range picker calendar",
+              on_previous?=previous,
+              on_select?=on_choose,
+              on_focus_change?,
+              on_focus_move?,
+              show_next=false,
+              id="\{id}-calendar",
+              attrs?=calendar_attrs,
+              day_attrs?,
+              style=range_calendar_style,
+              nav_style=["justify-content:flex-start"],
+              day_style~,
+            ),
+            render_calendar(
+              month=following_month,
+              selection_mode=CalendarRangeSelection,
+              range_start?,
+              range_end?,
+              today?,
+              focused=model.focused,
+              show_outside_days~,
+              hide_outside_before=true,
+              disabled~,
+              aria_label="Date range picker following calendar",
+              on_next?=next,
+              on_select?=on_choose,
+              on_focus_change?,
+              on_focus_move?,
+              show_previous=false,
+              id="\{id}-calendar-next",
+              attrs?=calendar_attrs,
+              day_attrs?,
+              style=range_calendar_style,
+              nav_style=["justify-content:flex-end"],
+              day_style~,
+            ),
+          ],
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+#cfg(target="js")
+fn[T] date_picker_notify(emit : @cmd.Emit[T]?, value : T) -> @cmd.Cmd {
+  if emit is Some(emit) {
+    emit(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn date_picker_update(
+  id : String,
+  disabled : Bool,
+  today : CalendarDate?,
+  on_value_change : @cmd.Emit[CalendarDate]?,
+  on_open_change : @cmd.Emit[Bool]?,
+  message : DatePickerMsg,
+  current : DatePickerModel,
+) -> (DatePickerModel, @cmd.Cmd) {
+  match message {
+    DatePickerToggle =>
+      if disabled {
+        (current, @cmd.none)
+      } else {
+        let open = !current.open
+        (
+          { ..current, open, },
+          @cmd.batch([
+            floating_set_open_cmd(id, open),
+            date_picker_notify(on_open_change, open),
+          ]),
+        )
+      }
+    DatePickerNativeChanged(open) =>
+      if open == current.open {
+        (current, @cmd.none)
+      } else {
+        ({ ..current, open, }, date_picker_notify(on_open_change, open))
+      }
+    DatePickerNavigate(delta) => {
+      let visible = calendar_shift_month(current.visible, delta)
+      let focused = calendar_focus_target(visible, current.value, today)
+      ({ ..current, visible, focused }, @cmd.none)
+    }
+    DatePickerChoose(value) => {
+      let visible = calendar_first_of_month(value)
+      (
+        { open: false, visible, value: Some(value), focused: value },
+        @cmd.batch([
+          date_picker_notify(on_value_change, value),
+          floating_set_open_cmd(id, false),
+          if current.open {
+            date_picker_notify(on_open_change, false)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    }
+    DatePickerSetFocused(value) => ({ ..current, focused: value }, @cmd.none)
+    DatePickerMoveFocus(value) => {
+      let visible = calendar_first_of_month(value)
+      (
+        { ..current, visible, focused: value },
+        calendar_focus_day_cmd(Some("\{id}-calendar"), value),
+      )
+    }
+  }
+}
+
+///|
+fn date_range_picker_next_value(
+  current : DateRange?,
+  chosen : CalendarDate,
+) -> (DateRange, Bool) {
+  let complete = current is Some(range) && range.end is None
+  (calendar_range_next_value(current, chosen), complete)
+}
+
+///|
+fn date_range_picker_visible_for_date(
+  visible : CalendarDate,
+  date : CalendarDate,
+) -> CalendarDate {
+  let visible = calendar_first_of_month(visible)
+  let following = calendar_shift_month(visible, 1)
+  if calendar_same_month(date, visible) || calendar_same_month(date, following) {
+    visible
+  } else {
+    calendar_first_of_month(date)
+  }
+}
+
+///|
+fn date_range_picker_focus_calendar_id(
+  id : String,
+  visible : CalendarDate,
+  date : CalendarDate,
+) -> String {
+  if calendar_same_month(date, calendar_shift_month(visible, 1)) {
+    "\{id}-calendar-next"
+  } else {
+    "\{id}-calendar"
+  }
+}
+
+///|
+#cfg(target="js")
+fn date_range_picker_update(
+  id : String,
+  disabled : Bool,
+  today : CalendarDate?,
+  on_value_change : @cmd.Emit[DateRange]?,
+  on_open_change : @cmd.Emit[Bool]?,
+  message : DateRangePickerMsg,
+  current : DateRangePickerModel,
+) -> (DateRangePickerModel, @cmd.Cmd) {
+  match message {
+    DateRangePickerToggle =>
+      if disabled {
+        (current, @cmd.none)
+      } else {
+        let open = !current.open
+        (
+          { ..current, open, },
+          @cmd.batch([
+            floating_set_open_cmd(id, open),
+            date_picker_notify(on_open_change, open),
+          ]),
+        )
+      }
+    DateRangePickerNativeChanged(open) =>
+      if open == current.open {
+        (current, @cmd.none)
+      } else {
+        ({ ..current, open, }, date_picker_notify(on_open_change, open))
+      }
+    DateRangePickerNavigate(delta) => {
+      let visible = calendar_shift_month(current.visible, delta)
+      let selected = current.value.map(value => value.start)
+      let focused = calendar_focus_target(visible, selected, today)
+      ({ ..current, visible, focused }, @cmd.none)
+    }
+    DateRangePickerChoose(chosen) => {
+      let (value, complete) = date_range_picker_next_value(
+        current.value,
+        chosen,
+      )
+      let visible = date_range_picker_visible_for_date(current.visible, chosen)
+      let open = !complete
+      (
+        { open, visible, value: Some(value), focused: chosen },
+        @cmd.batch([
+          date_picker_notify(on_value_change, value),
+          if complete {
+            floating_set_open_cmd(id, false)
+          } else {
+            @cmd.none
+          },
+          if complete && current.open {
+            date_picker_notify(on_open_change, false)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    }
+    DateRangePickerSetFocused(value) =>
+      ({ ..current, focused: value }, @cmd.none)
+    DateRangePickerMoveFocus(value) => {
+      let visible = date_range_picker_visible_for_date(current.visible, value)
+      let focus_calendar_id = date_range_picker_focus_calendar_id(
+        id, visible, value,
+      )
+      (
+        { ..current, visible, focused: value },
+        calendar_focus_day_cmd(Some(focus_calendar_id), value),
+      )
+    }
+  }
+}
+
+///|
+/// Stateful single-date picker composed from the package's native Calendar
+/// and CSS-anchored Popover primitives. Selecting a date updates the trigger,
+/// calls `on_value_change`, and closes the popup.
+#cfg(target="js")
+pub fn date_picker(
+  id~ : String,
+  default_value? : CalendarDate,
+  default_month? : CalendarDate,
+  today? : CalendarDate,
+  default_open? : Bool = false,
+  show_outside_days? : Bool = true,
+  placeholder? : String = "Pick a date",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  aria_label? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  presets? : Array[DatePickerPreset] = [],
+  format_value? : (CalendarDate) -> String,
+  on_value_change? : @cmd.Emit[CalendarDate],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  calendar_attrs? : @html.Attrs,
+  calendar_style? : Array[String] = [],
+  day_attrs? : @html.Attrs,
+  day_style? : Array[String] = [],
+  preset_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = date_picker_initial_model(
+    default_open, disabled, default_month, default_value, today,
+  )
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        @cmd.batch([
+          floating_bind_sync_cmd(
+            id,
+            emit.map(open => DatePickerNativeChanged(open)),
+          ),
+          if initial.open {
+            floating_set_open_cmd(id, true)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(_, message, current) => {
+      date_picker_update(
+        id, disabled, today, on_value_change, on_open_change, message, current,
+      )
+    },
+  )
+  let navigate = emit.map(delta => DatePickerNavigate(delta))
+  let choose = emit.map(value => DatePickerChoose(value))
+  let focus = emit.map(value => DatePickerSetFocused(value))
+  let move_focus = emit.map(value => DatePickerMoveFocus(value))
+  model.view(model => {
+    render_date_picker(
+      id,
+      model,
+      today,
+      show_outside_days,
+      placeholder,
+      disabled,
+      invalid,
+      aria_label,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      presets,
+      format_value,
+      class,
+      title,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      calendar_attrs,
+      calendar_style,
+      day_attrs,
+      day_style,
+      preset_style,
+      Some(emit(DatePickerToggle)),
+      Some(navigate),
+      Some(choose),
+      Some(focus),
+      Some(move_focus),
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for [`date_picker`].
+#cfg(not(target="js"))
+pub fn date_picker(
+  id~ : String,
+  default_value? : CalendarDate,
+  default_month? : CalendarDate,
+  today? : CalendarDate,
+  default_open? : Bool = false,
+  show_outside_days? : Bool = true,
+  placeholder? : String = "Pick a date",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  aria_label? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  presets? : Array[DatePickerPreset] = [],
+  format_value? : (CalendarDate) -> String,
+  on_value_change? : @cmd.Emit[CalendarDate],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  calendar_attrs? : @html.Attrs,
+  calendar_style? : Array[String] = [],
+  day_attrs? : @html.Attrs,
+  day_style? : Array[String] = [],
+  preset_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_change, on_open_change))
+  let initial = date_picker_initial_model(
+    default_open, disabled, default_month, default_value, today,
+  )
+  let choose : @cmd.Emit[CalendarDate] = Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_date_picker(
+      id,
+      initial,
+      today,
+      show_outside_days,
+      placeholder,
+      disabled,
+      invalid,
+      aria_label,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      presets,
+      format_value,
+      class,
+      title,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      calendar_attrs,
+      calendar_style,
+      day_attrs,
+      day_style,
+      preset_style,
+      None,
+      None,
+      Some(choose),
+      None,
+      None,
+    ),
+  )
+}
+
+///|
+/// Stateful date-range picker. The first click starts a range and emits a
+/// `DateRange` whose `end()` is `None`; the second click normalizes its
+/// boundaries, emits the completed range, and closes the popup. Clicking after
+/// a completed range starts a new selection.
+#cfg(target="js")
+pub fn date_range_picker(
+  id~ : String,
+  default_value? : DateRange,
+  default_month? : CalendarDate,
+  today? : CalendarDate,
+  default_open? : Bool = false,
+  show_outside_days? : Bool = true,
+  placeholder? : String = "Pick a date range",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  aria_label? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  format_value? : (DateRange) -> String,
+  on_value_change? : @cmd.Emit[DateRange],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  calendar_attrs? : @html.Attrs,
+  calendar_style? : Array[String] = [],
+  day_attrs? : @html.Attrs,
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let initial = date_range_picker_initial_model(
+    default_open, disabled, default_month, default_value, today,
+  )
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        @cmd.batch([
+          floating_bind_sync_cmd(
+            id,
+            emit.map(open => DateRangePickerNativeChanged(open)),
+          ),
+          if initial.open {
+            floating_set_open_cmd(id, true)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(_, message, current) => {
+      date_range_picker_update(
+        id, disabled, today, on_value_change, on_open_change, message, current,
+      )
+    },
+  )
+  let navigate = emit.map(delta => DateRangePickerNavigate(delta))
+  let choose = emit.map(value => DateRangePickerChoose(value))
+  let focus = emit.map(value => DateRangePickerSetFocused(value))
+  let move_focus = emit.map(value => DateRangePickerMoveFocus(value))
+  model.view(model => {
+    render_date_range_picker(
+      id,
+      model,
+      today,
+      show_outside_days,
+      placeholder,
+      disabled,
+      invalid,
+      aria_label,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      format_value,
+      class,
+      title,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      calendar_attrs,
+      calendar_style,
+      day_attrs,
+      day_style,
+      Some(emit(DateRangePickerToggle)),
+      Some(navigate),
+      Some(choose),
+      Some(focus),
+      Some(move_focus),
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback for [`date_range_picker`].
+#cfg(not(target="js"))
+pub fn date_range_picker(
+  id~ : String,
+  default_value? : DateRange,
+  default_month? : CalendarDate,
+  today? : CalendarDate,
+  default_open? : Bool = false,
+  show_outside_days? : Bool = true,
+  placeholder? : String = "Pick a date range",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  aria_label? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  format_value? : (DateRange) -> String,
+  on_value_change? : @cmd.Emit[DateRange],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  calendar_attrs? : @html.Attrs,
+  calendar_style? : Array[String] = [],
+  day_attrs? : @html.Attrs,
+  day_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_change, on_open_change))
+  let initial = date_range_picker_initial_model(
+    default_open, disabled, default_month, default_value, today,
+  )
+  let choose : @cmd.Emit[CalendarDate] = Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_date_range_picker(
+      id,
+      initial,
+      today,
+      show_outside_days,
+      placeholder,
+      disabled,
+      invalid,
+      aria_label,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      format_value,
+      class,
+      title,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      calendar_attrs,
+      calendar_style,
+      day_attrs,
+      day_style,
+      None,
+      None,
+      Some(choose),
+      None,
+      None,
+    ),
+  )
+}

--- a/rui/date_picker_test.mbt
+++ b/rui/date_picker_test.mbt
@@ -1,0 +1,254 @@
+///|
+#cfg(target="js")
+extern "js" fn install_date_picker_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 }
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_incremental_date_picker(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_date_picker_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_incremental_date_picker(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+test "date range is opaque, inspectable, and normalizes reversed boundaries" {
+  let earlier = @rui.calendar_date(year=2026, month=7, day=10)
+  let later = @rui.calendar_date(year=2026, month=7, day=18)
+  let normalized = @rui.date_range(start=later, end=earlier)
+  assert_eq(normalized.start(), earlier)
+  assert_eq(normalized.end(), Some(later))
+
+  let partial = @rui.date_range(start=earlier)
+  assert_eq(partial.start(), earlier)
+  assert_eq(partial.end(), None)
+}
+
+///|
+test "single date picker renders a CSS-anchored interactive composition" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let selected = @rui.calendar_date(year=2026, month=7, day=16)
+  let html = render_incremental_date_picker(() => {
+    @rui.date_picker(
+      id="release-date",
+      default_value=selected,
+      today=selected,
+      default_open=true,
+      invalid=true,
+      side=Bottom,
+      align=Start,
+      presets=[
+        @rui.date_picker_preset(label="Today", value=selected),
+        @rui.date_picker_preset(
+          label="Launch day",
+          value=@rui.calendar_date(year=2026, month=8, day=1),
+        ),
+      ],
+      format_value=date => "Selected \{date.to_iso_string()}",
+      attrs~,
+      style=["background:rebeccapurple"],
+      trigger_style=["width:20rem"],
+      content_style=["min-width:20rem"],
+      calendar_style=["background:linen"],
+      day_style=["font-variant-numeric:tabular-nums"],
+      preset_style=["min-height:2.5rem"],
+    )
+  })
+  assert_contains(html, "data-slot=\"date-picker\"")
+  assert_contains(html, "id=\"release-date-root\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-value=\"2026-07-16\"")
+  assert_contains(html, "data-owner=\"caller\"")
+  assert_contains(html, "background:rebeccapurple")
+  assert_contains(html, "data-slot=\"date-picker-trigger\"")
+  assert_contains(html, "data-variant=\"outline\"")
+  assert_contains(html, "data-size=\"default\"")
+  assert_contains(html, "id=\"release-date-trigger\"")
+  assert_contains(html, "aria-haspopup=\"dialog\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "aria-controls=\"release-date\"")
+  assert_contains(html, "aria-invalid=\"true\"")
+  assert_contains(html, "Selected 2026-07-16")
+  assert_contains(html, "width:20rem")
+  assert_contains(html, "<svg")
+  assert_contains(html, "id=\"release-date\"")
+  assert_contains(html, "popover=\"auto\"")
+  assert_contains(html, "role=\"dialog\"")
+  assert_contains(html, "data-trigger-id=\"release-date-trigger\"")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_contains(html, "position-area:bottom span-x-end")
+  assert_contains(html, "data-slot=\"date-picker-content\"")
+  assert_contains(html, "min-width:20rem")
+  assert_contains(html, "data-slot=\"date-picker-presets\"")
+  assert_contains(html, "data-slot=\"date-picker-preset\"")
+  assert_contains(html, "data-preset-value=\"2026-07-16\"")
+  assert_contains(html, "data-preset-value=\"2026-08-01\"")
+  assert_contains(html, "min-height:2.5rem")
+  assert_contains(html, "data-slot=\"calendar\"")
+  assert_contains(html, "id=\"release-date-calendar\"")
+  assert_contains(html, "aria-label=\"Date picker calendar\"")
+  assert_contains(html, "data-day=\"2026-07-16\"")
+  assert_contains(html, "data-selected-single=\"true\"")
+  assert_contains(html, "background:linen")
+  assert_contains(html, "font-variant-numeric:tabular-nums")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot=\"date-picker\"")
+  assert_not_contains(original, "data-state=\"open\"")
+}
+
+///|
+test "date picker placeholder and disabled state normalize an open default" {
+  let html = render_incremental_date_picker(() => {
+    @rui.date_picker(
+      id="disabled-date",
+      default_open=true,
+      disabled=true,
+      placeholder="Choose birthday",
+    )
+  })
+  assert_contains(html, "data-slot=\"date-picker\"")
+  assert_contains(html, "data-state=\"closed\"")
+  assert_contains(html, "data-disabled=\"true\"")
+  assert_contains(html, "data-placeholder=\"true\"")
+  assert_contains(html, "aria-expanded=\"false\"")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, " disabled")
+  assert_contains(html, ">Choose birthday</span>")
+  assert_contains(html, "color:var(--rui-muted-foreground,oklch(0.556 0 0))")
+  assert_not_contains(html, "data-state=\"open\"")
+}
+
+///|
+test "date range picker exposes default boundaries and range day semantics" {
+  let start = @rui.calendar_date(year=2026, month=7, day=10)
+  let end = @rui.calendar_date(year=2026, month=7, day=15)
+  let html = render_incremental_date_picker(() => {
+    @rui.date_range_picker(
+      id="sprint-range",
+      default_value=@rui.date_range(start~, end~),
+      default_open=true,
+      format_value=range => {
+        let finish = range
+          .end()
+          .map(date => date.to_iso_string())
+          .unwrap_or("…")
+        "\{range.start().to_iso_string()} / \{finish}"
+      },
+      style=["outline:1px solid rebeccapurple"],
+      trigger_style=["width:22rem"],
+      content_style=["box-shadow:none"],
+      day_style=["letter-spacing:0.01em"],
+    )
+  })
+  assert_contains(html, "data-slot=\"date-range-picker\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-range-start=\"2026-07-10\"")
+  assert_contains(html, "data-range-end=\"2026-07-15\"")
+  assert_contains(html, "2026-07-10 / 2026-07-15")
+  assert_contains(html, "outline:1px solid rebeccapurple")
+  assert_contains(html, "width:22rem")
+  assert_contains(html, "box-shadow:none")
+  assert_contains(html, "data-slot=\"date-range-picker-content\"")
+  assert_contains(html, "aria-label=\"Date range picker calendar\"")
+  assert_contains(html, "data-mode=\"range\"")
+  assert_contains(html, "aria-multiselectable=\"true\"")
+  assert_contains(html, "data-day=\"2026-07-10\"")
+  assert_contains(html, "data-range-start=\"\"")
+  assert_contains(html, "data-day=\"2026-07-15\"")
+  assert_contains(html, "data-range-end=\"\"")
+  assert_contains(html, "data-day=\"2026-07-12\"")
+  assert_contains(html, "data-range-middle=\"\"")
+  assert_contains(html, "aria-selected=\"true\"")
+  assert_contains(
+    html, "linear-gradient(var(--rui-calendar-range-start-direction,to right)",
+  )
+  assert_contains(
+    html, "linear-gradient(var(--rui-calendar-range-end-direction,to right)",
+  )
+  assert_contains(
+    html, "--rui-calendar-base-bg:var(--rui-accent,oklch(0.97 0 0))",
+  )
+  assert_contains(html, "border-radius:0")
+  assert_contains(html, "letter-spacing:0.01em")
+  assert_not_contains(html, "data-selected-single=\"true\"")
+}
+
+///|
+test "date range picker popup renders the shadcn-style two-month surface" {
+  let january = @rui.calendar_date(year=2026, month=1, day=1)
+  let start = @rui.calendar_date(year=2026, month=1, day=20)
+  let end = @rui.calendar_date(year=2026, month=2, day=9)
+  let html = render_incremental_date_picker(() => {
+    @rui.date_range_picker(
+      id="range-popup",
+      default_month=january,
+      default_value=@rui.date_range(start~, end~),
+      default_open=true,
+    )
+  })
+  assert_contains(html, "data-slot=\"popover-content\"")
+  assert_contains(html, "role=\"dialog\"")
+  assert_contains(html, "data-trigger-id=\"range-popup-trigger\"")
+  assert_contains(html, "data-side=\"bottom\"")
+  assert_contains(html, "data-align=\"start\"")
+  assert_contains(html, "data-side-offset=\"4\"")
+  assert_contains(
+    html, "width:var(--rui-date-range-picker-width,32rem);min-width:0;max-width:calc(100vw - 1rem);max-height:var(--rui-date-range-picker-max-height,none);position-try-order:most-height;gap:0;overflow-x:hidden;overflow-y:var(--rui-date-range-picker-overflow-y,hidden);padding:0",
+  )
+  assert_contains(html, "data-date-range-picker-popup=\"\"")
+  assert_contains(html, "box-shadow:0 4px 6px -1px")
+  assert_contains(html, "data-slot=\"date-range-picker-content\"")
+  assert_contains(
+    html, "display:flex;width:100%;min-width:0;max-width:100%;flex-wrap:wrap;align-items:flex-start;justify-content:center;gap:1rem",
+  )
+  assert_contains(html, "id=\"range-popup-calendar\"")
+  assert_contains(html, "data-month=\"2026-01-01\"")
+  assert_contains(html, "id=\"range-popup-calendar-next\"")
+  assert_contains(html, "data-month=\"2026-02-01\"")
+  assert_eq(html.split("data-slot=\"calendar\"").count(), 3)
+  assert_eq(html.split("aria-label=\"Go to previous month\"").count(), 2)
+  assert_eq(html.split("aria-label=\"Go to next month\"").count(), 2)
+  assert_eq(html.split("data-day=\"2026-01-31\"").count(), 2)
+  assert_eq(html.split("data-day=\"2026-02-01\"").count(), 2)
+  assert_contains(
+    html, "border-start-start-radius:var(--rui-calendar-cell-radius)",
+  )
+  assert_contains(
+    html, "border-start-end-radius:var(--rui-calendar-cell-radius)",
+  )
+}
+
+///|
+test "partial date range remains a real initial selection" {
+  let start = @rui.calendar_date(year=1990, month=4, day=7)
+  let html = render_incremental_date_picker(() => {
+    @rui.date_range_picker(
+      id="partial-range",
+      default_value=@rui.date_range(start~),
+      placeholder="Birthday window",
+    )
+  })
+  assert_contains(html, "data-range-start=\"1990-04-07\"")
+  assert_not_contains(html, "data-range-end=\"")
+  assert_contains(html, ">April 7, 1990</span>")
+  assert_contains(html, "data-range-start=\"\"")
+  assert_contains(html, "aria-selected=\"true\"")
+}

--- a/rui/date_picker_wbtest.mbt
+++ b/rui/date_picker_wbtest.mbt
@@ -1,0 +1,72 @@
+///|
+#cfg(target="js")
+test "single date picker selection commits and closes in one state update" {
+  let initial = date_picker_initial_model(
+    true,
+    false,
+    Some(calendar_date(year=2026, month=7, day=1)),
+    None,
+    None,
+  )
+  let chosen = calendar_date(year=2026, month=7, day=16)
+  let (next, _) = date_picker_update(
+    "release-date",
+    false,
+    None,
+    None,
+    None,
+    DatePickerChoose(chosen),
+    initial,
+  )
+  assert_false(next.open)
+  assert_eq(next.value, Some(chosen))
+  assert_eq(next.visible, calendar_date(year=2026, month=7, day=1))
+  assert_eq(next.focused, chosen)
+}
+
+///|
+test "range selection starts, completes, normalizes, then restarts" {
+  let later = calendar_date(year=2026, month=7, day=18)
+  let earlier = calendar_date(year=2026, month=7, day=10)
+  let (started, started_complete) = date_range_picker_next_value(None, later)
+  assert_false(started_complete)
+  assert_eq(started.start, later)
+  assert_eq(started.end, None)
+
+  let (completed, completed_now) = date_range_picker_next_value(
+    Some(started),
+    earlier,
+  )
+  assert_true(completed_now)
+  assert_eq(completed.start, earlier)
+  assert_eq(completed.end, Some(later))
+
+  let restart = calendar_date(year=2026, month=8, day=2)
+  let (restarted, restarted_complete) = date_range_picker_next_value(
+    Some(completed),
+    restart,
+  )
+  assert_false(restarted_complete)
+  assert_eq(restarted.start, restart)
+  assert_eq(restarted.end, None)
+}
+
+///|
+test "two-month range window stays stable for selection and keyboard focus" {
+  let january = calendar_date(year=2026, month=1, day=1)
+  let february_day = calendar_date(year=2026, month=2, day=9)
+  let march_day = calendar_date(year=2026, month=3, day=2)
+  assert_eq(date_range_picker_visible_for_date(january, february_day), january)
+  assert_eq(
+    date_range_picker_focus_calendar_id("range", january, february_day),
+    "range-calendar-next",
+  )
+  assert_eq(
+    date_range_picker_visible_for_date(january, march_day),
+    calendar_date(year=2026, month=3, day=1),
+  )
+  assert_eq(
+    date_range_picker_focus_calendar_id("range", march_day, march_day),
+    "range-calendar",
+  )
+}

--- a/rui/dialog.mbt
+++ b/rui/dialog.mbt
@@ -1,0 +1,680 @@
+///|
+/// Explicit scope passed by [`dialog`] to its compound parts.
+///
+/// Rabbita does not need a global component context here: the opaque scope
+/// carries the component-local state and commands without exposing them to
+/// callers.
+struct DialogScope {
+  id : String
+  open : Bool
+  open_command : @cmd.Cmd
+  close_command : @cmd.Cmd
+  on_close : @cmd.Emit[String]?
+  on_cancel : @cmd.Cmd?
+  native_open : Bool?
+  modal : Bool
+  close_on_escape : Bool
+}
+
+///|
+#cfg(target="js")
+priv struct DialogModel {
+  open : Bool
+  generation : Int
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum DialogMessage {
+  OpenDialog
+  RequestDialogClose
+  FinalizeDialogClose(Int)
+  DialogDidClose(String)
+}
+
+///|
+const DialogExitDurationMs : Int = 200
+
+///|
+const DialogNativeStyle : String = "width:100vw;height:100vh;max-width:none;max-height:none;margin:auto;border:0;padding:0;background:transparent;color:inherit;overflow:visible;pointer-events:none;transition:display 200ms,overlay 200ms;transition-behavior:allow-discrete"
+
+///|
+const DialogOverlayStyle : String = "position:fixed;inset:0;z-index:50;background:rgb(0 0 0 / 0.5);opacity:var(--rui-dialog-overlay-opacity,1);pointer-events:auto;transition:opacity 200ms ease"
+
+///|
+const DialogPositionerStyle : String = "position:fixed;inset:0;z-index:51;display:grid;place-items:center;overflow-y:auto;padding:1rem;pointer-events:none"
+
+///|
+const DialogContentStyle : String = "position:relative;display:grid;width:min(100%,32rem);max-height:calc(100vh - 2rem);gap:1rem;overflow-y:auto;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem);background:var(--rui-popover,var(--rui-background,oklch(1 0 0)));padding:1.5rem;color:var(--rui-popover-foreground,var(--rui-foreground,oklch(0.145 0 0)));box-shadow:0 16px 48px rgb(0 0 0 / 0.18);opacity:var(--rui-dialog-content-opacity,1);transform:var(--rui-dialog-content-transform,translateY(0) scale(1));pointer-events:auto;transition:opacity 200ms ease,transform 200ms ease"
+
+///|
+const DialogHeaderStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.375rem;text-align:start"
+
+///|
+const DialogFooterStyle : String = "display:flex;flex-wrap:wrap;align-items:center;justify-content:flex-end;gap:0.5rem"
+
+///|
+const DialogTitleStyle : String = "margin:0;color:var(--rui-foreground,oklch(0.145 0 0));font-size:1.125rem;line-height:1.25;font-weight:600;letter-spacing:-0.01em;text-wrap:balance"
+
+///|
+const DialogDescriptionStyle : String = "margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.5;text-wrap:pretty"
+
+///|
+const DialogCloseIconButtonStyle : String = "position:absolute;top:1rem;inset-inline-end:1rem;background:var(--rui-close-bg,var(--rui-button-bg,var(--rui-button-base-bg,transparent)));color:var(--rui-close-fg,var(--rui-button-fg,var(--rui-button-base-fg,currentColor)));box-shadow:var(--rui-close-shadow,var(--rui-button-shadow,var(--rui-button-base-shadow,none)));opacity:var(--rui-close-opacity,var(--rui-close-base-opacity,0.7))"
+
+///|
+fn DialogScope::title_id(self : DialogScope) -> String {
+  "\{self.id}-title"
+}
+
+///|
+fn DialogScope::description_id(self : DialogScope) -> String {
+  "\{self.id}-description"
+}
+
+///|
+#cfg(target="js")
+fn[T] dialog_emit_or_none(emit : @cmd.Emit[T]?, value : T) -> @cmd.Cmd {
+  if emit is Some(emit) {
+    emit(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn dialog_state_value(open : Bool) -> String {
+  if open {
+    "open"
+  } else {
+    "closed"
+  }
+}
+
+///|
+fn dialog_overlay_motion_style(open : Bool) -> String {
+  if open {
+    "--rui-dialog-overlay-opacity:1"
+  } else {
+    "--rui-dialog-overlay-opacity:0;pointer-events:none"
+  }
+}
+
+///|
+fn dialog_content_motion_style(open : Bool) -> String {
+  if open {
+    "--rui-dialog-content-opacity:1;--rui-dialog-content-transform:translateY(0) scale(1)"
+  } else {
+    "--rui-dialog-content-opacity:0;--rui-dialog-content-transform:translateY(-0.5rem) scale(0.95);pointer-events:none"
+  }
+}
+
+///|
+fn dialog_state_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  open : Bool,
+) -> @html.Attrs {
+  let state = dialog_state_value(open)
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("state", state)
+  if open {
+    ignore(element_attrs.data_set("open", ""))
+  } else {
+    ignore(element_attrs.data_set("closed", ""))
+  }
+  element_attrs
+}
+
+///|
+fn dialog_overlay_part(
+  scope : DialogScope,
+  slot~ : String,
+  close_on_overlay~ : Bool,
+  id~ : String?,
+  class~ : String?,
+  title~ : String?,
+  hidden~ : Bool?,
+  attrs~ : @html.Attrs?,
+  style~ : Array[String],
+) -> @html.Html {
+  let element_attrs = dialog_state_attrs(attrs, slot, scope.open)
+  if close_on_overlay {
+    ignore(
+      element_attrs.on_click(_ => {
+        if ui_dialog_should_close_outside() {
+          scope.close_command
+        } else {
+          @cmd.none
+        }
+      }),
+    )
+  }
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, DialogOverlayStyle, dialog_overlay_motion_style(scope.open)],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    @html.nothing,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] dialog_control_button(
+  slot~ : String,
+  command~ : @cmd.Cmd,
+  variant~ : ButtonVariant,
+  size~ : ButtonSize,
+  disabled~ : Bool,
+  id~ : String?,
+  class~ : String?,
+  title~ : String?,
+  aria_label~ : String?,
+  on_click~ : @cmd.Cmd?,
+  attrs~ : @html.Attrs?,
+  style~ : Array[String],
+  children : C,
+) -> @html.Html {
+  let control_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+  ignore(control_attrs.aria_disabled(ui_bool(disabled)))
+  if aria_label is Some(label) {
+    ignore(control_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(control_attrs.data_set("disabled", ""))
+  } else {
+    if on_click is Some(on_click) {
+      ignore(control_attrs.on_click(_ => on_click))
+    }
+    ignore(control_attrs.on_click(_ => command))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=control_attrs,
+    children,
+  )
+}
+
+///|
+fn dialog_close_icon(scope : DialogScope, label : String) -> @html.Html {
+  let icon_attrs = @html.Attrs::build().aria_hidden("true")
+  let close_attrs = @html.Attrs::build()
+    .data_set("rui-close-icon", "")
+    .data_set("state", dialog_state_value(scope.open))
+  dialog_control_button(
+    slot="dialog-close",
+    command=scope.close_command,
+    variant=Ghost,
+    size=IconSm,
+    disabled=false,
+    id=None,
+    class=None,
+    title=None,
+    aria_label=Some(label),
+    on_click=None,
+    attrs=Some(close_attrs),
+    style=[DialogCloseIconButtonStyle],
+    @html.span(attrs=icon_attrs, ui_x_icon()),
+  )
+}
+
+///|
+/// Create a stateful native-dialog component.
+///
+/// The builder receives one opaque scope. Pass that scope to
+/// [`dialog_trigger`], [`dialog_content`], and [`dialog_close`]. This is the
+/// explicit Rabbita equivalent of shadcn's implicit Dialog context. Modal
+/// dialogs use `showModal()` for inert background, focus containment, and
+/// native Escape behavior. With `modal=false`, the page stays interactive and
+/// Rabbita dismisses only the top non-modal layer.
+#cfg(target="js")
+pub fn dialog(
+  id~ : String,
+  default_open? : Bool = false,
+  modal? : Bool = true,
+  close_on_escape? : Bool = true,
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  children : (DialogScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=fn(emit) {
+      (
+        { open: default_open, generation: 0 },
+        @cmd.batch([
+          ui_dialog_bind(id, emit(RequestDialogClose)),
+          if default_open {
+            ui_dialog_show(id, modal)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=fn(emit, message, current) {
+      match message {
+        OpenDialog =>
+          if current.open {
+            (current, @cmd.none)
+          } else {
+            let next = { open: true, generation: current.generation + 1 }
+            (
+              next,
+              @cmd.batch([
+                dialog_emit_or_none(on_open_change, true),
+                ui_dialog_show(id, modal),
+              ]),
+            )
+          }
+        RequestDialogClose =>
+          if current.open {
+            let generation = current.generation + 1
+            (
+              { open: false, generation },
+              @cmd.batch([
+                dialog_emit_or_none(on_open_change, false),
+                @rabbita.delay(
+                  emit(FinalizeDialogClose(generation)),
+                  DialogExitDurationMs,
+                ),
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        FinalizeDialogClose(generation) =>
+          if !current.open && current.generation == generation {
+            (current, ui_dialog_close(id))
+          } else {
+            (current, @cmd.none)
+          }
+        DialogDidClose(value) =>
+          (
+            { open: false, generation: current.generation + 1 },
+            @cmd.batch([
+              if current.open {
+                dialog_emit_or_none(on_open_change, false)
+              } else {
+                @cmd.none
+              },
+              dialog_emit_or_none(on_close, value),
+            ]),
+          )
+      }
+    },
+  )
+  model.view(model => {
+    let scope : DialogScope = {
+      id,
+      open: model.open,
+      open_command: emit(OpenDialog),
+      close_command: emit(RequestDialogClose),
+      on_close: Some(emit.map(value => DialogDidClose(value))),
+      on_cancel: Some(
+        if close_on_escape {
+          emit(RequestDialogClose)
+        } else {
+          @cmd.none
+        },
+      ),
+      native_open: None,
+      modal,
+      close_on_escape,
+    }
+    children(scope)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn dialog(
+  id~ : String,
+  default_open? : Bool = false,
+  modal? : Bool = true,
+  close_on_escape? : Bool = true,
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  children : (DialogScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_open_change, on_close))
+  let scope : DialogScope = {
+    id,
+    open: default_open,
+    open_command: @cmd.none,
+    close_command: @cmd.none,
+    on_close: None,
+    on_cancel: None,
+    native_open: Some(default_open),
+    modal,
+    close_on_escape,
+  }
+  @rabbita.Val::constant(children(scope))
+}
+
+///|
+/// Render the default Vega trigger for a dialog scope.
+///
+/// Caller handlers stored in `attrs` and `on_click` run before the component's
+/// open command; neither is discarded.
+pub fn[C : @html.IsChildren] dialog_trigger(
+  scope : DialogScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let trigger_attrs = dialog_state_attrs(attrs, "dialog-trigger", scope.open)
+    .aria_haspopup("dialog")
+    .aria_controls(scope.id)
+    .aria_expanded(ui_bool(scope.open))
+  dialog_control_button(
+    slot="dialog-trigger",
+    command=scope.open_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(trigger_attrs),
+    style~,
+    children,
+  )
+}
+
+///|
+/// Pass native-dialog content through without adding a DOM node.
+///
+/// Native `<dialog>` already enters the browser top layer, so a JavaScript
+/// body portal would be redundant. The fragment keeps the familiar shadcn
+/// compound API while preserving the caller's exact DOM structure.
+pub fn dialog_portal(children : Array[@html.Html]) -> @html.Html {
+  @html.fragment(children)
+}
+
+///|
+/// Render the dialog backdrop associated with a compound dialog scope.
+///
+/// Caller click handlers run before the optional close command and are never
+/// discarded. Set `close_on_overlay=false` for a non-dismissible backdrop.
+pub fn dialog_overlay(
+  scope : DialogScope,
+  close_on_overlay? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  dialog_overlay_part(
+    scope,
+    slot="dialog-overlay",
+    close_on_overlay~,
+    id~,
+    class~,
+    title~,
+    hidden~,
+    attrs~,
+    style~,
+  )
+}
+
+///|
+/// Render the native dialog, backdrop, positioner, and Vega content surface.
+///
+/// `attrs` and `style` customize the visible content surface. Use
+/// `native_attrs` / `native_style` for the underlying `<dialog>` and
+/// `overlay_attrs` / `overlay_style` for the backdrop.
+pub fn[C : @html.IsChildren] dialog_content(
+  scope : DialogScope,
+  close_on_overlay? : Bool = true,
+  show_close? : Bool = true,
+  close_label? : String = "Close",
+  described? : Bool = true,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  native_attrs? : @html.Attrs,
+  native_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let native_element_attrs = dialog_state_attrs(
+      native_attrs,
+      "dialog-native",
+      scope.open,
+    )
+    .data_set("modal", ui_bool(scope.modal))
+    .data_set("close-on-outside", ui_bool(close_on_overlay))
+    .data_set("close-on-escape", ui_bool(scope.close_on_escape))
+  if scope.modal {
+    ignore(native_element_attrs.aria_modal("true"))
+  }
+  if aria_label is Some(label) {
+    ignore(native_element_attrs.aria_label(label))
+  } else {
+    ignore(native_element_attrs.aria_labelledby(scope.title_id()))
+  }
+  if described {
+    ignore(native_element_attrs.aria_describedby(scope.description_id()))
+  }
+  let content_attrs = dialog_state_attrs(attrs, "dialog-content", scope.open)
+  let positioner_attrs = dialog_state_attrs(
+    None,
+    "dialog-positioner",
+    scope.open,
+  )
+  let content = @html.div(
+    style=ui_styles(
+      [UiBoxSizing, DialogContentStyle, dialog_content_motion_style(scope.open)],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=content_attrs,
+    [
+      @html.div(style=[UiBoxSizing, "display:contents"], children),
+      if show_close {
+        dialog_close_icon(scope, close_label)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+  let open = scope.native_open
+  let on_close = scope.on_close
+  let on_cancel = scope.on_cancel
+  let closedby = if !scope.modal {
+    "none"
+  } else if close_on_overlay {
+    "any"
+  } else if scope.close_on_escape {
+    "closerequest"
+  } else {
+    "none"
+  }
+  dialog_portal([
+    @html.dialog(
+      style=ui_styles([UiBoxSizing, DialogNativeStyle], native_style),
+      id=scope.id,
+      open?,
+      closedby~,
+      on_close?,
+      on_cancel?,
+      attrs=native_element_attrs,
+      [
+        if scope.modal {
+          dialog_overlay(
+            scope,
+            close_on_overlay~,
+            attrs=ui_attrs(overlay_attrs),
+            style=overlay_style,
+          )
+        } else {
+          @html.nothing
+        },
+        @html.div(
+          style=[UiBoxSizing, DialogPositionerStyle],
+          attrs=positioner_attrs,
+          content,
+        ),
+      ],
+    ),
+  ])
+}
+
+///|
+pub fn[C : @html.IsChildren] dialog_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DialogHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "dialog-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dialog_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DialogFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "dialog-footer"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dialog_title(
+  scope : DialogScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.title_id())
+  @html.h2(
+    style=ui_styles([UiBoxSizing, DialogTitleStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "dialog-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dialog_description(
+  scope : DialogScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.description_id())
+  @html.p(
+    style=ui_styles([UiBoxSizing, DialogDescriptionStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "dialog-description"),
+    children,
+  )
+}
+
+///|
+/// Render a close control wired to this dialog's internal state.
+pub fn[C : @html.IsChildren] dialog_close(
+  scope : DialogScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  dialog_control_button(
+    slot="dialog-close",
+    command=scope.close_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs~,
+    style~,
+    children,
+  )
+}

--- a/rui/dialog_test.mbt
+++ b/rui/dialog_test.mbt
@@ -1,0 +1,328 @@
+///|
+#cfg(target="native")
+#warnings("-alert_unstable")
+fn render_dialog_component(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn dialog_assert_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected dialog HTML to contain `\{expected}`; got `\{actual}`")
+  }
+}
+
+///|
+fn dialog_assert_not_contains(
+  actual : String,
+  unexpected : String,
+) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail("expected dialog HTML not to contain `\{unexpected}`; got `\{actual}`")
+  }
+}
+
+///|
+fn dialog_test_warning_icon() -> @html.Html {
+  @html.span(
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(width=32, height=32, view_box="0 0 24 24", [
+      @svg.path(
+        d="M21.73 18 13.73 4a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3ZM12 9v4M12 17h.01",
+        fill="none",
+        stroke="currentColor",
+        stroke_width=2,
+        attrs=@svg.Attrs::build()
+          .stroke_linecap("round")
+          .stroke_linejoin("round"),
+      ),
+    ]),
+  )
+}
+
+///|
+#cfg(target="js")
+#warnings("-alert_unstable")
+test "dialog static compound parts render on JS" {
+  let html = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      @html.div([
+        @rui.dialog_portal([@rui.dialog_header("Dialog header")]),
+        @rui.dialog_footer("Dialog footer"),
+        @rui.alert_dialog_portal([
+          @rui.alert_dialog_header([
+            @rui.alert_dialog_media(
+              attrs=@html.Attrs::build().data_set("owner", "media"),
+              dialog_test_warning_icon(),
+            ),
+            @html.span("Alert header"),
+          ]),
+        ]),
+        @rui.alert_dialog_footer("Alert footer"),
+      ]),
+    )
+  })
+  dialog_assert_contains(html, "data-slot=\"dialog-header\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-footer\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-header\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-media\"")
+  dialog_assert_contains(html, "data-owner=\"media\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-footer\"")
+  dialog_assert_not_contains(html, "data-slot=\"dialog-portal\"")
+  dialog_assert_not_contains(html, "data-slot=\"alert-dialog-portal\"")
+}
+
+///|
+#cfg(target="native")
+test "dialog composes native semantics and shadcn slots" {
+  let html = render_dialog_component(() => {
+    @rui.dialog(id="account-dialog", default_open=true, scope => {
+      @html.div([
+        @rui.dialog_trigger(
+          scope,
+          attrs=@html.Attrs::build().data_set("owner", "trigger"),
+          "Edit profile",
+        ),
+        @rui.dialog_portal([
+          @rui.dialog_content(
+            scope,
+            style=["width:40rem"],
+            overlay_attrs=@html.Attrs::build().data_set("owner", "overlay"),
+            native_attrs=@html.Attrs::build().data_set("owner", "native"),
+            [
+              @rui.dialog_header([
+                @rui.dialog_title(scope, "Edit profile"),
+                @rui.dialog_description(scope, "Make changes to your profile."),
+              ]),
+              @rui.dialog_footer(@rui.dialog_close(scope, "Done")),
+            ],
+          ),
+        ]),
+      ])
+    })
+  })
+  dialog_assert_contains(html, "<dialog")
+  dialog_assert_contains(html, "id=\"account-dialog\"")
+  dialog_assert_contains(html, "open")
+  dialog_assert_contains(html, "closedby=\"any\"")
+  dialog_assert_contains(html, "aria-modal=\"true\"")
+  dialog_assert_contains(html, "aria-labelledby=\"account-dialog-title\"")
+  dialog_assert_contains(
+    html, "aria-describedby=\"account-dialog-description\"",
+  )
+  dialog_assert_contains(html, "data-slot=\"dialog-trigger\"")
+  dialog_assert_contains(html, "aria-expanded=\"true\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-overlay\"")
+  dialog_assert_not_contains(html, "backdrop-filter")
+  dialog_assert_contains(html, "data-slot=\"dialog-positioner\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-content\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-header\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-title\"")
+  dialog_assert_contains(html, "id=\"account-dialog-title\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-description\"")
+  dialog_assert_contains(html, "id=\"account-dialog-description\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-footer\"")
+  dialog_assert_contains(html, "data-slot=\"dialog-close\"")
+  dialog_assert_contains(html, "data-rui-close-icon=\"\"")
+  dialog_assert_contains(html, "data-state=\"open\"")
+  dialog_assert_contains(html, "<svg")
+  dialog_assert_not_contains(html, ">×<")
+  dialog_assert_contains(html, "transition:display 200ms,overlay 200ms")
+  dialog_assert_contains(html, "transition-behavior:allow-discrete")
+  dialog_assert_contains(html, "transition:opacity 200ms ease")
+  dialog_assert_contains(
+    html, "transition:opacity 200ms ease,transform 200ms ease",
+  )
+  dialog_assert_contains(html, "--rui-dialog-overlay-opacity:1")
+  dialog_assert_contains(html, "--rui-dialog-content-opacity:1")
+  dialog_assert_contains(
+    html, "opacity:var(--rui-close-opacity,var(--rui-close-base-opacity,0.7))",
+  )
+  dialog_assert_contains(
+    html, "background:var(--rui-close-bg,var(--rui-button-bg,var(--rui-button-base-bg,transparent)))",
+  )
+  dialog_assert_contains(
+    html, "box-shadow:var(--rui-close-shadow,var(--rui-button-shadow,var(--rui-button-base-shadow,none)))",
+  )
+  dialog_assert_contains(html, "pointer-events:auto")
+  dialog_assert_contains(html, "width:40rem")
+  dialog_assert_contains(html, "data-owner=\"overlay\"")
+  dialog_assert_contains(html, "data-owner=\"native\"")
+  dialog_assert_not_contains(html, "data-slot=\"dialog-portal\"")
+}
+
+///|
+#cfg(target="native")
+test "non-modal dialog leaves the page interactive without an overlay" {
+  let html = render_dialog_component(() => {
+    @rui.dialog(id="nonmodal-dialog", default_open=true, modal=false, scope => {
+      @html.div([
+        @rui.dialog_trigger(scope, "Open inspector"),
+        @rui.dialog_content(
+          scope,
+          @html.button(id="nonmodal-first-control", "Inspect"),
+        ),
+      ])
+    })
+  })
+  dialog_assert_contains(html, "<dialog")
+  dialog_assert_contains(html, "id=\"nonmodal-dialog\"")
+  dialog_assert_contains(html, "open")
+  dialog_assert_contains(html, "closedby=\"none\"")
+  dialog_assert_contains(html, "data-modal=\"false\"")
+  dialog_assert_contains(html, "data-close-on-outside=\"true\"")
+  dialog_assert_contains(html, "data-close-on-escape=\"true\"")
+  dialog_assert_contains(html, "pointer-events:none")
+  dialog_assert_contains(html, "data-slot=\"dialog-content\"")
+  dialog_assert_not_contains(html, "aria-modal")
+  dialog_assert_not_contains(html, "data-slot=\"dialog-overlay\"")
+}
+
+///|
+#cfg(target="native")
+test "closed dialog SSR omits open state" {
+  let html = render_dialog_component(() => {
+    @rui.dialog(id="closed-dialog", scope => {
+      @html.div([
+        @rui.dialog_trigger(scope, "Open"),
+        @rui.dialog_content(
+          scope,
+          show_close=false,
+          described=false,
+          @rui.dialog_title(scope, "Closed"),
+        ),
+      ])
+    })
+  })
+  dialog_assert_contains(html, "data-state=\"closed\"")
+  dialog_assert_contains(html, "aria-expanded=\"false\"")
+  dialog_assert_contains(html, "--rui-dialog-overlay-opacity:0")
+  dialog_assert_contains(html, "--rui-dialog-content-opacity:0")
+  dialog_assert_contains(
+    html, "--rui-dialog-content-transform:translateY(-0.5rem) scale(0.95)",
+  )
+  dialog_assert_not_contains(html, "aria-describedby")
+  dialog_assert_not_contains(html, "aria-label=\"Close\"")
+}
+
+///|
+#cfg(target="native")
+test "dialog and alert overlays are independently composable" {
+  let dialog_html = render_dialog_component(() => {
+    @rui.dialog(id="standalone-dialog-parts", default_open=true, scope => {
+      @rui.dialog_portal([
+        @rui.dialog_overlay(
+          scope,
+          close_on_overlay=false,
+          id="standalone-dialog-overlay",
+          attrs=@html.Attrs::build().data_set("owner", "dialog-overlay"),
+          style=["opacity:0.75"],
+        ),
+        @html.span(attrs=@html.Attrs::build().data_set("portal-child", ""), "D"),
+      ])
+    })
+  })
+  dialog_assert_contains(dialog_html, "id=\"standalone-dialog-overlay\"")
+  dialog_assert_contains(dialog_html, "data-slot=\"dialog-overlay\"")
+  dialog_assert_contains(dialog_html, "data-state=\"open\"")
+  dialog_assert_contains(dialog_html, "data-owner=\"dialog-overlay\"")
+  dialog_assert_contains(dialog_html, "opacity:0.75")
+  dialog_assert_contains(dialog_html, "data-portal-child=\"\"")
+  dialog_assert_not_contains(dialog_html, "data-slot=\"dialog-portal\"")
+  dialog_assert_not_contains(dialog_html, "<dialog")
+  let alert_html = render_dialog_component(() => {
+    @rui.alert_dialog(id="standalone-alert-parts", default_open=true, scope => {
+      @rui.alert_dialog_portal([
+        @rui.alert_dialog_overlay(
+          scope,
+          id="standalone-alert-overlay",
+          attrs=@html.Attrs::build().data_set("owner", "alert-overlay"),
+        ),
+        @html.span(attrs=@html.Attrs::build().data_set("portal-child", ""), "A"),
+      ])
+    })
+  })
+  dialog_assert_contains(alert_html, "id=\"standalone-alert-overlay\"")
+  dialog_assert_contains(alert_html, "data-slot=\"alert-dialog-overlay\"")
+  dialog_assert_contains(alert_html, "data-state=\"open\"")
+  dialog_assert_contains(alert_html, "data-owner=\"alert-overlay\"")
+  dialog_assert_contains(alert_html, "data-portal-child=\"\"")
+  dialog_assert_not_contains(alert_html, "data-slot=\"alert-dialog-portal\"")
+  dialog_assert_not_contains(alert_html, "<dialog")
+}
+
+///|
+#cfg(target="native")
+test "alert dialog requires deliberate action and exposes alert semantics" {
+  let html = render_dialog_component(() => {
+    @rui.alert_dialog(id="delete-dialog", scope => {
+      @html.div([
+        @rui.alert_dialog_trigger(scope, "Delete project"),
+        @rui.alert_dialog_portal([
+          @rui.alert_dialog_content(scope, style=["max-width:28rem"], [
+            @rui.alert_dialog_header([
+              @rui.alert_dialog_media(
+                attrs=@html.Attrs::build().data_set("owner", "warning-icon"),
+                dialog_test_warning_icon(),
+              ),
+              @rui.alert_dialog_title(scope, "Are you sure?"),
+              @rui.alert_dialog_description(
+                scope, "This action cannot be undone.",
+              ),
+            ]),
+            @rui.alert_dialog_footer([
+              @rui.alert_dialog_cancel(scope, "Cancel"),
+              @rui.alert_dialog_action(scope, "Continue"),
+            ]),
+          ]),
+        ]),
+      ])
+    })
+  })
+  dialog_assert_contains(html, "role=\"alertdialog\"")
+  dialog_assert_contains(html, "aria-modal=\"true\"")
+  dialog_assert_contains(html, "data-modal=\"true\"")
+  dialog_assert_contains(html, "data-close-on-outside=\"false\"")
+  dialog_assert_contains(html, "closedby=\"closerequest\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-trigger\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-overlay\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-content\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-title\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-description\"")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-media\"")
+  dialog_assert_contains(html, "data-owner=\"warning-icon\"")
+  dialog_assert_contains(html, "width:4rem;height:4rem")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-cancel\"")
+  dialog_assert_contains(html, "autofocus")
+  dialog_assert_contains(html, "data-slot=\"alert-dialog-action\"")
+  dialog_assert_contains(html, "--rui-dialog-overlay-opacity:0")
+  dialog_assert_contains(html, "--rui-dialog-content-opacity:0")
+  dialog_assert_contains(html, "pointer-events:auto")
+  dialog_assert_contains(html, "width:min(100%,32rem)")
+  dialog_assert_contains(html, "max-width:28rem")
+  dialog_assert_not_contains(html, "aria-label=\"Close\"")
+  dialog_assert_not_contains(html, "data-slot=\"alert-dialog-portal\"")
+}
+
+///|
+#cfg(target="native")
+test "dialog parts copy caller attrs" {
+  let shared = @html.Attrs::build().data_set("owner", "caller")
+  ignore(
+    render_dialog_component(() => {
+      @rui.dialog(id="copy-dialog", scope => {
+        @rui.dialog_content(
+          scope,
+          attrs=shared,
+          @rui.dialog_title(scope, "Copy"),
+        )
+      })
+    }),
+  )
+  let original = render_dialog_component(() => {
+    @rabbita.Val::constant(@html.div(attrs=shared, @html.nothing))
+  })
+  dialog_assert_contains(original, "data-owner=\"caller\"")
+  dialog_assert_not_contains(original, "data-slot")
+  dialog_assert_not_contains(original, "data-state")
+}

--- a/rui/direction.mbt
+++ b/rui/direction.mbt
@@ -1,0 +1,38 @@
+///|
+pub(all) enum TextDirection {
+  Ltr
+  Rtl
+} derive(Debug, Eq)
+
+///|
+fn text_direction_value(direction : TextDirection) -> String {
+  match direction {
+    Ltr => "ltr"
+    Rtl => "rtl"
+  }
+}
+
+///|
+/// Apply native writing direction to a subtree.
+pub fn[C : @html.IsChildren] direction(
+  direction? : TextDirection = Ltr,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let direction_value = text_direction_value(direction)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .dir(direction_value)
+      .data_set("slot", "direction")
+      .data_set("direction", direction_value),
+    style=ui_styles([UiBoxSizing], style),
+    children,
+  )
+}

--- a/rui/disclosure_test.mbt
+++ b/rui/disclosure_test.mbt
@@ -1,0 +1,331 @@
+///|
+#cfg(target="js")
+extern "js" fn install_incremental_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_incremental(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  install_incremental_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_incremental(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+test "collapsible composes a native button with an animated default state" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render_incremental(() => {
+    @rui.collapsible(
+      default_open=true,
+      id="release-notes",
+      trigger_id="release-notes-trigger",
+      content_id="release-notes-content",
+      attrs~,
+      style=["width:32rem"],
+      trigger_style=["background:rebeccapurple"],
+      content_body_style=["padding:2rem"],
+      trigger="What changed?",
+      content="Native button keeps its browser keyboard behavior.",
+    )
+  })
+  assert_contains(html, "<button")
+  assert_contains(html, "type=\"button\"")
+  assert_contains(html, "data-slot=\"collapsible\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-open=\"\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "aria-controls=\"release-notes-content\"")
+  assert_contains(html, "aria-labelledby=\"release-notes-trigger\"")
+  assert_contains(html, "data-slot=\"collapsible-indicator\"")
+  assert_contains(html, "data-slot=\"collapsible-content-clip\"")
+  assert_contains(html, "data-slot=\"collapsible-content-body\"")
+  assert_contains(
+    html, "grid-template-rows:var(--rui-collapsible-content-rows,0fr)",
+  )
+  assert_contains(html, "--rui-collapsible-content-rows:1fr")
+  assert_contains(
+    html, "color:var(--rui-foreground,oklch(0.145 0 0));width:32rem",
+  )
+  assert_contains(html, "background:rebeccapurple")
+  assert_contains(html, "padding:2rem")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-state")
+}
+
+///|
+test "collapsible owns incremental state and renders its initial value" {
+  let html = render_incremental(() => {
+    @rui.collapsible(
+      default_open=true,
+      trigger="Advanced settings",
+      content="Visible on the first render",
+    )
+  })
+  assert_contains(html, "data-slot=\"collapsible\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "aria-hidden=\"false\"")
+  assert_contains(html, "--rui-collapsible-content-visibility:visible")
+}
+
+///|
+test "collapsible derives its trigger and content relationship from the root id" {
+  let html = render_incremental(() => {
+    @rui.collapsible(
+      id="derived-disclosure",
+      trigger="Details",
+      content="More details",
+    )
+  })
+  assert_contains(html, "id=\"derived-disclosure-trigger\"")
+  assert_contains(html, "aria-controls=\"derived-disclosure-content\"")
+  assert_contains(html, "id=\"derived-disclosure-content\"")
+  assert_contains(html, "aria-labelledby=\"derived-disclosure-trigger\"")
+}
+
+///|
+test "collapsible closed state stays mounted for its exit animation" {
+  let html = render_incremental(() => {
+    @rui.collapsible(
+      trigger="Advanced settings",
+      content="Hidden after the transition",
+    )
+  })
+  assert_contains(html, "data-slot=\"collapsible-content\"")
+  assert_contains(html, "data-state=\"closed\"")
+  assert_contains(html, "aria-hidden=\"true\"")
+  assert_contains(html, "inert")
+  assert_contains(html, "--rui-collapsible-content-rows:0fr")
+  assert_contains(html, "--rui-collapsible-content-visibility-delay:200ms")
+  assert_not_contains(html, "data-slot=\"collapsible-content\" hidden")
+}
+
+///|
+test "accordion renders one animated button group with incremental state" {
+  let items = [
+    @rui.accordion_entry(
+      value="shipping",
+      label="Shipping",
+      content=@html.p("Ships in two business days."),
+    ),
+    @rui.accordion_entry(
+      value="returns",
+      label="Returns",
+      content=@html.p("Return within thirty days."),
+      disabled=true,
+    ),
+  ]
+  let html = render_incremental(() => {
+    @rui.accordion(items~, default_value="shipping", id="faq", trigger_style=[
+      "padding-inline:0.5rem",
+    ])
+  })
+  assert_contains(html, "data-slot=\"accordion\"")
+  assert_contains(html, "data-type=\"single\"")
+  assert_contains(html, "data-collapsible=\"true\"")
+  assert_contains(html, "data-group=\"faq-group\"")
+  assert_contains(html, "id=\"faq-trigger-0\"")
+  assert_contains(html, "id=\"faq-content-0\"")
+  assert_contains(html, "aria-controls=\"faq-content-0\"")
+  assert_contains(html, "aria-labelledby=\"faq-trigger-0\"")
+  assert_contains(html, "role=\"region\"")
+  assert_contains(html, "data-slot=\"accordion-content-clip\"")
+  assert_contains(
+    html, "grid-template-rows:var(--rui-accordion-content-rows,0fr)",
+  )
+  assert_contains(html, "--rui-accordion-content-rows:1fr")
+  assert_contains(html, "data-value=\"shipping\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(
+    html, "border:1px solid var(--rui-accordion-border,var(--rui-accordion-base-border,transparent))",
+  )
+  assert_contains(
+    html, "background:var(--rui-accordion-bg,var(--rui-accordion-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-accordion-shadow,var(--rui-accordion-base-shadow,none))",
+  )
+  assert_contains(
+    html, "--rui-accordion-base-fg:var(--rui-foreground,oklch(0.145 0 0))",
+  )
+  assert_contains(html, "data-value=\"returns\"")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "data-disabled=\"\"")
+  assert_contains(html, "padding-inline:0.5rem")
+}
+
+///|
+test "accordion multiple mode keeps independent default open values" {
+  let items = [
+    @rui.accordion_entry(
+      value="one",
+      label="One",
+      content=@html.p("First panel"),
+    ),
+    @rui.accordion_entry(
+      value="two",
+      label="Two",
+      content=@html.p("Second panel"),
+    ),
+  ]
+  let html = render_incremental(() => {
+    @rui.accordion(
+      items~,
+      default_values=["one", "two"],
+      type_=@rui.Multiple,
+      id="sections",
+    )
+  })
+  assert_contains(html, "data-type=\"multiple\"")
+  assert_contains(
+    html, "data-slot=\"accordion-item\" data-state=\"open\" data-open=\"\" data-value=\"one\"",
+  )
+  assert_contains(
+    html, "data-slot=\"accordion-item\" data-state=\"open\" data-open=\"\" data-value=\"two\"",
+  )
+  assert_not_contains(html, "data-group=\"sections-group\"")
+}
+
+///|
+test "tabs expose tablist, roving tab stops, and linked panels" {
+  let items = [
+    @rui.tab_entry(
+      value="account",
+      label="Account",
+      content=@html.p("Account preferences"),
+    ),
+    @rui.tab_entry(
+      value="password",
+      label="Password",
+      content=@html.p("Password preferences"),
+    ),
+  ]
+  let html = render_incremental(() => {
+    @rui.tabs(
+      items~,
+      default_value="password",
+      orientation=@rui.TabsVertical,
+      aria_label="Settings",
+      id="settings",
+      trigger_style=["background:rebeccapurple"],
+    )
+  })
+  assert_contains(html, "data-slot=\"tabs\"")
+  assert_contains(html, "data-orientation=\"vertical\"")
+  assert_contains(html, "flex-direction:row;flex-wrap:wrap")
+  assert_contains(html, "min-width:min(9rem,100%);flex:0 1 9rem")
+  assert_contains(html, "role=\"tablist\"")
+  assert_contains(html, "aria-label=\"Settings\"")
+  assert_contains(html, "aria-orientation=\"vertical\"")
+  assert_contains(html, "id=\"settings-trigger-0\"")
+  assert_contains(html, "id=\"settings-content-0\"")
+  assert_contains(html, "aria-controls=\"settings-content-0\"")
+  assert_contains(html, "aria-labelledby=\"settings-trigger-0\"")
+  assert_contains(html, "role=\"tab\"")
+  assert_contains(html, "role=\"tabpanel\"")
+  assert_contains(
+    html, "data-value=\"account\" role=\"tab\" aria-selected=\"false\"",
+  )
+  assert_contains(
+    html, "data-value=\"password\" role=\"tab\" aria-selected=\"true\"",
+  )
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "tabindex=\"0\"")
+  assert_contains(html, "background:rebeccapurple")
+  assert_contains(
+    html, "background:var(--rui-tabs-bg,var(--rui-tabs-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "border-color:var(--rui-control-border,var(--rui-tabs-border,var(--rui-tabs-base-border,transparent)))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-tabs-shadow,var(--rui-tabs-base-shadow,none)))",
+  )
+  assert_element_tag_contains(
+    html, "data-value=\"password\" role=\"tab\"", "--rui-tabs-base-bg:var(--rui-tabs-active-bg,var(--rui-background",
+  )
+  assert_element_tag_contains(
+    html, "data-value=\"account\" role=\"tab\"", "--rui-tabs-base-fg:var(--rui-muted-foreground",
+  )
+}
+
+///|
+test "tabs normalize an unavailable default and clone caller attrs" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let items = [
+    @rui.tab_entry(
+      value="disabled",
+      label="Disabled",
+      content=@html.p("Unavailable"),
+      disabled=true,
+    ),
+    @rui.tab_entry(value="ready", label="Ready", content=@html.p("Available")),
+  ]
+  let html = render_incremental(() => {
+    @rui.tabs(items~, default_value="disabled", attrs~)
+  })
+  assert_contains(html, "data-value=\"ready\"")
+  assert_contains(
+    html, "data-value=\"ready\" role=\"tab\" aria-selected=\"true\"",
+  )
+  assert_contains(
+    html, "data-value=\"disabled\" role=\"tab\" aria-selected=\"false\"",
+  )
+  assert_contains(html, "data-disabled=\"\"")
+  assert_contains(html, "aria-disabled=\"true\" tabindex=\"-1\"")
+  assert_element_tag_contains(
+    html, "data-value=\"disabled\" role=\"tab\"", " disabled>",
+  )
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-orientation")
+}
+
+///|
+test "tabs keep a usable tab stop when the default value is unavailable" {
+  let items = [
+    @rui.tab_entry(
+      value="disabled",
+      label="Disabled",
+      content=@html.p("Unavailable"),
+      disabled=true,
+    ),
+    @rui.tab_entry(value="ready", label="Ready", content=@html.p("Available")),
+  ]
+  let html = render_incremental(() => {
+    @rui.tabs(
+      items~,
+      default_value="disabled",
+      force_mount=true,
+      id="invalid-tabs",
+    )
+  })
+  assert_element_tag_contains(
+    html, "data-value=\"disabled\" role=\"tab\"", "aria-selected=\"false\"",
+  )
+  assert_element_tag_contains(
+    html, "data-value=\"disabled\" role=\"tab\"", "tabindex=\"-1\"",
+  )
+  assert_element_tag_contains(
+    html, "data-value=\"ready\" role=\"tab\"", "tabindex=\"0\"",
+  )
+  assert_element_tag_contains(html, "id=\"invalid-tabs-content-1\"", "hidden")
+  assert_contains(html, "data-force-mount=\"true\"")
+  assert_contains(html, "aria-hidden=\"true\"")
+}

--- a/rui/dom_internal.mbt
+++ b/rui/dom_internal.mbt
@@ -1,0 +1,225 @@
+///|
+#cfg(target="js")
+fn ui_has_global(name : String) -> Bool {
+  let value : @js.Value = @js.globalThis.get_with_string(name)
+  !value.is_undefined() && !value.is_null()
+}
+
+///|
+#cfg(target="js")
+fn ui_has_window() -> Bool {
+  ui_has_global("window")
+}
+
+///|
+#cfg(target="js")
+fn ui_has_document() -> Bool {
+  ui_has_global("document")
+}
+
+///|
+#cfg(target="js")
+fn[E] ui_transition_event(event : E) -> @dom.TransitionEvent? {
+  @js.Cast::into(@js.Value::cast_from(event))
+}
+
+///|
+#cfg(target="js")
+fn ui_element_by_id(id : String) -> @dom.Element? {
+  @dom.document().get_element_by_id(id).to_option()
+}
+
+///|
+#cfg(target="js")
+fn ui_find_descendant(
+  root : @dom.Element,
+  predicate : (@dom.Element) -> Bool,
+) -> @dom.Element? {
+  for child in root.get_children() {
+    if predicate(child) {
+      return Some(child)
+    }
+    if ui_find_descendant(child, predicate) is Some(found) {
+      return Some(found)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn ui_find_element(
+  elements : Array[@dom.Element],
+  predicate : (@dom.Element) -> Bool,
+) -> @dom.Element? {
+  for element in elements {
+    if predicate(element) {
+      return Some(element)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn ui_find_descendant_by_attribute(
+  root : @dom.Element,
+  name : String,
+  value : String,
+) -> @dom.Element? {
+  ui_find_descendant(root, element => {
+    element.get_attribute(name).unwrap_or("") == value
+  })
+}
+
+///|
+#cfg(target="js")
+fn ui_element_contains_target(
+  root : @dom.Element,
+  target : @dom.EventTarget,
+) -> Bool {
+  if target.to_node() is Some(node) {
+    root.contains(node)
+  } else {
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_focus_element(element : @dom.Element) -> Unit {
+  if element.to_html_element() is Some(html_element) {
+    html_element.focus()
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_focus_element_without_scroll(element : @dom.Element) -> Unit {
+  if element.to_html_element() is Some(html_element) {
+    html_element.focus_with_options(prevent_scroll=true)
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_click_element(element : @dom.Element) -> Unit {
+  if element.to_html_element() is Some(html_element) {
+    html_element.click()
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_set_element_tab_index(element : @dom.Element, value : Int) -> Unit {
+  if element.to_html_element() is Some(html_element) {
+    html_element.set_tab_index(value)
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_element_is_enabled(element : @dom.Element) -> Bool {
+  !element.has_attribute("disabled") &&
+  element.get_attribute("aria-disabled").unwrap_or("") != "true"
+}
+
+///|
+#cfg(target="js")
+fn ui_element_is_rtl(element : @dom.Element) -> Bool {
+  if ui_has_window() {
+    let style = @dom.window().get_computed_style(element)
+    style.get_property_value("direction") == "rtl"
+  } else {
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+priv struct UiRovingContext {
+  current : @dom.Element
+  root : @dom.Element
+  items : Array[@dom.Element]
+}
+
+///|
+#cfg(target="js")
+fn ui_roving_context(
+  event : @dom.KeyboardEvent,
+  current_selector : String,
+  root_selector : String,
+  item_selector : String,
+) -> UiRovingContext? {
+  guard event.target().to_element() is Some(target) else { return None }
+  guard target.closest(current_selector) is Some(current) else { return None }
+  guard current.closest(root_selector) is Some(root) else { return None }
+  let items = root
+    .query_selector_all(item_selector)
+    .filter(item => {
+      item.closest(root_selector) is Some(owner) &&
+      owner.is_same_node(root.as_node()) &&
+      ui_element_is_enabled(item)
+    })
+  if items.length() == 0 {
+    None
+  } else {
+    Some({ current, root, items })
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_roving_target(
+  context : UiRovingContext,
+  key : String,
+  orientation : String,
+  rtl : Bool,
+) -> @dom.Element? {
+  let mut index = -1
+  for item_index, item in context.items {
+    if item.is_same_node(context.current.as_node()) {
+      index = item_index
+    }
+  }
+  if index < 0 {
+    return None
+  }
+  let length = context.items.length()
+  let previous = if index == 0 { length - 1 } else { index - 1 }
+  let next = if index == length - 1 { 0 } else { index + 1 }
+  let target_index = match key {
+    "Home" => 0
+    "End" => length - 1
+    "ArrowUp" if orientation == "vertical" || orientation == "both" => previous
+    "ArrowDown" if orientation == "vertical" || orientation == "both" => next
+    "ArrowLeft" if orientation == "horizontal" || orientation == "both" =>
+      if rtl {
+        next
+      } else {
+        previous
+      }
+    "ArrowRight" if orientation == "horizontal" || orientation == "both" =>
+      if rtl {
+        previous
+      } else {
+        next
+      }
+    _ => -1
+  }
+  context.items.get(target_index)
+}
+
+///|
+fn ui_parse_int_or(value : String, fallback : Int) -> Int {
+  @string.parse_int(value) catch {
+    _ => fallback
+  }
+}
+
+///|
+fn ui_parse_double_or(value : String, fallback : Double) -> Double {
+  @string.parse_double(value) catch {
+    _ => fallback
+  }
+}

--- a/rui/drawer.mbt
+++ b/rui/drawer.mbt
@@ -1,0 +1,798 @@
+///|
+/// Edge from which a [`drawer_content`] surface is presented.
+pub(all) enum DrawerDirection {
+  DrawerTop
+  DrawerRight
+  DrawerBottom
+  DrawerLeft
+} derive(Debug, Eq)
+
+///|
+/// Explicit compound-component scope created by [`drawer`].
+struct DrawerScope(DialogScope)
+
+///|
+const DrawerPositionerStyle : String = "position:fixed;inset:0;z-index:51;display:flex;overflow:hidden;pointer-events:none"
+
+///|
+const DrawerSurfaceStyle : String = "position:relative;display:flex;min-width:0;min-height:0;flex-direction:column;overflow:auto;background:var(--rui-popover,var(--rui-background,oklch(1 0 0)));color:var(--rui-popover-foreground,var(--rui-foreground,oklch(0.145 0 0)));box-shadow:0 16px 48px rgb(0 0 0 / 0.2);opacity:var(--rui-drawer-opacity,1);transform:var(--rui-drawer-transform,translate3d(0,0,0));will-change:opacity,transform;pointer-events:auto;transition:opacity 200ms cubic-bezier(0.22,1,0.36,1),transform 200ms cubic-bezier(0.22,1,0.36,1)"
+
+///|
+const DrawerHeaderStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.375rem;padding:1rem 1.5rem;text-align:center"
+
+///|
+const DrawerFooterStyle : String = "display:flex;flex-direction:column-reverse;gap:0.5rem;padding:1rem 1.5rem"
+
+///|
+const DrawerCloseButtonStyle : String = "position:absolute;top:1rem;inset-inline-end:1rem;z-index:1;opacity:var(--rui-close-opacity,var(--rui-close-base-opacity,0.7))"
+
+///|
+const DrawerHandleInteractionStyle : String = "cursor:grab;touch-action:none;user-select:none;-webkit-user-select:none"
+
+///|
+fn drawer_direction_value(direction : DrawerDirection) -> String {
+  match direction {
+    DrawerTop => "top"
+    DrawerRight => "right"
+    DrawerBottom => "bottom"
+    DrawerLeft => "left"
+  }
+}
+
+///|
+fn drawer_positioner_direction_style(direction : DrawerDirection) -> String {
+  match direction {
+    DrawerTop => "align-items:flex-start"
+    DrawerRight => "justify-content:flex-end"
+    DrawerBottom => "align-items:flex-end"
+    DrawerLeft => "justify-content:flex-start"
+  }
+}
+
+///|
+fn drawer_surface_direction_style(direction : DrawerDirection) -> String {
+  match direction {
+    DrawerTop =>
+      "width:100%;max-height:96vh;border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:0 0 var(--rui-radius,0.625rem) var(--rui-radius,0.625rem)"
+    DrawerRight =>
+      "width:min(90vw,24rem);height:100%;border-left:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem) 0 0 var(--rui-radius,0.625rem)"
+    DrawerBottom =>
+      "width:100%;max-height:96vh;border-top:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem) var(--rui-radius,0.625rem) 0 0"
+    DrawerLeft =>
+      "width:min(90vw,24rem);height:100%;border-right:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:0 var(--rui-radius,0.625rem) var(--rui-radius,0.625rem) 0"
+  }
+}
+
+///|
+fn drawer_closed_transform(direction : DrawerDirection) -> String {
+  match direction {
+    DrawerTop => "translate3d(0,calc(-100% - 2px),0)"
+    DrawerRight => "translate3d(calc(100% + 2px),0,0)"
+    DrawerBottom => "translate3d(0,calc(100% + 2px),0)"
+    DrawerLeft => "translate3d(calc(-100% - 2px),0,0)"
+  }
+}
+
+///|
+fn drawer_motion_style(direction : DrawerDirection, open : Bool) -> String {
+  let closed_transform = drawer_closed_transform(direction)
+  if open {
+    "--rui-drawer-closed-transform:\{closed_transform};--rui-drawer-opacity:1;--rui-drawer-transform:translate3d(0,0,0);animation:rui-drawer-enter 200ms cubic-bezier(0.22,1,0.36,1)"
+  } else {
+    "--rui-drawer-closed-transform:\{closed_transform};--rui-drawer-opacity:0;--rui-drawer-transform:\{closed_transform};animation:rui-drawer-exit 200ms cubic-bezier(0.22,1,0.36,1);pointer-events:none"
+  }
+}
+
+///|
+#cfg(target="js")
+priv struct DrawerPointerState {
+  surface : @dom.Element
+  pointer_id : Int
+  horizontal : Bool
+  sign : Int
+  start_x : Int
+  start_y : Int
+  start_time : Double
+  size : Double
+  mut active : Bool
+  overlay : @dom.Element?
+  original_transform : String
+  original_transition : String
+  original_overlay_opacity : String
+}
+
+///|
+#cfg(target="js")
+let drawer_pointer_states : Array[DrawerPointerState] = []
+
+///|
+#cfg(target="js")
+fn drawer_pointer_state(surface : @dom.Element) -> DrawerPointerState? {
+  for state in drawer_pointer_states {
+    if state.surface.is_same_node(surface.as_node()) {
+      return Some(state)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn drawer_remove_pointer_state(surface : @dom.Element) -> Unit {
+  for index, state in drawer_pointer_states {
+    if state.surface.is_same_node(surface.as_node()) {
+      ignore(drawer_pointer_states.remove(index))
+      return
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn drawer_restore_style_property(
+  style : @dom.CSSStyleDeclaration,
+  name : String,
+  value : String,
+) -> Unit {
+  if value == "" {
+    ignore(style.remove_property(name))
+  } else {
+    style.set_property(name, value)
+  }
+}
+
+///|
+#cfg(target="js")
+fn drawer_release_pointer_state(
+  state : DrawerPointerState,
+  restore_drag_values : Bool,
+) -> Unit {
+  if state.surface.to_html_element() is Some(surface) {
+    let style = surface.get_style()
+    if restore_drag_values {
+      drawer_restore_style_property(
+        style,
+        "--rui-drawer-transform",
+        state.original_transform,
+      )
+    }
+    drawer_restore_style_property(
+      style,
+      "transition",
+      state.original_transition,
+    )
+  }
+  if restore_drag_values &&
+    state.overlay is Some(overlay) &&
+    overlay.to_html_element() is Some(overlay_html) {
+    drawer_restore_style_property(
+      overlay_html.get_style(),
+      "--rui-dialog-overlay-opacity",
+      state.original_overlay_opacity,
+    )
+  }
+  state.surface.remove_attribute("data-dragging")
+  if state.surface.has_pointer_capture(state.pointer_id) {
+    state.surface.release_pointer_capture(state.pointer_id)
+  }
+  drawer_remove_pointer_state(state.surface)
+}
+
+///|
+#cfg(target="js")
+fn drawer_pointer_start(event : @dom.MouseEvent, direction : String) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  if pointer.get_default_prevented() ||
+    !pointer.get_is_primary() ||
+    (pointer.get_pointer_type() == "mouse" && pointer.get_button() != 0) {
+    return false
+  }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(surface) else { return false }
+  guard surface.to_html_element() is Some(surface_html) else { return false }
+  guard pointer.target().to_element() is Some(target) else { return false }
+  guard target.closest("[data-slot=\"drawer-handle\"]") is Some(handle) else {
+    return false
+  }
+  guard surface.contains(handle.as_node()) else { return false }
+  if drawer_pointer_state(surface) is Some(previous) {
+    drawer_release_pointer_state(previous, true)
+  }
+  for animation in surface.get_animations() {
+    animation.finish()
+  }
+  let horizontal = direction == "left" || direction == "right"
+  let overlay = if surface.closest("dialog") is Some(dialog) {
+    dialog.query_selector("[data-slot=\"drawer-overlay\"]")
+  } else {
+    None
+  }
+  let style = surface_html.get_style()
+  let original_overlay_opacity = if overlay is Some(overlay) &&
+    overlay.to_html_element() is Some(overlay_html) {
+    overlay_html.get_style().get_property_value("--rui-dialog-overlay-opacity")
+  } else {
+    ""
+  }
+  let state : DrawerPointerState = {
+    surface,
+    pointer_id: pointer.get_pointer_id(),
+    horizontal,
+    sign: if direction == "left" || direction == "top" {
+      -1
+    } else {
+      1
+    },
+    start_x: pointer.get_client_x(),
+    start_y: pointer.get_client_y(),
+    start_time: pointer.get_time_stamp(),
+    size: if horizontal {
+      surface.get_client_width()
+    } else {
+      surface.get_client_height()
+    },
+    active: false,
+    overlay,
+    original_transform: style.get_property_value("--rui-drawer-transform"),
+    original_transition: style.get_property_value("transition"),
+    original_overlay_opacity,
+  }
+  drawer_pointer_states.push(state)
+  surface.set_pointer_capture(state.pointer_id)
+  true
+}
+
+///|
+#cfg(target="js")
+fn drawer_pointer_move(event : @dom.MouseEvent) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(surface) else { return false }
+  guard drawer_pointer_state(surface) is Some(state) else { return false }
+  guard state.pointer_id == pointer.get_pointer_id() else { return false }
+  guard surface.to_html_element() is Some(surface_html) else { return false }
+  let delta = if state.horizontal {
+    pointer.get_client_x() - state.start_x
+  } else {
+    pointer.get_client_y() - state.start_y
+  }
+  let cross = if state.horizontal {
+    pointer.get_client_y() - state.start_y
+  } else {
+    pointer.get_client_x() - state.start_x
+  }
+  let progress = delta * state.sign
+  if !state.active {
+    if delta.abs() < 6 || delta.abs() <= cross.abs() {
+      return false
+    }
+    state.active = true
+    surface.set_attribute("data-dragging", "true")
+  }
+  let visual = if progress < 0 {
+    delta.to_double() * 0.2
+  } else {
+    delta.to_double()
+  }
+  let style = surface_html.get_style()
+  style.set_property("transition", "none")
+  style.set_property(
+    "--rui-drawer-transform",
+    if state.horizontal {
+      "translate3d(\{visual}px,0,0)"
+    } else {
+      "translate3d(0,\{visual}px,0)"
+    },
+  )
+  if state.overlay is Some(overlay) &&
+    overlay.to_html_element() is Some(overlay_html) {
+    let ratio = (progress.to_double() / state.size.max(1.0)).clamp(
+      min=0.0,
+      max=1.0,
+    )
+    overlay_html
+    .get_style()
+    .set_property("--rui-dialog-overlay-opacity", "\{1.0 - ratio}")
+  }
+  true
+}
+
+///|
+#cfg(target="js")
+fn drawer_pointer_end(event : @dom.MouseEvent) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(surface) else { return false }
+  guard drawer_pointer_state(surface) is Some(state) else { return false }
+  guard state.pointer_id == pointer.get_pointer_id() else { return false }
+  let delta = if state.horizontal {
+    pointer.get_client_x() - state.start_x
+  } else {
+    pointer.get_client_y() - state.start_y
+  }
+  let progress = delta * state.sign
+  let elapsed = (pointer.get_time_stamp() - state.start_time).max(1.0)
+  let threshold = (state.size * 0.25).max(48.0).min(160.0)
+  let dismiss = state.active &&
+    progress > 0 &&
+    (
+      progress.to_double() >= threshold ||
+      (progress >= 16 && progress.to_double() / elapsed >= 0.5)
+    )
+  drawer_release_pointer_state(state, !dismiss)
+  dismiss
+}
+
+///|
+#cfg(target="js")
+fn drawer_pointer_cancel(event : @dom.MouseEvent) -> Unit {
+  guard event.to_pointer_event() is Some(pointer) else { return }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return
+  }
+  guard current_target.to_element() is Some(surface) else { return }
+  guard drawer_pointer_state(surface) is Some(state) else { return }
+  guard state.pointer_id == pointer.get_pointer_id() else { return }
+  drawer_release_pointer_state(state, true)
+}
+
+///|
+#cfg(target="js")
+fn drawer_bind_pointer_attrs(
+  attrs : @html.Attrs,
+  direction : DrawerDirection,
+  close_command : @cmd.Cmd,
+) -> Unit {
+  ignore(
+    attrs
+    .on_pointerdown(event => {
+      ignore(drawer_pointer_start(event, drawer_direction_value(direction)))
+      @cmd.none
+    })
+    .on_pointermove(event => {
+      if drawer_pointer_move(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    })
+    .on_pointerup(event => {
+      if drawer_pointer_end(event) {
+        event.prevent_default()
+        close_command
+      } else {
+        @cmd.none
+      }
+    })
+    .on_pointercancel(event => {
+      drawer_pointer_cancel(event)
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn drawer_bind_pointer_attrs(
+  attrs : @html.Attrs,
+  direction : DrawerDirection,
+  close_command : @cmd.Cmd,
+) -> Unit {
+  ignore((attrs, direction, close_command))
+}
+
+///|
+fn drawer_handle_style(direction : DrawerDirection) -> String {
+  match direction {
+    DrawerTop =>
+      "width:3rem;height:0.25rem;margin:0.5rem auto 0;border-radius:999px;background:var(--rui-muted,oklch(0.97 0 0))"
+    DrawerBottom =>
+      "width:3rem;height:0.25rem;margin:0.5rem auto 0;border-radius:999px;background:var(--rui-muted,oklch(0.97 0 0))"
+    DrawerRight =>
+      "width:0.25rem;height:3rem;margin:auto 0 auto 0.5rem;border-radius:999px;background:var(--rui-muted,oklch(0.97 0 0))"
+    DrawerLeft =>
+      "width:0.25rem;height:3rem;margin:auto 0.5rem auto auto;border-radius:999px;background:var(--rui-muted,oklch(0.97 0 0))"
+  }
+}
+
+///|
+fn drawer_close_icon(scope : DialogScope, label : String) -> @html.Html {
+  dialog_control_button(
+    slot="drawer-close",
+    command=scope.close_command,
+    variant=Ghost,
+    size=IconSm,
+    disabled=false,
+    id=None,
+    class=None,
+    title=None,
+    aria_label=Some(label),
+    on_click=None,
+    attrs=Some(
+      @html.Attrs::build()
+      .data_set("rui-close-icon", "")
+      .data_set("state", dialog_state_value(scope.open)),
+    ),
+    style=[DrawerCloseButtonStyle],
+    ui_x_icon(),
+  )
+}
+
+///|
+/// Create a stateful native-dialog drawer. Modal drawers use native focus
+/// containment, restoration, Escape handling, and top-layer stacking;
+/// `modal=false` intentionally leaves background controls available.
+pub fn drawer(
+  id~ : String,
+  default_open? : Bool = false,
+  modal? : Bool = true,
+  close_on_escape? : Bool = true,
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  children : (DrawerScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  dialog(
+    id~,
+    default_open~,
+    modal~,
+    close_on_escape~,
+    on_open_change?,
+    on_close?,
+    scope => children(DrawerScope(scope)),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] drawer_trigger(
+  scope : DrawerScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let dialog_scope = scope.0
+  let trigger_attrs = dialog_state_attrs(
+      attrs,
+      "drawer-trigger",
+      dialog_scope.open,
+    )
+    .aria_haspopup("dialog")
+    .aria_controls(dialog_scope.id)
+    .aria_expanded(ui_bool(dialog_scope.open))
+  dialog_control_button(
+    slot="drawer-trigger",
+    command=dialog_scope.open_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(trigger_attrs),
+    style~,
+    children,
+  )
+}
+
+///|
+/// Pass native drawer content through without adding a DOM node.
+pub fn drawer_portal(children : Array[@html.Html]) -> @html.Html {
+  @html.fragment(children)
+}
+
+///|
+/// Render the drawer backdrop associated with a compound drawer scope.
+pub fn drawer_overlay(
+  scope : DrawerScope,
+  close_on_overlay? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  dialog_overlay_part(
+    scope.0,
+    slot="drawer-overlay",
+    close_on_overlay~,
+    id~,
+    class~,
+    title~,
+    hidden~,
+    attrs~,
+    style~,
+  )
+}
+
+///|
+/// Render an edge drawer. `show_handle` adds the familiar shadcn/Vaul visual
+/// affordance; it is decorative, while all dismissal remains available through
+/// native Escape, backdrop, and explicit close controls.
+pub fn[C : @html.IsChildren] drawer_content(
+  scope : DrawerScope,
+  direction? : DrawerDirection = DrawerBottom,
+  close_on_overlay? : Bool = true,
+  show_handle? : Bool = true,
+  show_close? : Bool = false,
+  close_label? : String = "Close",
+  described? : Bool = true,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  native_attrs? : @html.Attrs,
+  native_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let dialog_scope = scope.0
+  let native_element_attrs = dialog_state_attrs(
+      native_attrs,
+      "drawer-native",
+      dialog_scope.open,
+    )
+    .data_set("modal", ui_bool(dialog_scope.modal))
+    .data_set("close-on-outside", ui_bool(close_on_overlay))
+    .data_set("close-on-escape", ui_bool(dialog_scope.close_on_escape))
+  if dialog_scope.modal {
+    ignore(native_element_attrs.aria_modal("true"))
+  }
+  if aria_label is Some(label) {
+    ignore(native_element_attrs.aria_label(label))
+  } else {
+    ignore(native_element_attrs.aria_labelledby(dialog_scope.title_id()))
+  }
+  if described {
+    ignore(native_element_attrs.aria_describedby(dialog_scope.description_id()))
+  }
+  let content_attrs = dialog_state_attrs(
+    attrs,
+    "drawer-content",
+    dialog_scope.open,
+  ).data_set("direction", drawer_direction_value(direction))
+  drawer_bind_pointer_attrs(
+    content_attrs,
+    direction,
+    dialog_scope.close_command,
+  )
+  let positioner_attrs = dialog_state_attrs(
+    None,
+    "drawer-positioner",
+    dialog_scope.open,
+  ).data_set("direction", drawer_direction_value(direction))
+  let content = @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        DrawerSurfaceStyle,
+        drawer_surface_direction_style(direction),
+        drawer_motion_style(direction, dialog_scope.open),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=content_attrs,
+    [
+      if show_handle {
+        drawer_handle(direction~)
+      } else {
+        @html.nothing
+      },
+      @html.div(style=[UiBoxSizing, "display:contents"], children),
+      if show_close {
+        drawer_close_icon(dialog_scope, close_label)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+  let open = dialog_scope.native_open
+  let on_close = dialog_scope.on_close
+  let on_cancel = dialog_scope.on_cancel
+  let closedby = if !dialog_scope.modal {
+    "none"
+  } else if close_on_overlay {
+    "any"
+  } else if dialog_scope.close_on_escape {
+    "closerequest"
+  } else {
+    "none"
+  }
+  drawer_portal([
+    @html.dialog(
+      style=ui_styles([UiBoxSizing, DialogNativeStyle], native_style),
+      id=dialog_scope.id,
+      open?,
+      closedby~,
+      on_close?,
+      on_cancel?,
+      attrs=native_element_attrs,
+      [
+        if dialog_scope.modal {
+          drawer_overlay(
+            scope,
+            close_on_overlay~,
+            attrs=ui_attrs(overlay_attrs),
+            style=overlay_style,
+          )
+        } else {
+          @html.nothing
+        },
+        @html.div(
+          style=[
+            UiBoxSizing,
+            DrawerPositionerStyle,
+            drawer_positioner_direction_style(direction),
+          ],
+          attrs=positioner_attrs,
+          content,
+        ),
+      ],
+    ),
+  ])
+}
+
+///|
+/// Render the drawer's visual grab handle. It is intentionally presentation
+/// only; keyboard and assistive-technology users use the regular controls.
+pub fn drawer_handle(
+  direction? : DrawerDirection = DrawerBottom,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        drawer_handle_style(direction),
+        DrawerHandleInteractionStyle,
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "drawer-handle")
+      .data_set("direction", drawer_direction_value(direction))
+      .aria_hidden("true"),
+    @html.nothing,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] drawer_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DrawerHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "drawer-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] drawer_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DrawerFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "drawer-footer"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] drawer_title(
+  scope : DrawerScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.0.title_id())
+  @html.h2(
+    style=ui_styles([UiBoxSizing, DialogTitleStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "drawer-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] drawer_description(
+  scope : DrawerScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.0.description_id())
+  @html.p(
+    style=ui_styles([UiBoxSizing, DialogDescriptionStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "drawer-description"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] drawer_close(
+  scope : DrawerScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  dialog_control_button(
+    slot="drawer-close",
+    command=scope.0.close_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs~,
+    style~,
+    children,
+  )
+}

--- a/rui/drawer_pointer_wbtest.mbt
+++ b/rui/drawer_pointer_wbtest.mbt
@@ -1,0 +1,239 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_drawer_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const saved = {
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own("PointerEvent"),
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class PointerEvent {
+  #|     constructor(init) {
+  #|       Object.assign(this, init)
+  #|       this.defaultPrevented = init.defaultPrevented ?? false
+  #|     }
+  #|   }
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement, PointerEvent })
+  #|   const props = {
+  #|     "--rui-drawer-transform": "translate3d(0,0,0)",
+  #|     transition: "opacity 200ms cubic-bezier(0.22,1,0.36,1),transform 200ms cubic-bezier(0.22,1,0.36,1)",
+  #|   }
+  #|   const overlayProps = { "--rui-dialog-overlay-opacity": "1" }
+  #|   const handle = new HTMLElement()
+  #|   handle.closest = selector => selector === '[data-slot="drawer-handle"]' ? handle : null
+  #|   const outside = new HTMLElement()
+  #|   outside.closest = () => null
+  #|   const style = values => ({
+  #|     getPropertyValue: key => values[key] || "",
+  #|     setProperty: (key, value) => { values[key] = value },
+  #|     removeProperty: key => {
+  #|       const value = values[key] || ""
+  #|       delete values[key]
+  #|       return value
+  #|     },
+  #|   })
+  #|   const overlay = new HTMLElement()
+  #|   overlay.style = style(overlayProps)
+  #|   const dialog = new HTMLElement()
+  #|   dialog.querySelector = selector => selector === '[data-slot="drawer-overlay"]' ? overlay : null
+  #|   const surface = new HTMLElement()
+  #|   Object.assign(surface, {
+  #|     clientWidth: 240,
+  #|     clientHeight: 400,
+  #|     dataset: {},
+  #|     style: style(props),
+  #|     contains: node => node === handle,
+  #|     closest: selector => selector === "dialog" ? dialog : null,
+  #|     captures: 0,
+  #|     releases: 0,
+  #|     finishedAnimations: 0,
+  #|     getAnimations() {
+  #|       return [{ finish: () => { this.finishedAnimations += 1 } }]
+  #|     },
+  #|     setAttribute(name, value) {
+  #|       if (name === "data-dragging") this.dataset.dragging = value
+  #|     },
+  #|     removeAttribute(name) {
+  #|       if (name === "data-dragging") delete this.dataset.dragging
+  #|     },
+  #|     setPointerCapture(pointerId) {
+  #|       this.__capturedPointerId = pointerId
+  #|       this.captures += 1
+  #|     },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId !== pointerId) return
+  #|       delete this.__capturedPointerId
+  #|       this.releases += 1
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|   })
+  #|   globalThis.__ruiDrawerPointerFixture = {
+  #|     ...saved,
+  #|     props,
+  #|     overlayProps,
+  #|     handle,
+  #|     outside,
+  #|     surface,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_drawer_pointer_fixture_event(
+  x : Int,
+  y : Int,
+  time : Int,
+  outside : Bool,
+) -> @dom.MouseEvent =
+  #| (x, y, time, outside) => {
+  #|   const fixture = globalThis.__ruiDrawerPointerFixture
+  #|   return new PointerEvent({
+  #|     currentTarget: fixture.surface,
+  #|     target: outside ? fixture.outside : fixture.handle,
+  #|     pointerId: 9,
+  #|     pointerType: "touch",
+  #|     isPrimary: true,
+  #|     button: 0,
+  #|     clientX: x,
+  #|     clientY: y,
+  #|     timeStamp: time,
+  #|     defaultPrevented: false,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_drawer_fixture_value(key : String) -> String =
+  #| key => globalThis.__ruiDrawerPointerFixture?.props?.[key] || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_drawer_fixture_overlay_opacity() -> String =
+  #| () => globalThis.__ruiDrawerPointerFixture?.overlayProps?.["--rui-dialog-overlay-opacity"] || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_drawer_fixture_dragging() -> Bool =
+  #| () => globalThis.__ruiDrawerPointerFixture?.surface?.dataset?.dragging === "true"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_drawer_fixture_releases() -> Int =
+  #| () => globalThis.__ruiDrawerPointerFixture?.surface?.releases ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_drawer_fixture_finished_animations() -> Int =
+  #| () => globalThis.__ruiDrawerPointerFixture?.surface?.finishedAnimations ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_drawer_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiDrawerPointerFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiDrawerPointerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "drawer handle drag dismisses in bottom and left directions" {
+  ffi_install_drawer_pointer_fixture()
+  let bottom_start = ffi_drawer_pointer_fixture_event(100, 50, 0, false)
+  let bottom_move = ffi_drawer_pointer_fixture_event(102, 180, 150, false)
+  let bottom_end = ffi_drawer_pointer_fixture_event(102, 180, 300, false)
+  assert_true(drawer_pointer_start(bottom_start, "bottom"))
+  assert_eq(ffi_drawer_fixture_finished_animations(), 1)
+  assert_true(drawer_pointer_move(bottom_move))
+  assert_true(ffi_drawer_fixture_dragging())
+  assert_eq(
+    ffi_drawer_fixture_value("--rui-drawer-transform"),
+    "translate3d(0,130px,0)",
+  )
+  assert_eq(ffi_drawer_fixture_overlay_opacity(), "0.675")
+  assert_true(drawer_pointer_end(bottom_end))
+  assert_eq(
+    ffi_drawer_fixture_value("--rui-drawer-transform"),
+    "translate3d(0,130px,0)",
+  )
+  assert_eq(ffi_drawer_fixture_overlay_opacity(), "0.675")
+  assert_eq(
+    ffi_drawer_fixture_value("transition"),
+    "opacity 200ms cubic-bezier(0.22,1,0.36,1),transform 200ms cubic-bezier(0.22,1,0.36,1)",
+  )
+  assert_eq(ffi_drawer_fixture_releases(), 1)
+  ffi_restore_drawer_pointer_fixture()
+
+  ffi_install_drawer_pointer_fixture()
+  let left_start = ffi_drawer_pointer_fixture_event(200, 100, 0, false)
+  let left_move = ffi_drawer_pointer_fixture_event(120, 102, 100, false)
+  let left_end = ffi_drawer_pointer_fixture_event(120, 102, 300, false)
+  assert_true(drawer_pointer_start(left_start, "left"))
+  assert_true(drawer_pointer_move(left_move))
+  assert_eq(
+    ffi_drawer_fixture_value("--rui-drawer-transform"),
+    "translate3d(-80px,0,0)",
+  )
+  assert_true(drawer_pointer_end(left_end))
+  ffi_restore_drawer_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "drawer drag resists the wrong direction and snaps back" {
+  ffi_install_drawer_pointer_fixture()
+  let start = ffi_drawer_pointer_fixture_event(100, 100, 0, false)
+  let drag_move = ffi_drawer_pointer_fixture_event(100, 40, 100, false)
+  let finish = ffi_drawer_pointer_fixture_event(100, 40, 300, false)
+  assert_true(drawer_pointer_start(start, "bottom"))
+  assert_true(drawer_pointer_move(drag_move))
+  assert_eq(
+    ffi_drawer_fixture_value("--rui-drawer-transform"),
+    "translate3d(0,-12px,0)",
+  )
+  assert_true(!drawer_pointer_end(finish))
+  assert_eq(
+    ffi_drawer_fixture_value("--rui-drawer-transform"),
+    "translate3d(0,0,0)",
+  )
+  ffi_restore_drawer_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "drawer drag starts only from its handle and cancel restores state" {
+  ffi_install_drawer_pointer_fixture()
+  let outside = ffi_drawer_pointer_fixture_event(100, 100, 0, true)
+  assert_true(!drawer_pointer_start(outside, "bottom"))
+  let start = ffi_drawer_pointer_fixture_event(100, 100, 0, false)
+  let drag_move = ffi_drawer_pointer_fixture_event(100, 180, 100, false)
+  assert_true(drawer_pointer_start(start, "bottom"))
+  assert_true(drawer_pointer_move(drag_move))
+  drawer_pointer_cancel(drag_move)
+  assert_true(!ffi_drawer_fixture_dragging())
+  assert_eq(
+    ffi_drawer_fixture_value("--rui-drawer-transform"),
+    "translate3d(0,0,0)",
+  )
+  assert_eq(ffi_drawer_fixture_releases(), 1)
+  ffi_restore_drawer_pointer_fixture()
+}

--- a/rui/dropdown_menu.mbt
+++ b/rui/dropdown_menu.mbt
@@ -1,0 +1,613 @@
+///|
+struct DropdownMenuScope {
+  menu : MenuScope
+}
+
+///|
+struct DropdownMenuRadioGroupScope {
+  menu : MenuScope
+  group : String
+}
+
+///|
+struct DropdownMenuSubScope {
+  menu : MenuScope
+  key : String
+}
+
+///|
+#cfg(target="js")
+priv enum DropdownMenuMsg {
+  DropdownSetOpen(Bool)
+  DropdownNativeOpen(Bool)
+  DropdownSetActive(Int)
+  DropdownToggleChecked(String)
+  DropdownSetRadio(String, String)
+  DropdownSetSubmenu(MenuSubmenuChange)
+}
+
+///|
+#cfg(target="js")
+fn dropdown_notify(on_open_change : @cmd.Emit[Bool]?, open : Bool) -> @cmd.Cmd {
+  if on_open_change is Some(notify) {
+    notify(open)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn dropdown_scope(
+  id : String,
+  model : MenuCoreModel,
+  set_open : @cmd.Emit[Bool],
+  set_active : @cmd.Emit[Int],
+  toggle_checked : @cmd.Emit[String],
+  set_radio : @cmd.Emit[(String, String)],
+  set_submenu : @cmd.Emit[MenuSubmenuChange],
+) -> DropdownMenuScope {
+  {
+    menu: {
+      id,
+      content_id: id + "-content",
+      trigger_id: id + "-trigger",
+      model,
+      counter: Ref(0),
+      open_command: set_open(true),
+      close_command: set_open(false),
+      toggle_command: set_open(!model.open),
+      set_active,
+      toggle_checked,
+      set_radio,
+      set_submenu,
+    },
+  }
+}
+
+///|
+/// Stateful shadcn/Vega dropdown menu. The builder receives an opaque scope
+/// shared by all compound parts; no registration or stylesheet is required.
+#cfg(target="js")
+pub fn dropdown_menu(
+  id~ : String,
+  default_open? : Bool = false,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (DropdownMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let initial = menu_core_model(
+    default_open, default_checked_values, default_radio_values,
+  )
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      let set_active = emit.map(index => DropdownSetActive(index))
+      let set_submenu = emit.map(value => DropdownSetSubmenu(value))
+      (
+        initial,
+        @cmd.batch([
+          floating_bind_sync_cmd(
+            id + "-content",
+            emit.map(open => DropdownNativeOpen(open)),
+          ),
+          menu_bind_surface_cmd(
+            id + "-root",
+            set_active,
+            emit(DropdownSetOpen(false)),
+            set_submenu,
+          ),
+          if default_open {
+            @cmd.batch([
+              floating_set_open_cmd(id + "-content", true),
+              menu_focus_first_cmd(id + "-root", set_active),
+            ])
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(emit, msg, current) => {
+      match msg {
+        DropdownSetOpen(open) =>
+          if open == current.open {
+            (current, @cmd.none)
+          } else {
+            let next = {
+              ..current,
+              open,
+              active: if open {
+                -1
+              } else {
+                current.active
+              },
+              submenus: [],
+            }
+            (
+              next,
+              @cmd.batch([
+                floating_set_open_cmd(id + "-content", open),
+                if open {
+                  menu_focus_first_cmd(
+                    id + "-root",
+                    emit.map(index => DropdownSetActive(index)),
+                  )
+                } else {
+                  ui_focus_id(id + "-trigger")
+                },
+                if open {
+                  @cmd.none
+                } else {
+                  menu_position_submenus_cmd(id + "-root")
+                },
+                dropdown_notify(on_open_change, open),
+              ]),
+            )
+          }
+        DropdownNativeOpen(open) =>
+          if open == current.open {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, open, submenus: [] },
+              @cmd.batch([
+                if open {
+                  @cmd.none
+                } else {
+                  menu_position_submenus_cmd(id + "-root")
+                },
+                dropdown_notify(on_open_change, open),
+              ]),
+            )
+          }
+        DropdownSetActive(index) =>
+          if current.active == index {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, active: index },
+              menu_focus_item_cmd(id + "-root", index),
+            )
+          }
+        DropdownToggleChecked(value) =>
+          (
+            { ..current, checked: menu_toggle_value(current.checked, value) },
+            @cmd.none,
+          )
+        DropdownSetRadio(group, value) =>
+          (
+            {
+              ..current,
+              radios: menu_set_radio_value(current.radios, group, value),
+            },
+            @cmd.none,
+          )
+        DropdownSetSubmenu(change) => {
+          let submenus = menu_update_submenus(current.submenus, change)
+          if submenus == current.submenus {
+            (current, @cmd.none)
+          } else {
+            ({ ..current, submenus, }, menu_position_submenus_cmd(id + "-root"))
+          }
+        }
+      }
+    },
+  )
+  model.view(model => {
+    let scope = dropdown_scope(
+      id,
+      model,
+      emit.map(open => DropdownSetOpen(open)),
+      emit.map(index => DropdownSetActive(index)),
+      emit.map(value => DropdownToggleChecked(value)),
+      emit.map(pair => DropdownSetRadio(pair.0, pair.1)),
+      emit.map(value => DropdownSetSubmenu(value)),
+    )
+    menu_root_surface(
+      "dropdown-menu",
+      id + "-root",
+      model.open,
+      attrs,
+      style,
+      children(scope),
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn dropdown_menu(
+  id~ : String,
+  default_open? : Bool = false,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (DropdownMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_open_change)
+  let scope = dropdown_scope(
+    id,
+    menu_core_model(default_open, default_checked_values, default_radio_values),
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+  )
+  @rabbita.Val::constant(
+    menu_root_surface(
+      "dropdown-menu",
+      id + "-root",
+      default_open,
+      attrs,
+      style,
+      children(scope),
+    ),
+  )
+}
+
+///|
+/// Explicit Root spelling matching the compound-component API.
+pub fn dropdown_menu_root(
+  id~ : String,
+  default_open? : Bool = false,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (DropdownMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  dropdown_menu(
+    id~,
+    default_open~,
+    default_checked_values~,
+    default_radio_values~,
+    on_open_change?,
+    attrs?,
+    style~,
+    children,
+  )
+}
+
+///|
+/// Zero-DOM Portal adapter for shadcn-compatible compound composition.
+/// Native `popover="auto"` promotes Content to the top layer when opened, so
+/// no registration, DOM relocation, or build-time portal runtime is required.
+pub fn dropdown_menu_portal(children : Array[@html.Html]) -> @html.Html {
+  @html.fragment(children)
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_trigger(
+  scope : DropdownMenuScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_trigger_button(
+    "dropdown-menu-trigger",
+    scope.menu,
+    variant,
+    size,
+    disabled,
+    aria_label,
+    on_click,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_content(
+  scope : DropdownMenuScope,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_content_surface(
+    "dropdown-menu-content",
+    scope.menu,
+    side,
+    align,
+    side_offset,
+    align_offset,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_group(
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_group_surface(
+    "dropdown-menu-group", aria_label, class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_item(
+  scope : DropdownMenuScope,
+  disabled? : Bool = false,
+  inset? : Bool = false,
+  destructive? : Bool = false,
+  close_on_select? : Bool = true,
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_item_surface(
+    "dropdown-menu-item",
+    scope.menu,
+    "menuitem",
+    None,
+    MenuIndicatorInlineStart,
+    disabled,
+    inset,
+    destructive,
+    None,
+    close_on_select,
+    None,
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_checkbox_item(
+  scope : DropdownMenuScope,
+  value~ : String,
+  disabled? : Bool = false,
+  close_on_select? : Bool = false,
+  on_checked_change? : @cmd.Emit[Bool],
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let checked = menu_contains(scope.menu.model.checked, value)
+  let notify = if on_checked_change is Some(notify) {
+    notify(!checked)
+  } else {
+    @cmd.none
+  }
+  menu_item_surface(
+    "dropdown-menu-checkbox-item",
+    scope.menu,
+    "menuitemcheckbox",
+    Some(checked),
+    MenuIndicatorInlineEnd,
+    disabled,
+    false,
+    false,
+    None,
+    close_on_select,
+    Some(@cmd.batch([notify, (scope.menu.toggle_checked)(value)])),
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_radio_group(
+  scope : DropdownMenuScope,
+  value~ : String,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (DropdownMenuRadioGroupScope) -> C,
+) -> @html.Html {
+  menu_group_surface(
+    "dropdown-menu-radio-group",
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children({ menu: scope.menu, group: value }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_radio_item(
+  scope : DropdownMenuRadioGroupScope,
+  value~ : String,
+  disabled? : Bool = false,
+  close_on_select? : Bool = false,
+  on_value_change? : @cmd.Emit[String],
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let checked = menu_radio_value(scope.menu.model.radios, scope.group) ==
+    Some(value)
+  let notify = if on_value_change is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+  menu_item_surface(
+    "dropdown-menu-radio-item",
+    scope.menu,
+    "menuitemradio",
+    Some(checked),
+    MenuIndicatorInlineEnd,
+    disabled,
+    false,
+    false,
+    None,
+    close_on_select,
+    Some(@cmd.batch([notify, (scope.menu.set_radio)((scope.group, value))])),
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_label(
+  inset? : Bool = false,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_label_surface(
+    "dropdown-menu-label", inset, class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn dropdown_menu_separator(
+  class? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  menu_separator_surface("dropdown-menu-separator", class, attrs, style)
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_shortcut(
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_shortcut_surface(
+    "dropdown-menu-shortcut", class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_sub(
+  scope : DropdownMenuScope,
+  value~ : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (DropdownMenuSubScope) -> C,
+) -> @html.Html {
+  let key = menu_submenu_key(scope.menu, value)
+  let open = menu_submenu_open(scope.menu.model.submenus, key)
+  menu_sub_root_surface(
+    "dropdown-menu-sub",
+    open,
+    attrs,
+    style,
+    children({ menu: scope.menu, key }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_sub_trigger(
+  scope : DropdownMenuSubScope,
+  disabled? : Bool = false,
+  inset? : Bool = false,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_item_surface(
+    "dropdown-menu-sub-trigger",
+    scope.menu,
+    "menuitem",
+    None,
+    MenuIndicatorInlineStart,
+    disabled,
+    inset,
+    false,
+    Some(scope.key),
+    false,
+    None,
+    None,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] dropdown_menu_sub_content(
+  scope : DropdownMenuSubScope,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_sub_content_surface(
+    "dropdown-menu-sub-content",
+    scope.key,
+    menu_submenu_open(scope.menu.model.submenus, scope.key),
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}

--- a/rui/empty.mbt
+++ b/rui/empty.mbt
@@ -1,0 +1,158 @@
+///|
+pub(all) enum EmptyMediaVariant {
+  EmptyMediaDefault
+  EmptyMediaIcon
+} derive(Debug, Eq)
+
+///|
+const EmptyStyle : String = "display:flex;min-width:0;flex:1;flex-direction:column;align-items:center;justify-content:center;gap:1.5rem;border-style:dashed;border-radius:var(--rui-radius,0.625rem);padding:var(--rui-empty-padding,1.5rem);text-align:center;text-wrap:balance"
+
+///|
+const EmptyHeaderStyle : String = "display:flex;max-width:24rem;min-width:0;flex-direction:column;align-items:center;gap:0.5rem;text-align:center;overflow-wrap:anywhere"
+
+///|
+const EmptyMediaStyle : String = "display:flex;flex-shrink:0;align-items:center;justify-content:center;margin-bottom:0.5rem"
+
+///|
+const EmptyMediaIconStyle : String = "width:2.5rem;height:2.5rem;border-radius:0.5rem;background:var(--rui-muted,oklch(0.97 0 0));color:var(--rui-foreground,oklch(0.145 0 0));--rui-icon-size:1.5rem"
+
+///|
+const EmptyTitleStyle : String = "font-size:1.125rem;line-height:1.75rem;font-weight:500;letter-spacing:-0.025em"
+
+///|
+const EmptyDescriptionStyle : String = "color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.625"
+
+///|
+const EmptyContentStyle : String = "display:flex;width:100%;max-width:24rem;min-width:0;flex-direction:column;align-items:center;gap:1rem;font-size:0.875rem;text-wrap:balance;overflow-wrap:anywhere"
+
+///|
+pub fn[C : @html.IsChildren] empty(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "empty"),
+    style=ui_styles([UiBoxSizing, UiFontSans, EmptyStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] empty_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "empty-header"),
+    style=ui_styles([UiBoxSizing, EmptyHeaderStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] empty_media(
+  variant? : EmptyMediaVariant = EmptyMediaDefault,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let variant_value = match variant {
+    EmptyMediaDefault => "default"
+    EmptyMediaIcon => "icon"
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "empty-icon")
+      .data_set("variant", variant_value),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        EmptyMediaStyle,
+        if variant is EmptyMediaIcon {
+          EmptyMediaIconStyle
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] empty_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "empty-title"),
+    style=ui_styles([EmptyTitleStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] empty_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "empty-description"),
+    style=ui_styles([EmptyDescriptionStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] empty_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "empty-content"),
+    style=ui_styles([UiBoxSizing, EmptyContentStyle], style),
+    children,
+  )
+}

--- a/rui/field.mbt
+++ b/rui/field.mbt
@@ -1,0 +1,326 @@
+///|
+pub(all) enum FieldOrientation {
+  FieldVertical
+  FieldHorizontal
+  FieldResponsive
+} derive(Debug, Eq)
+
+///|
+pub(all) enum FieldLegendVariant {
+  FieldLegend
+  FieldLabelLegend
+} derive(Debug, Eq)
+
+///|
+fn field_orientation_value(orientation : FieldOrientation) -> String {
+  match orientation {
+    FieldVertical => "vertical"
+    FieldHorizontal => "horizontal"
+    FieldResponsive => "responsive"
+  }
+}
+
+///|
+fn field_orientation_style(orientation : FieldOrientation) -> String {
+  match orientation {
+    FieldVertical => "flex-direction:column"
+    FieldHorizontal => "flex-direction:row;align-items:center"
+    FieldResponsive => "flex-direction:column"
+  }
+}
+
+///|
+const FieldLabelStyle : String = "display:flex;width:var(--rui-field-label-width,fit-content);flex-direction:var(--rui-field-label-direction,row);align-items:var(--rui-field-label-align,center);gap:0.5rem;--rui-field-label-base-bg:transparent;--rui-field-label-base-border:transparent;--rui-field-label-base-shadow:none;border-width:var(--rui-field-label-border-width,0px);border-style:solid;border-color:var(--rui-field-label-border,var(--rui-field-label-base-border,transparent));border-radius:var(--rui-field-label-radius,0px);background:var(--rui-field-label-bg,var(--rui-field-label-base-bg,transparent));padding:var(--rui-field-label-padding,0px);color:var(--rui-field-label-fg,inherit);box-shadow:var(--rui-field-label-shadow,var(--rui-field-label-base-shadow,none));font-size:0.875rem;line-height:1.375;font-weight:500"
+
+///|
+pub fn[C : @html.IsChildren] field_set(
+  disabled? : Bool = false,
+  name? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let set_attrs = ui_attrs(attrs).data_set("slot", "field-set")
+  if disabled {
+    ignore(set_attrs.data_set("disabled", ""))
+  }
+  @html.fieldset(
+    disabled~,
+    name?,
+    id?,
+    class?,
+    title?,
+    attrs=set_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "display:flex;min-width:0;flex-direction:column;gap:1.5rem;border:0;margin:0;padding:0",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_legend(
+  variant? : FieldLegendVariant = FieldLegend,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let value = if variant is FieldLegend { "legend" } else { "label" }
+  @html.legend(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "field-legend")
+      .data_set("variant", value),
+    style=ui_styles(
+      [
+        "margin:0 0 0.75rem;padding:0;font-weight:500",
+        if variant is FieldLegend {
+          "font-size:1rem;line-height:1.5rem"
+        } else {
+          "font-size:0.875rem;line-height:1.25rem"
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "field-group"),
+    style=ui_styles(
+      [
+        "display:flex;width:100%;flex-direction:column;gap:1.75rem;container-type:inline-size;container-name:rui-field-group",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field(
+  orientation? : FieldOrientation = FieldVertical,
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let value = field_orientation_value(orientation)
+  let field_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "field")
+    .data_set("orientation", value)
+    .data_set("invalid", ui_bool(invalid))
+  if disabled {
+    ignore(field_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(field_attrs.aria_invalid("true"))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=field_attrs,
+    style=ui_styles(
+      [
+        "display:flex;width:100%;gap:0.75rem",
+        field_orientation_style(orientation),
+        if invalid {
+          "color:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+        } else {
+          ""
+        },
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "field-content"),
+    style=ui_styles(
+      [
+        "display:flex;min-width:0;flex:1;flex-direction:column;gap:0.375rem;line-height:1.375",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_label(
+  for_? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.label(
+    for_?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "field-label"),
+    style=ui_styles([UiBoxSizing, FieldLabelStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "field-label"),
+    style=ui_styles(
+      [
+        "display:flex;width:fit-content;align-items:center;gap:0.5rem;font-size:0.875rem;line-height:1.375;font-weight:500",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "field-description"),
+    style=ui_styles(
+      [
+        "margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.5;font-weight:400",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_error(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).role("alert").data_set("slot", "field-error"),
+    style=ui_styles(
+      [
+        "color:var(--rui-destructive,oklch(0.577 0.245 27.325));font-size:0.875rem;line-height:1.25rem;font-weight:400",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] field_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "field-separator"),
+    style=ui_styles(
+      [
+        "position:relative;display:flex;height:1.25rem;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem",
+      ],
+      style,
+    ),
+    [
+      @html.span(
+        attrs=@html.Attrs::build().aria_hidden("true"),
+        style=[
+          "position:absolute;left:0;right:0;top:50%;height:1px;background:var(--rui-border,oklch(0.922 0 0))",
+        ],
+        "",
+      ),
+      @html.span(
+        attrs=@html.Attrs::build().data_set("slot", "field-separator-content"),
+        style=[
+          "position:relative;display:block;width:fit-content;background:var(--rui-background,white);padding-inline:0.5rem",
+        ],
+        children,
+      ),
+    ],
+  )
+}

--- a/rui/form.mbt
+++ b/rui/form.mbt
@@ -1,0 +1,207 @@
+///|
+const FormFieldLayoutStyle : String = "display:flex;width:100%;flex-direction:column;gap:0.5rem"
+
+///|
+const FormFieldInvalidStyle : String = "color:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+
+///|
+pub fn[C : @html.IsChildren] form(
+  action? : String,
+  name? : String,
+  on_submit? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.form(
+    action?,
+    name?,
+    on_submit?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "form"),
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, "display:flex;flex-direction:column;gap:1.5rem"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+/// Adapt caller-owned field state into one semantic Rabbita form group.
+///
+/// This is not React Hook Form's context-backed `FormField`: it does not
+/// register, validate, or retain a value. Pass the field name and validity from
+/// the application's TEA model, and keep native `id`, `for`, and description
+/// relationships explicit on the composed controls.
+pub fn[C : @html.IsChildren] form_field(
+  name~ : String,
+  invalid? : Bool = false,
+  required? : Bool = false,
+  describedby? : String,
+  errormessage? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let field_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "form-field")
+    .data_set("name", name)
+    .data_set("invalid", ui_bool(invalid))
+    .data_set("required", ui_bool(required))
+  if invalid {
+    ignore(field_attrs.aria_invalid("true"))
+  }
+  if required {
+    ignore(field_attrs.aria_required("true"))
+  }
+  if describedby is Some(description_id) {
+    ignore(field_attrs.aria_describedby(description_id))
+  }
+  if invalid && errormessage is Some(message_id) {
+    ignore(field_attrs.aria_errormessage(message_id))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=field_attrs,
+    style=ui_styles(
+      [FormFieldLayoutStyle, if invalid { FormFieldInvalidStyle } else { "" }],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] form_item(
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let item_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "form-item")
+    .data_set("invalid", ui_bool(invalid))
+  if invalid {
+    ignore(item_attrs.aria_invalid("true"))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=item_attrs,
+    style=ui_styles(
+      [FormFieldLayoutStyle, if invalid { FormFieldInvalidStyle } else { "" }],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] form_label(
+  for_? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.label(
+    for_?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "form-label"),
+    style=ui_styles(
+      [
+        "display:flex;width:fit-content;align-items:center;gap:0.5rem;font-size:0.875rem;line-height:1.375;font-weight:500",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] form_control(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "form-control"),
+    style=ui_styles(["min-width:0"], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] form_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "form-description"),
+    style=ui_styles(
+      [
+        "margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.5;font-weight:400",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] form_message(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).role("alert").data_set("slot", "form-message"),
+    style=ui_styles(
+      [
+        "color:var(--rui-destructive,oklch(0.577 0.245 27.325));font-size:0.875rem;line-height:1.25rem;font-weight:400",
+      ],
+      style,
+    ),
+    children,
+  )
+}

--- a/rui/form_composition_test.mbt
+++ b/rui/form_composition_test.mbt
@@ -1,0 +1,182 @@
+///|
+test "radio group uses native radio semantics" {
+  let html = render_incremental(() => {
+    @rui.radio_group(default_value="pro", name="plan", aria_label="Plan", scope => {
+      @rui.radio_group_item(scope~, value="pro", aria_label="Pro")
+    })
+  })
+  assert_contains(html, "role=\"radiogroup\"")
+  assert_contains(html, "type=\"radio\"")
+  assert_contains(html, "name=\"plan\"")
+  assert_contains(html, "data-slot=\"radio-group-item\"")
+  assert_contains(html, "data-checked=\"\"")
+  assert_contains(
+    html, "--rui-control-base-bg:radial-gradient(circle at center",
+  )
+  assert_contains(
+    html, "radial-gradient(circle at center,var(--rui-primary,oklch(0.205 0 0))",
+  )
+  assert_contains(
+    html, "--rui-control-base-border:var(--rui-input,oklch(0.922 0 0))",
+  )
+  assert_contains(
+    html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)))",
+  )
+}
+
+///|
+test "native select exposes wrapper options and controlled value" {
+  let html = render(
+    @rui.native_select(value="team", aria_label="Scope", [
+      @rui.native_select_option(value="personal", "Personal"),
+      @rui.native_select_option(value="team", selected=true, "Team"),
+    ]),
+  )
+  assert_contains(html, "data-slot=\"native-select-wrapper\"")
+  assert_contains(html, "data-slot=\"native-select\"")
+  assert_contains(html, "data-slot=\"native-select-icon\"")
+  assert_contains(html, "<svg")
+  assert_contains(html, "width=\"16\"")
+  assert_contains(html, "height=\"16\"")
+  assert_not_contains(html, "border-right:1.5px")
+  assert_contains(html, "value=\"team\"")
+  assert_contains(html, "selected")
+  assert_contains(
+    html, "border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))))",
+  )
+}
+
+///|
+test "button group supplies one shared control surface" {
+  let html = render(
+    @rui.button_group(aria_label="History", [
+      @rui.button(variant=@rui.Outline, "Back"),
+      @rui.button_group_text("2 / 5"),
+      @rui.button(variant=@rui.Outline, "Next"),
+    ]),
+  )
+  assert_contains(html, "role=\"group\"")
+  assert_contains(html, "data-slot=\"button-group\"")
+  assert_contains(html, "data-orientation=\"horizontal\"")
+  assert_contains(html, "overflow:visible")
+  assert_contains(html, "align-items:stretch;gap:0")
+  assert_contains(html, "data-slot=\"button\"")
+  assert_contains(html, "data-slot=\"button-group-text\"")
+  assert_contains(html, "border-style:solid")
+  assert_contains(html, "padding-inline:0.625rem")
+  assert_not_contains(html, "min-height:2.25rem")
+  assert_contains(html, "border-color:var(--rui-border,oklch(0.922 0 0))")
+  assert_contains(
+    html, "border-top-width:var(--rui-control-border-top-width,var(--rui-control-border-width,1px))",
+  )
+}
+
+///|
+test "form field adapts explicit Rabbita-owned semantics without hidden context" {
+  let html = render(
+    @rui.form_field(
+      name="email",
+      invalid=true,
+      required=true,
+      describedby="email-description",
+      errormessage="email-message",
+      style=["max-width:24rem"],
+      [
+        @rui.form_label(for_="email", "Email"),
+        @rui.form_control(@rui.input(id="email")),
+        @rui.form_description(id="email-description", "Used for notifications."),
+        @rui.form_message(id="email-message", "Enter a valid address."),
+      ],
+    ),
+  )
+  assert_contains(html, "data-slot=\"form-field\"")
+  assert_contains(html, "data-name=\"email\"")
+  assert_contains(html, "data-invalid=\"true\"")
+  assert_contains(html, "data-required=\"true\"")
+  assert_contains(html, "aria-invalid=\"true\"")
+  assert_contains(html, "aria-required=\"true\"")
+  assert_contains(html, "aria-describedby=\"email-description\"")
+  assert_contains(html, "aria-errormessage=\"email-message\"")
+  assert_contains(html, "max-width:24rem")
+}
+
+///|
+test "field label exposes the choice-card state bridge" {
+  let html = render_incremental(() => {
+    let checkbox_view = @rui.checkbox(
+      default_checked=true,
+      aria_label="Use priority support",
+    )
+    checkbox_view.view(checkbox_html => {
+      @rui.field_label(
+        style=["background:rebeccapurple"],
+        @rui.field([
+          checkbox_html,
+          @rui.field_content([
+            @rui.field_title("Priority support"),
+            @rui.field_description("Replies within one business day."),
+          ]),
+        ]),
+      )
+    })
+  })
+  assert_contains(html, "data-slot=\"field-label\"")
+  assert_contains(html, "--rui-field-label-base-bg:transparent")
+  assert_contains(
+    html, "border-color:var(--rui-field-label-border,var(--rui-field-label-base-border,transparent))",
+  )
+  assert_contains(
+    html, "background:var(--rui-field-label-bg,var(--rui-field-label-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-field-label-shadow,var(--rui-field-label-base-shadow,none))",
+  )
+  assert_contains(html, "font-weight:500;background:rebeccapurple")
+  assert_contains(html, "data-slot=\"checkbox\"")
+  assert_contains(html, "data-state=\"checked\"")
+}
+
+///|
+test "field responsive layout uses its own container and shared label slot" {
+  let html = render(
+    @rui.theme(
+      @rui.field_group(
+        @rui.field(orientation=@rui.FieldResponsive, [
+          @rui.field_title("Workspace"),
+          @rui.field_content(@rui.input()),
+        ]),
+      ),
+    ),
+  )
+  assert_contains(html, "container-name:rui-field-group")
+  assert_contains(html, "data-orientation=\"responsive\"")
+  assert_contains(html, "data-slot=\"field-label\"")
+  assert_contains(html, "@container rui-field-group (min-width:28rem)")
+  assert_not_contains(html, "data-slot=\"field-title\"")
+}
+
+///|
+test "input otp marks one insertion slot and delegates focus styling to css" {
+  let otp_html = render_incremental(() => {
+    @rui.input_otp(
+      id="verification",
+      max_length=6,
+      default_value="123",
+      separator_after=3,
+      invalid=true,
+    )
+  })
+  assert_contains(otp_html, "data-current=\"true\"")
+  assert_contains(otp_html, "data-index=\"3\"")
+  assert_contains(otp_html, "data-slot=\"input-otp-caret\"")
+  assert_contains(otp_html, "data-slot=\"input-otp-separator\"")
+  assert_contains(otp_html, "aria-invalid=\"true\"")
+
+  let theme_html = render(@rui.theme(@html.nothing))
+  assert_contains(
+    theme_html, "[data-slot=\"input-otp\"]:focus-within [data-slot=\"input-otp-slot\"][data-current=\"true\"]",
+  )
+  assert_contains(
+    theme_html, "[data-slot=\"input-otp\"]:focus-within [data-slot=\"input-otp-caret\"]",
+  )
+}

--- a/rui/foundations_data_paths_test.mbt
+++ b/rui/foundations_data_paths_test.mbt
@@ -1,0 +1,434 @@
+///|
+#warnings("-alert_unstable")
+fn audit_render(html : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+}
+
+///|
+fn audit_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected rendered HTML to contain `\{expected}`; got `\{actual}`")
+  }
+}
+
+///|
+fn audit_not_contains(actual : String, unexpected : String) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail(
+      "expected rendered HTML not to contain `\{unexpected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+fn audit_test_icon(path : String) -> @html.Html {
+  @html.span(
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(width=16, height=16, view_box="0 0 24 24", [
+      @svg.path(
+        d=path,
+        fill="none",
+        stroke="currentColor",
+        stroke_width=2,
+        attrs=@svg.Attrs::build()
+          .stroke_linecap("round")
+          .stroke_linejoin("round"),
+      ),
+    ]),
+  )
+}
+
+///|
+test "native as-child link paths retain semantics and disabled state" {
+  let html = audit_render(
+    @html.div([
+      @rui.badge_link(
+        href="/status",
+        variant=@rui.Outline,
+        disabled=true,
+        aria_label="Unavailable status",
+        "Status",
+      ),
+      @rui.item_link(
+        href="/workspace",
+        variant=@rui.ItemMuted,
+        size=@rui.ItemSm,
+        disabled=true,
+        aria_label="Unavailable workspace",
+        @rui.item_content([
+          @rui.item_title("Workspace"),
+          @rui.item_description(
+            "A deliberately long description that exercises wrapping and the two-line clamp.",
+          ),
+        ]),
+      ),
+      @rui.attachment(
+        @rui.attachment_trigger_link(
+          href="/files/specification",
+          disabled=true,
+          aria_label="Unavailable specification",
+          "Open",
+        ),
+      ),
+      @rui.bubble(
+        variant=@rui.BubbleSecondary,
+        @rui.bubble_content_link(
+          href="/reply",
+          disabled=true,
+          aria_label="Unavailable reply",
+          "Reply",
+        ),
+      ),
+      @rui.marker_link(
+        href="/activity",
+        variant=@rui.MarkerSeparator,
+        disabled=true,
+        aria_label="Unavailable activity",
+        @rui.marker_content("Activity"),
+      ),
+    ]),
+  )
+  audit_contains(html, "<a")
+  audit_contains(html, "href=\"/status\"")
+  audit_contains(html, "href=\"/workspace\"")
+  audit_contains(html, "href=\"/files/specification\"")
+  audit_contains(html, "href=\"/reply\"")
+  audit_contains(html, "href=\"/activity\"")
+  audit_contains(html, "aria-disabled=\"true\"")
+  audit_contains(html, "tabindex=\"-1\"")
+  audit_contains(html, "data-disabled=\"\"")
+  audit_contains(html, "data-slot=\"badge\" data-variant=\"outline\"")
+  audit_contains(
+    html, "data-slot=\"item\" data-variant=\"muted\" data-size=\"sm\"",
+  )
+  audit_contains(html, "data-slot=\"attachment-trigger\"")
+  audit_contains(html, "data-slot=\"bubble-content\"")
+  audit_contains(html, "data-slot=\"marker\" data-variant=\"separator\"")
+  audit_contains(html, "cursor:not-allowed;pointer-events:none;opacity:0.5")
+}
+
+///|
+test "interactive bubble button follows parent variant and native button state" {
+  let html = audit_render(
+    @rui.bubble(
+      variant=@rui.BubbleDestructive,
+      align=@rui.AlignEnd,
+      @rui.bubble_content_button(
+        disabled=true,
+        aria_label="Retry unavailable",
+        "Retry",
+      ),
+    ),
+  )
+  audit_contains(html, "data-slot=\"bubble\"")
+  audit_contains(html, "data-variant=\"destructive\"")
+  audit_contains(html, "data-align=\"end\"")
+  audit_contains(html, "--rui-bubble-bg:var(--rui-destructive-subtle")
+  audit_contains(html, "<button")
+  audit_contains(html, "type=\"button\"")
+  audit_contains(html, "disabled")
+  audit_contains(html, "aria-disabled=\"true\"")
+  audit_contains(
+    html, "background:var(--rui-bubble-bg,var(--rui-primary,oklch(0.205 0 0)))",
+  )
+
+  let standalone = audit_render(
+    @rui.bubble_content_button(aria_label="Retry", "Retry"),
+  )
+  audit_not_contains(standalone, "--rui-bubble-bg:")
+  audit_not_contains(standalone, "--rui-bubble-border:")
+}
+
+///|
+test "message and bubble recipes cover Vega variants alignment and reactions" {
+  let html = audit_render(
+    @rui.message(
+      align=@rui.AlignEnd,
+      @rui.message_content([
+        @rui.message_header(
+          "A long sender label that must stay inside a narrow message row",
+        ),
+        @rui.bubble_group([
+          @rui.bubble(
+            @rui.bubble_content(
+              "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz",
+            ),
+          ),
+          @rui.bubble(
+            variant=@rui.BubbleSecondary,
+            @rui.bubble_content("Secondary"),
+          ),
+          @rui.bubble(variant=@rui.BubbleMuted, @rui.bubble_content("Muted")),
+          @rui.bubble(variant=@rui.BubbleTinted, @rui.bubble_content("Tinted")),
+          @rui.bubble(
+            variant=@rui.BubbleOutline,
+            @rui.bubble_content("Outline"),
+          ),
+          @rui.bubble(variant=@rui.BubbleGhost, @rui.bubble_content("Ghost")),
+          @rui.bubble(variant=@rui.BubbleDestructive, align=@rui.AlignEnd, [
+            @rui.bubble_content("Destructive"),
+            @rui.bubble_reactions(
+              side=@rui.ReactionTop,
+              align=@rui.AlignStart,
+              audit_test_icon("M20 6 9 17l-5-5"),
+            ),
+            @rui.bubble_reactions(
+              side=@rui.ReactionBottom,
+              align=@rui.AlignEnd,
+              @html.span("2"),
+            ),
+          ]),
+        ]),
+        @rui.message_footer("Delivered"),
+      ]),
+    ),
+  )
+  audit_contains(html, "--rui-message-content-align:flex-end")
+  audit_contains(html, "align-self:var(--rui-message-content-align,flex-start)")
+  audit_contains(html, "overflow-wrap:break-word;word-break:normal")
+  audit_contains(html, "data-variant=\"default\"")
+  audit_contains(html, "data-variant=\"secondary\"")
+  audit_contains(html, "data-variant=\"muted\"")
+  audit_contains(html, "data-variant=\"tinted\"")
+  audit_contains(html, "data-variant=\"outline\"")
+  audit_contains(html, "data-variant=\"ghost\"")
+  audit_contains(html, "data-variant=\"destructive\"")
+  audit_contains(html, "max-width:100%")
+  audit_contains(html, "light-dark(oklch(from var(--rui-primary")
+  audit_contains(html, "--rui-bubble-content-align:flex-end")
+  audit_contains(html, "data-side=\"top\" data-align=\"start\"")
+  audit_contains(html, "top:0;inset-inline-start:0.75rem")
+  audit_contains(html, "data-side=\"bottom\" data-align=\"end\"")
+  audit_contains(html, "bottom:0;inset-inline-end:0.75rem")
+
+  let avatar = audit_render(@rui.message_avatar("Y"))
+  audit_contains(avatar, "min-height:2rem;aspect-ratio:1")
+  let themed = audit_render(@rui.theme(@html.nothing))
+  audit_contains(themed, "[data-slot=\"bubble-reactions\"]:has(button)")
+  audit_contains(
+    themed, ":is(a,button)[data-slot=\"bubble-content\"]:not(:disabled):not([aria-disabled=\"true\"]):active",
+  )
+  audit_contains(
+    themed, "color-mix(in oklch,var(--rui-secondary,oklch(0.97 0 0)) 95%,var(--rui-foreground",
+  )
+}
+
+///|
+test "button and button-group children expose per-edge merge variables" {
+  let html = audit_render(
+    @rui.button_group([
+      @rui.button(
+        size=@rui.IconXs,
+        attrs=@html.Attrs::build().aria_label("Previous item"),
+        audit_test_icon("m15 18-6-6 6-6"),
+      ),
+      @rui.button_group_text("of 3"),
+      @rui.button(size=@rui.Lg, "Next"),
+    ]),
+  )
+  audit_contains(html, "data-slot=\"button-group\"")
+  audit_contains(
+    html, "border-top-width:var(--rui-control-border-top-width,var(--rui-control-border-width,1px))",
+  )
+  audit_contains(
+    html, "border-left-width:var(--rui-control-border-left-width,var(--rui-control-border-width,1px))",
+  )
+  audit_contains(
+    html, "border-top-left-radius:var(--rui-control-radius-top-left,var(--rui-control-radius",
+  )
+  audit_contains(
+    html, "border-bottom-right-radius:var(--rui-control-radius-bottom-right,var(--rui-control-radius",
+  )
+  audit_contains(html, "--rui-button-icon-size:0.75rem")
+  audit_contains(html, "--rui-button-padding-inline:1.5rem")
+
+  let themed = audit_render(@rui.theme(@html.nothing))
+  audit_contains(
+    themed, "[data-slot=\"button-group\"][data-orientation=\"horizontal\"]:dir(ltr) > :has(+ [data-slot=\"button-group-separator\"][data-orientation=\"vertical\"]) {\n    --rui-control-border-right-width:0px",
+  )
+  audit_contains(
+    themed, "[data-slot=\"button-group\"][data-orientation=\"horizontal\"]:dir(rtl) > :has(+ [data-slot=\"button-group-separator\"][data-orientation=\"vertical\"]) {\n    --rui-control-border-left-width:0px",
+  )
+  audit_contains(
+    themed, "[data-slot=\"button-group\"][data-orientation=\"vertical\"] > :has(+ [data-slot=\"button-group-separator\"][data-orientation=\"horizontal\"]) {\n    --rui-control-border-bottom-width:0px",
+  )
+}
+
+///|
+test "separator, spinner, and skeleton cover semantic and motion branches" {
+  let invalid_ratio = audit_render(@rui.aspect_ratio(ratio=0.0, "Preview"))
+  audit_contains(invalid_ratio, "aspect-ratio:1")
+
+  let decorative = audit_render(@rui.separator())
+  audit_contains(decorative, "role=\"none\"")
+  audit_not_contains(decorative, "aria-orientation")
+
+  let semantic = audit_render(
+    @rui.separator(orientation=@rui.Vertical, decorative=false),
+  )
+  audit_contains(semantic, "role=\"separator\"")
+  audit_contains(semantic, "aria-orientation=\"vertical\"")
+
+  let spinner_html = audit_render(@rui.spinner(label="Loading data"))
+  audit_contains(spinner_html, "role=\"status\"")
+  audit_contains(spinner_html, "aria-label=\"Loading data\"")
+  audit_contains(spinner_html, "width=\"16\"")
+  audit_contains(spinner_html, "height=\"16\"")
+  audit_contains(spinner_html, "viewBox=\"0 0 24 24\"")
+  audit_contains(spinner_html, "animation:rui-spin 1s linear infinite")
+  audit_contains(spinner_html, "M21 12a9 9 0 1 1-6.219-8.56")
+  audit_not_contains(spinner_html, "<circle")
+  audit_not_contains(spinner_html, "animateTransform")
+
+  let skeleton_html = audit_render(@rui.skeleton())
+  audit_contains(skeleton_html, "data-slot=\"skeleton\"")
+  audit_contains(skeleton_html, "animation:rui-pulse 2s")
+}
+
+///|
+test "attachment size orientation and state variables propagate to parts" {
+  let html = audit_render(
+    @html.div([
+      @rui.attachment(
+        state=@rui.AttachmentIdle,
+        size=@rui.AttachmentXs,
+        orientation=@rui.AttachmentHorizontal,
+        @rui.attachment_media("File"),
+      ),
+      @rui.attachment(
+        state=@rui.AttachmentError,
+        size=@rui.AttachmentSm,
+        orientation=@rui.AttachmentVertical,
+        [
+          @rui.attachment_media(variant=@rui.AttachmentImage, "Preview"),
+          @rui.attachment_content(@rui.attachment_description("Upload failed")),
+        ],
+      ),
+      @rui.attachment(
+        state=@rui.AttachmentProcessing,
+        @rui.attachment_content(@rui.attachment_title("Processing file")),
+      ),
+    ]),
+  )
+  audit_contains(html, "data-state=\"idle\"")
+  audit_contains(html, "data-size=\"xs\"")
+  audit_contains(html, "data-orientation=\"horizontal\"")
+  audit_contains(html, "--rui-attachment-media-size:1.75rem")
+  audit_contains(html, "border-style:dashed")
+  audit_contains(html, "data-state=\"error\"")
+  audit_contains(html, "data-size=\"sm\"")
+  audit_contains(html, "data-orientation=\"vertical\"")
+  audit_contains(html, "--rui-attachment-media-width:100%")
+  audit_contains(html, "--rui-attachment-icon-size:1.5rem")
+  audit_contains(html, "--rui-attachment-image-opacity:0.6")
+  audit_contains(html, "--rui-attachment-description-fg:color-mix")
+  audit_contains(
+    html, "--rui-attachment-title-animation:rui-shimmer 2s linear infinite",
+  )
+  audit_contains(html, "--rui-attachment-title-shimmer-spread:calc(3ch + 40px)")
+  audit_contains(
+    html, "linear-gradient(calc(90deg + var(--rui-attachment-title-shimmer-angle,20deg))",
+  )
+  audit_contains(html, "--rui-attachment-title-text-fill:transparent")
+  audit_contains(html, "animation:var(--rui-attachment-title-animation,none)")
+  audit_contains(
+    html, "-webkit-text-fill-color:var(--rui-attachment-title-text-fill,currentColor)",
+  )
+  audit_contains(
+    html, "padding-block:var(--rui-attachment-padding-block,0);padding-inline:var(--rui-attachment-padding-inline,0)",
+  )
+
+  let themed = audit_render(@rui.theme(@html.nothing))
+  audit_contains(
+    themed, "[data-slot=\"attachment\"]:has(> [data-slot=\"attachment-content\"])",
+  )
+  audit_contains(
+    themed, "--rui-attachment-padding-block:var(--rui-attachment-content-padding-block,0)",
+  )
+  audit_contains(
+    themed, "[data-slot=\"attachment\"]:has(> [data-slot=\"attachment-media\"]):not(:has(> [data-slot=\"attachment-content\"]))",
+  )
+
+  let group = audit_render(
+    @rui.attachment_group(
+      @rui.attachment(
+        @rui.attachment_trigger(aria_label="Open file", @html.nothing),
+      ),
+    ),
+  )
+  audit_contains(group, "box-sizing:border-box")
+  audit_contains(group, "padding-inline:0.25rem")
+  audit_contains(group, "scroll-padding-inline:0.25rem")
+}
+
+///|
+test "alert and card optional tracks do not reserve empty columns" {
+  let html = audit_render(
+    @html.div([
+      @rui.alert([
+        @rui.alert_title("Notice"),
+        @rui.alert_description("Description"),
+      ]),
+      @rui.card(
+        @rui.card_header([
+          @rui.card_title("Title"),
+          @rui.card_description("Description"),
+        ]),
+      ),
+    ]),
+  )
+  audit_contains(
+    html, "grid-template-columns:var(--rui-alert-columns,0 minmax(0,1fr) auto)",
+  )
+  audit_contains(html, "column-gap:var(--rui-alert-column-gap,0)")
+  audit_contains(
+    html, "grid-template-columns:var(--rui-card-header-columns,minmax(0,1fr))",
+  )
+  audit_contains(html, "column-gap:var(--rui-card-header-column-gap,0)")
+
+  let themed = audit_render(
+    @rui.theme(
+      @rui.alert(@svg.svg(view_box="0 0 24 24", [@svg.path(d="M12 2v20")])),
+    ),
+  )
+  audit_contains(themed, "[data-slot=\"alert\"]:has(> svg)")
+  audit_contains(themed, "--rui-alert-columns:auto minmax(0,1fr) auto")
+  audit_contains(
+    themed, "[data-slot=\"card-header\"]:has(> [data-slot=\"card-action\"])",
+  )
+  audit_contains(themed, "@keyframes rui-shimmer")
+  audit_contains(themed, "from { background-position:100% 0; }")
+  audit_contains(themed, "to { background-position:0 0; }")
+  audit_contains(themed, "-webkit-text-fill-color:currentColor !important")
+}
+
+///|
+test "logical-direction and long-content recipes remain narrow-safe" {
+  let html = audit_render(
+    @rui.direction(
+      direction=@rui.Rtl,
+      @html.div([
+        @rui.item_link(
+          href="/rtl",
+          @rui.item_description(
+            "A very long unbroken identifier abcdefghijklmnopqrstuvwxyz0123456789",
+          ),
+        ),
+        @rui.message(align=@rui.AlignEnd, @rui.message_content("Message")),
+        @rui.table(
+          @rui.table_body(
+            @rui.table_row(
+              @rui.table_cell("A long cell that may need horizontal scroll"),
+            ),
+          ),
+        ),
+      ]),
+    ),
+  )
+  audit_contains(html, "dir=\"rtl\"")
+  audit_contains(html, "text-align:start")
+  audit_contains(html, "min-width:0")
+  audit_contains(html, "-webkit-line-clamp:2")
+  audit_contains(html, "--rui-message-content-align:flex-end")
+  audit_contains(html, "overflow-x:auto")
+}

--- a/rui/foundations_test.mbt
+++ b/rui/foundations_test.mbt
@@ -1,0 +1,145 @@
+///|
+#warnings("-alert_unstable")
+fn render(html : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+}
+
+///|
+fn assert_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected rendered HTML to contain `\{expected}`; got `\{actual}`")
+  }
+}
+
+///|
+fn assert_not_contains(actual : String, unexpected : String) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail(
+      "expected rendered HTML not to contain `\{unexpected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+test "button is a zero-setup native button" {
+  let html = render(
+    @rui.button(
+      variant=@rui.Outline,
+      size=@rui.Sm,
+      disabled=true,
+      style=["background:rebeccapurple"],
+      "Save",
+    ),
+  )
+  assert_contains(html, "<button")
+  assert_contains(html, "type=\"button\"")
+  assert_contains(html, "disabled")
+  assert_contains(html, "height:2rem")
+  assert_contains(
+    html, "background:var(--rui-button-bg,var(--rui-button-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "--rui-button-base-bg:var(--rui-outline-background,var(--rui-background,oklch(1 0 0)))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-button-shadow,var(--rui-button-base-shadow,none))",
+  )
+  assert_contains(
+    html, "cursor:not-allowed;pointer-events:none;opacity:0.5;background:rebeccapurple",
+  )
+  assert_contains(html, ">Save</button>")
+}
+
+///|
+test "caller styles are appended after the built-in recipe" {
+  let html = render(
+    @rui.badge(
+      style=["background:rebeccapurple", "border-radius:2px"],
+      "Custom",
+    ),
+  )
+  assert_contains(
+    html, "--rui-badge-base-bg:var(--rui-primary,oklch(0.205 0 0));--rui-badge-base-fg:var(--rui-primary-foreground,oklch(0.985 0 0));--rui-badge-base-border:transparent;background:rebeccapurple;border-radius:2px",
+  )
+}
+
+///|
+test "destructive controls keep the Vega solid surface before hover" {
+  let button_html = render(@rui.button(variant=@rui.Destructive, "Delete"))
+  assert_contains(
+    button_html, "--rui-button-base-bg:var(--rui-destructive-surface,var(--rui-destructive",
+  )
+  assert_contains(button_html, "--rui-button-base-fg:white")
+
+  let badge_html = render(@rui.badge(variant=@rui.Destructive, "Failed"))
+  assert_contains(
+    badge_html, "--rui-badge-base-bg:var(--rui-destructive-surface,var(--rui-destructive",
+  )
+  assert_contains(badge_html, "--rui-badge-base-fg:white")
+}
+
+///|
+test "theme supplies dark Neutral tokens inline" {
+  let html = render(@rui.theme(mode=@rui.Dark, @rui.badge("Dark")))
+  assert_contains(html, "color-scheme:dark")
+  assert_contains(html, "--rui-background:oklch(0.145 0 0)")
+  assert_contains(
+    html, "<style data-rui-style=\"interactions\">@keyframes rui-spin",
+  )
+  assert_contains(html, "@layer rui-interactions")
+  assert_contains(html, ":hover")
+  assert_contains(html, ":focus-visible")
+  assert_contains(html, "[data-state=\"on\"]")
+  assert_contains(html, "::-webkit-slider-thumb")
+  assert_contains(html, "[data-slot=\"combobox-chip-remove\"]")
+  assert_contains(html, "--rui-field-label-checked-bg")
+  assert_contains(html, "--rui-tabs-active-bg")
+  assert_contains(html, ":where([hidden]:not([hidden=\"until-found\"]))")
+  assert_contains(
+    html, "[data-slot=\"accordion-trigger\"]:not([aria-disabled=\"true\"]):hover",
+  )
+  assert_contains(
+    html, "[data-slot=\"collapsible-trigger\"]:not([aria-disabled=\"true\"]):hover",
+  )
+  assert_contains(
+    html, ":where([data-slot=\"toggle\"],[data-slot=\"toggle-group-item\"]):not(:disabled):not([aria-disabled=\"true\"])[data-variant][data-state=\"on\"]",
+  )
+  assert_contains(
+    html, ":not([aria-disabled=\"true\"]):not([aria-haspopup]):active",
+  )
+  assert_contains(html, "transform:translateY(1px)")
+  assert_contains(html, "[data-state=\"off\"][data-variant=\"outline\"]:hover")
+  assert_contains(
+    html, ":where(button,a)[data-variant=\"destructive\"][data-size]:not(:disabled):not([aria-disabled=\"true\"]):focus-visible",
+  )
+  assert_contains(
+    html, "[data-slot=\"navigation-menu-trigger\"][data-state=\"open\"]:not(:disabled):hover",
+  )
+  assert_contains(
+    html, "[data-slot=\"navigation-menu-link\"][data-active=\"true\"]:not(:disabled):focus",
+  )
+  assert_contains(
+    html, "[data-slot=\"sidebar-menu-button\"][data-active=\"true\"] ~ [data-slot=\"sidebar-menu-badge\"]",
+  )
+  assert_contains(html, "@media (hover: none)")
+  assert_contains(
+    html, "[data-slot=\"popover-content\"][data-date-range-picker-popup]",
+  )
+  assert_contains(html, "--rui-date-range-picker-width:15.5rem")
+  assert_contains(html, "--rui-date-range-picker-max-height:calc(100% - 1rem)")
+  assert_contains(html, ":not([data-range-start]):not([data-range-end]):hover")
+  assert_contains(
+    html, "[data-slot=\"combobox-chip-remove\"]:not(:disabled):not([aria-disabled=\"true\"]):focus-visible",
+  )
+  assert_contains(
+    html, "[data-slot=\"scroll-area\"][data-managed]:has(> [data-slot=\"scroll-area-viewport\"]:focus-visible)",
+  )
+  assert_contains(
+    html, "[data-slot=\"message-scroller\"]:has([data-slot=\"message-scroller-viewport\"]:focus-visible)",
+  )
+  assert_contains(
+    html, ":where([data-slot=\"scroll-area-viewport\"],[data-slot=\"message-scroller-viewport\"]):focus-visible",
+  )
+  assert_not_contains(html, "&gt;")
+  assert_contains(html, ">Dark</span>")
+}

--- a/rui/hover_card.mbt
+++ b/rui/hover_card.mbt
@@ -1,0 +1,806 @@
+///|
+const HoverCardRootStyle : String = "display:contents"
+
+///|
+const HoverCardContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:block;width:16rem;max-width:calc(100vw - 1rem);transform-origin:var(--rui-floating-transform-origin,center);margin:0;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:1rem;color:var(--rui-popover-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem;box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1),0 2px 4px -2px rgb(0 0 0 / 0.1);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+fn hover_card_delay(value : Int) -> Int {
+  if value < 0 {
+    0
+  } else {
+    value
+  }
+}
+
+///|
+fn hover_card_trigger_adjustment_style(variant : ButtonVariant) -> String {
+  match variant {
+    Link =>
+      "height:auto;padding:0;border:0;vertical-align:baseline;text-decoration-line:underline;text-decoration-thickness:from-font"
+    _ => ""
+  }
+}
+
+///|
+/// Render the native link that owns hover-card interaction.
+///
+/// The stateful `hover_card` root wires hover and focus events. This standalone
+/// part exposes the same state, delay, and relationship attributes for custom
+/// composition without requiring a stylesheet.
+pub fn[C : @html.IsChildren] hover_card_trigger(
+  content_id~ : String,
+  href~ : String,
+  open? : Bool = false,
+  disabled? : Bool = false,
+  open_delay? : Int = 600,
+  close_delay? : Int = 300,
+  variant? : ButtonVariant = Link,
+  size? : ButtonSize = Default,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let resolved_id = id.unwrap_or(content_id + "-trigger")
+  let actual_open_delay = hover_card_delay(open_delay)
+  let actual_close_delay = hover_card_delay(close_delay)
+  let element_attrs = popup_state_attrs(attrs, "hover-card-trigger", open)
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+    .data_set("delay", "\{actual_open_delay}")
+    .data_set("close-delay", "\{actual_close_delay}")
+    .aria_expanded(ui_bool(open))
+    .aria_controls(content_id)
+  if open {
+    ignore(element_attrs.data_set("popup-open", ""))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").tabindex(-1).data_set("disabled", ""),
+    )
+  }
+  if !disabled && on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  @html.a(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        hover_card_trigger_adjustment_style(variant),
+        ui_disabled_style(disabled),
+        popup_anchor_style(resolved_id),
+      ],
+      style,
+    ),
+    id=resolved_id,
+    class?,
+    title?,
+    href~,
+    target~,
+    rel?,
+    download?,
+    attrs=element_attrs,
+    children,
+    escape~,
+  )
+}
+
+///|
+/// Render the shadcn Vega hover-card surface on the native Popover top layer.
+///
+/// `popover="auto"` supplies browser Escape and light-dismiss behavior. The
+/// stateful root synchronizes those native changes back into Rabbita state.
+pub fn[C : @html.IsChildren] hover_card_content(
+  id~ : String,
+  trigger_id~ : String,
+  open? : Bool = false,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  aria_labelledby? : String,
+  aria_describedby? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = popup_state_attrs(attrs, "hover-card-content", open)
+    .popover("auto")
+    .tabindex(-1)
+    .data_set("initial-focus", "false")
+    .data_set("restore-focus", "false")
+    .data_set("trigger-id", trigger_id)
+    .data_set("requested-side", popup_side_value(side))
+    .data_set("requested-align", popup_align_value(align))
+    .data_set("side", popup_side_value(side))
+    .data_set("align", popup_align_value(align))
+    .data_set("side-offset", "\{side_offset}")
+    .data_set("align-offset", "\{align_offset}")
+    .data_set("collision-padding", "0")
+    .data_set("sticky", "partial")
+  if aria_labelledby is Some(labelledby) {
+    ignore(element_attrs.aria_labelledby(labelledby))
+  }
+  if aria_describedby is Some(describedby) {
+    ignore(element_attrs.aria_describedby(describedby))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        HoverCardContentStyle,
+        PopupTransition100Style,
+        popup_floating_anchor_style(
+          trigger_id, side, align, side_offset, align_offset,
+        ),
+        popup_state_style(open),
+      ],
+      style,
+    ),
+    id~,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+priv struct HoverCardEventBinding {
+  root : @dom.Element
+  dispatch : Ref[(Int, Int) -> Unit]
+}
+
+///|
+#cfg(target="js")
+let hover_card_event_bindings : Map[String, HoverCardEventBinding] = Map([])
+
+///|
+#cfg(target="js")
+fn hover_card_config(
+  trigger : @dom.Element,
+  root : @dom.Element,
+  trigger_name : String,
+  root_name : String,
+  fallback : Int,
+) -> Int {
+  let own = trigger.get_attribute("data-" + trigger_name).unwrap_or("")
+  let inherited = root.get_attribute("data-" + root_name).unwrap_or("")
+  let value = if own == "" { inherited } else { own }
+  let parsed = ui_parse_int_or(value, fallback)
+  if parsed < 0 {
+    0
+  } else {
+    parsed
+  }
+}
+
+///|
+#cfg(target="js")
+fn bind_hover_card_events(id : String, dispatch : (Int, Int) -> Unit) -> Bool {
+  guard ui_element_by_id(id) is Some(popup) else { return false }
+  guard ui_element_by_id(id + "-trigger") is Some(trigger) else { return false }
+  guard ui_element_by_id(id + "-root") is Some(root) else { return false }
+  if !popup.get_is_connected() ||
+    !trigger.get_is_connected() ||
+    !root.get_is_connected() {
+    return false
+  }
+  if hover_card_event_bindings.get(id) is Some(binding) &&
+    binding.root.is_same_node(root.as_node()) {
+    binding.dispatch.val = dispatch
+    return true
+  }
+  let binding : HoverCardEventBinding = { root, dispatch: Ref(dispatch) }
+  hover_card_event_bindings[id] = binding
+  fn open_delay() -> Int {
+    hover_card_config(trigger, root, "delay", "open-delay", 600)
+  }
+
+  fn close_delay() -> Int {
+    hover_card_config(trigger, root, "close-delay", "close-delay", 300)
+  }
+
+  fn send(kind : Int, wait : Int) -> Unit {
+    if !root.has_attribute("data-disabled") {
+      (binding.dispatch.val)(kind, wait)
+    }
+  }
+
+  trigger.add_event_listener("mouseenter", _ => send(0, open_delay()))
+  trigger.add_event_listener("mouseleave", _ => {
+    let hover_grace = if root.get_attribute("data-hoverable").unwrap_or("") ==
+      "true" {
+      100
+    } else {
+      0
+    }
+    let wait = close_delay()
+    send(1, if wait < hover_grace { hover_grace } else { wait })
+  })
+  trigger.add_event_listener("focus", _ => {
+    if trigger.matches(":focus-visible") {
+      send(2, open_delay())
+    }
+  })
+  trigger.add_event_listener("blur", _ => send(3, close_delay()))
+  trigger.add_event_listener("click", event => {
+    if root.has_attribute("data-disabled") {
+      event.prevent_default()
+      event.stop_propagation()
+    }
+  })
+  popup.add_event_listener("mouseenter", _ => {
+    if root.get_attribute("data-hoverable").unwrap_or("") == "true" {
+      send(4, 0)
+    }
+  })
+  popup.add_event_listener("mouseleave", _ => {
+    if root.get_attribute("data-hoverable").unwrap_or("") == "true" {
+      send(5, close_delay())
+    }
+  })
+  popup.add_event_listener("focusin", _ => send(6, 0))
+  popup.add_event_listener("focusout", event => {
+    let still_inside = if event.to_focus_event() is Some(focus_event) {
+      if focus_event.related_target() is Some(target) {
+        ui_element_contains_target(popup, target)
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+    if !still_inside {
+      send(7, close_delay())
+    }
+  })
+  true
+}
+
+///|
+#cfg(target="js")
+priv struct HoverCardModel {
+  open : Bool
+  trigger_hovered : Bool
+  trigger_focused : Bool
+  content_hovered : Bool
+  content_focused : Bool
+  generation : Int
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum HoverCardMsg {
+  HoverCardDomEvent(Int, Int)
+  HoverCardOpenAfter(Int)
+  HoverCardCloseAfter(Int)
+  HoverCardNativeChanged(Bool)
+}
+
+///|
+#cfg(target="js")
+fn hover_card_is_active(model : HoverCardModel) -> Bool {
+  model.trigger_hovered ||
+  model.trigger_focused ||
+  model.content_hovered ||
+  model.content_focused
+}
+
+///|
+#cfg(target="js")
+fn hover_card_notify_cmd(
+  on_open_change : @cmd.Emit[Bool]?,
+  open : Bool,
+) -> @cmd.Cmd {
+  if on_open_change is Some(notify) {
+    notify(open)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn hover_card_commit_open(
+  id : String,
+  on_open_change : @cmd.Emit[Bool]?,
+  model : HoverCardModel,
+  open : Bool,
+) -> (HoverCardModel, @cmd.Cmd) {
+  if model.open == open {
+    (model, @cmd.none)
+  } else {
+    (
+      { ..model, open, },
+      @cmd.batch([
+        floating_set_open_cmd(id, open),
+        hover_card_notify_cmd(on_open_change, open),
+      ]),
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+fn hover_card_commit_native(
+  on_open_change : @cmd.Emit[Bool]?,
+  model : HoverCardModel,
+  open : Bool,
+) -> (HoverCardModel, @cmd.Cmd) {
+  if open {
+    if model.open {
+      (model, @cmd.none)
+    } else {
+      ({ ..model, open: true }, hover_card_notify_cmd(on_open_change, true))
+    }
+  } else {
+    let next : HoverCardModel = {
+      open: false,
+      trigger_hovered: false,
+      trigger_focused: false,
+      content_hovered: false,
+      content_focused: false,
+      generation: model.generation + 1,
+    }
+    if model.open {
+      (next, hover_card_notify_cmd(on_open_change, false))
+    } else {
+      (next, @cmd.none)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn hover_card_bind_events_cmd(
+  id : String,
+  emit : @cmd.Emit[HoverCardMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_ready("hover-card-events:" + id, () => {
+      bind_hover_card_events(id, (kind, wait) => {
+        scheduler.add(emit(HoverCardDomEvent(kind, wait)))
+      })
+    })
+  })
+}
+
+///|
+#cfg(target="js")
+fn hover_card_open_from_interaction(
+  id : String,
+  on_open_change : @cmd.Emit[Bool]?,
+  emit : @cmd.Emit[HoverCardMsg],
+  current : HoverCardModel,
+  next : HoverCardModel,
+  wait : Int,
+) -> (HoverCardModel, @cmd.Cmd) {
+  if current.open {
+    (next, @cmd.none)
+  } else if wait <= 0 {
+    hover_card_commit_open(id, on_open_change, next, true)
+  } else {
+    (next, @cmd.delay(emit(HoverCardOpenAfter(next.generation)), wait))
+  }
+}
+
+///|
+#cfg(target="js")
+fn hover_card_close_from_interaction(
+  id : String,
+  on_open_change : @cmd.Emit[Bool]?,
+  emit : @cmd.Emit[HoverCardMsg],
+  next : HoverCardModel,
+  wait : Int,
+) -> (HoverCardModel, @cmd.Cmd) {
+  if hover_card_is_active(next) || !next.open {
+    (next, @cmd.none)
+  } else if wait <= 0 {
+    hover_card_commit_open(id, on_open_change, next, false)
+  } else {
+    (next, @cmd.delay(emit(HoverCardCloseAfter(next.generation)), wait))
+  }
+}
+
+///|
+#cfg(target="js")
+fn hover_card_update(
+  id : String,
+  on_open_change : @cmd.Emit[Bool]?,
+  emit : @cmd.Emit[HoverCardMsg],
+  msg : HoverCardMsg,
+  current : HoverCardModel,
+) -> (HoverCardModel, @cmd.Cmd) {
+  match msg {
+    HoverCardDomEvent(kind, wait) =>
+      match kind {
+        // Trigger hover opens after the configured delay.
+        0 => {
+          let next = {
+            ..current,
+            trigger_hovered: true,
+            generation: current.generation + 1,
+          }
+          hover_card_open_from_interaction(
+            id, on_open_change, emit, current, next, wait,
+          )
+        }
+        1 => {
+          let next = {
+            ..current,
+            trigger_hovered: false,
+            generation: current.generation + 1,
+          }
+          hover_card_close_from_interaction(
+            id, on_open_change, emit, next, wait,
+          )
+        }
+        // Keyboard focus uses the same opening delay as pointer hover.
+        2 => {
+          let next = {
+            ..current,
+            trigger_focused: true,
+            generation: current.generation + 1,
+          }
+          hover_card_open_from_interaction(
+            id, on_open_change, emit, current, next, wait,
+          )
+        }
+        3 => {
+          let next = {
+            ..current,
+            trigger_focused: false,
+            generation: current.generation + 1,
+          }
+          hover_card_close_from_interaction(
+            id, on_open_change, emit, next, wait,
+          )
+        }
+        // Hovering or focusing the popup invalidates a pending close.
+        4 =>
+          (
+            {
+              ..current,
+              content_hovered: true,
+              generation: current.generation + 1,
+            },
+            @cmd.none,
+          )
+        5 => {
+          let next = {
+            ..current,
+            content_hovered: false,
+            generation: current.generation + 1,
+          }
+          hover_card_close_from_interaction(
+            id, on_open_change, emit, next, wait,
+          )
+        }
+        6 =>
+          (
+            {
+              ..current,
+              content_focused: true,
+              generation: current.generation + 1,
+            },
+            @cmd.none,
+          )
+        7 => {
+          let next = {
+            ..current,
+            content_focused: false,
+            generation: current.generation + 1,
+          }
+          hover_card_close_from_interaction(
+            id, on_open_change, emit, next, wait,
+          )
+        }
+        // Native light-dismiss synchronizes through HoverCardNativeChanged.
+        _ =>
+          hover_card_commit_open(
+            id,
+            on_open_change,
+            {
+              ..current,
+              trigger_hovered: false,
+              trigger_focused: false,
+              content_hovered: false,
+              content_focused: false,
+              generation: current.generation + 1,
+            },
+            false,
+          )
+      }
+    HoverCardOpenAfter(generation) =>
+      if generation == current.generation && hover_card_is_active(current) {
+        hover_card_commit_open(id, on_open_change, current, true)
+      } else {
+        (current, @cmd.none)
+      }
+    HoverCardCloseAfter(generation) =>
+      if generation == current.generation && !hover_card_is_active(current) {
+        hover_card_commit_open(id, on_open_change, current, false)
+      } else {
+        (current, @cmd.none)
+      }
+    HoverCardNativeChanged(open) =>
+      hover_card_commit_native(on_open_change, current, open)
+  }
+}
+
+///|
+fn[T : @html.IsChildren, C : @html.IsChildren] render_hover_card(
+  id : String,
+  href : String,
+  target : @html.Target,
+  rel : String?,
+  download : String?,
+  escape : Bool,
+  open : Bool,
+  disabled : Bool,
+  open_delay : Int,
+  close_delay : Int,
+  hoverable : Bool,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+  trigger_variant : ButtonVariant,
+  trigger_size : ButtonSize,
+  aria_labelledby : String?,
+  aria_describedby : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  trigger_attrs : @html.Attrs?,
+  trigger_style : Array[String],
+  content_attrs : @html.Attrs?,
+  content_style : Array[String],
+  on_trigger_click : @cmd.Cmd?,
+  trigger : T,
+  content : C,
+) -> @html.Html {
+  let root_id = id + "-root"
+  let trigger_id = id + "-trigger"
+  let root_attrs = popup_state_attrs(attrs, "hover-card", open)
+    .data_set("open-delay", "\{open_delay}")
+    .data_set("close-delay", "\{close_delay}")
+    .data_set("hoverable", ui_bool(hoverable))
+  if disabled {
+    ignore(root_attrs.data_set("disabled", "").aria_disabled("true"))
+  }
+  let link_attrs = trigger_attrs
+  let popup_attrs = content_attrs
+  @html.div(
+    style=ui_styles([UiBoxSizing, HoverCardRootStyle], style),
+    id=root_id,
+    attrs=root_attrs,
+    [
+      hover_card_trigger(
+        content_id=id,
+        href~,
+        open~,
+        disabled~,
+        open_delay~,
+        close_delay~,
+        variant=trigger_variant,
+        size=trigger_size,
+        target~,
+        rel?,
+        download?,
+        escape~,
+        on_click?=on_trigger_click,
+        id=trigger_id,
+        attrs?=link_attrs,
+        style=trigger_style,
+        trigger,
+      ),
+      hover_card_content(
+        id~,
+        trigger_id~,
+        open~,
+        side~,
+        align~,
+        side_offset~,
+        align_offset~,
+        aria_labelledby?,
+        aria_describedby?,
+        attrs?=popup_attrs,
+        style=content_style,
+        content,
+      ),
+    ],
+  )
+}
+
+///|
+/// Build a black-box hover card with Rabbita-owned incremental state.
+///
+/// Pointer hover, keyboard focus, configurable opening/closing delays,
+/// hoverable content, Escape, outside press, native light-dismiss, and floating
+/// positioning are handled internally. All Vega styling is inline.
+#cfg(target="js")
+pub fn[T : @html.IsChildren, C : @html.IsChildren] hover_card(
+  id~ : String,
+  href? : String = "#",
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  open_delay? : Int = 600,
+  close_delay? : Int = 300,
+  hoverable? : Bool = true,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  trigger_variant? : ButtonVariant = Link,
+  trigger_size? : ButtonSize = Default,
+  aria_labelledby? : String,
+  aria_describedby? : String,
+  on_open_change? : @cmd.Emit[Bool],
+  on_trigger_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  trigger : T,
+  content : C,
+) -> @rabbita.Val[@html.Html] {
+  let actual_open_delay = hover_card_delay(open_delay)
+  let actual_close_delay = hover_card_delay(close_delay)
+  let initial_open = default_open && !disabled
+  let initial_model : HoverCardModel = {
+    open: initial_open,
+    trigger_hovered: false,
+    trigger_focused: false,
+    content_hovered: false,
+    content_focused: false,
+    generation: 0,
+  }
+  let (model, _) = @rabbita.create_state_with_init(
+    init=emit => {
+      let sync = emit.map(value => HoverCardNativeChanged(value))
+      (
+        initial_model,
+        @cmd.batch([
+          floating_bind_sync_cmd(id, sync),
+          hover_card_bind_events_cmd(id, emit),
+          if initial_open {
+            floating_set_open_cmd(id, true)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(emit, msg, current) => {
+      hover_card_update(id, on_open_change, emit, msg, current)
+    },
+  )
+  model.view(model => {
+    render_hover_card(
+      id,
+      href,
+      target,
+      rel,
+      download,
+      escape,
+      model.open,
+      disabled,
+      actual_open_delay,
+      actual_close_delay,
+      hoverable,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      trigger_variant,
+      trigger_size,
+      aria_labelledby,
+      aria_describedby,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      on_trigger_click,
+      trigger,
+      content,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: retain the same API and render the normalized initial
+/// state as a constant incremental value.
+#cfg(not(target="js"))
+pub fn[T : @html.IsChildren, C : @html.IsChildren] hover_card(
+  id~ : String,
+  href? : String = "#",
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  open_delay? : Int = 600,
+  close_delay? : Int = 300,
+  hoverable? : Bool = true,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  trigger_variant? : ButtonVariant = Link,
+  trigger_size? : ButtonSize = Default,
+  aria_labelledby? : String,
+  aria_describedby? : String,
+  on_open_change? : @cmd.Emit[Bool],
+  on_trigger_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  trigger : T,
+  content : C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_open_change)
+  @rabbita.Val::constant(
+    render_hover_card(
+      id,
+      href,
+      target,
+      rel,
+      download,
+      escape,
+      default_open && !disabled,
+      disabled,
+      hover_card_delay(open_delay),
+      hover_card_delay(close_delay),
+      hoverable,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      trigger_variant,
+      trigger_size,
+      aria_labelledby,
+      aria_describedby,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      on_trigger_click,
+      trigger,
+      content,
+    ),
+  )
+}

--- a/rui/hover_card_state_wbtest.mbt
+++ b/rui/hover_card_state_wbtest.mbt
@@ -1,0 +1,108 @@
+///|
+#cfg(target="js")
+fn hover_card_test_model(open : Bool) -> HoverCardModel {
+  {
+    open,
+    trigger_hovered: false,
+    trigger_focused: false,
+    content_hovered: false,
+    content_focused: false,
+    generation: 0,
+  }
+}
+
+///|
+#cfg(target="js")
+fn hover_card_test_update(
+  current : HoverCardModel,
+  message : HoverCardMsg,
+) -> HoverCardModel {
+  let (next, _) = hover_card_update(
+    "test-hover-card",
+    None,
+    @cmd.Emit(_ => @cmd.none),
+    message,
+    current,
+  )
+  next
+}
+
+///|
+#cfg(target="js")
+test "hover card delayed work is invalidated by the next interaction" {
+  let waiting = hover_card_test_update(
+    hover_card_test_model(false),
+    HoverCardDomEvent(0, 600),
+  )
+  let open_generation = waiting.generation
+  let left = hover_card_test_update(waiting, HoverCardDomEvent(1, 0))
+  let stale_open = hover_card_test_update(
+    left,
+    HoverCardOpenAfter(open_generation),
+  )
+  assert_true(!stale_open.open)
+
+  let hovering_trigger : HoverCardModel = {
+    ..hover_card_test_model(true),
+    trigger_hovered: true,
+  }
+  let waiting_close = hover_card_test_update(
+    hovering_trigger,
+    HoverCardDomEvent(1, 300),
+  )
+  let close_generation = waiting_close.generation
+  let hovering_content = hover_card_test_update(
+    waiting_close,
+    HoverCardDomEvent(4, 0),
+  )
+  let stale_close = hover_card_test_update(
+    hovering_content,
+    HoverCardCloseAfter(close_generation),
+  )
+  assert_true(stale_close.open)
+  assert_true(stale_close.content_hovered)
+}
+
+///|
+#cfg(target="js")
+test "hover card focus sources and native dismissal remain synchronized" {
+  let trigger_focused = hover_card_test_update(
+    hover_card_test_model(false),
+    HoverCardDomEvent(2, 0),
+  )
+  assert_true(trigger_focused.open)
+  let content_focused = hover_card_test_update(
+    trigger_focused,
+    HoverCardDomEvent(6, 0),
+  )
+  let trigger_blurred = hover_card_test_update(
+    content_focused,
+    HoverCardDomEvent(3, 0),
+  )
+  assert_true(trigger_blurred.open)
+  assert_true(trigger_blurred.content_focused)
+  let content_blurred = hover_card_test_update(
+    trigger_blurred,
+    HoverCardDomEvent(7, 0),
+  )
+  assert_true(!content_blurred.open)
+
+  let active : HoverCardModel = {
+    open: true,
+    trigger_hovered: true,
+    trigger_focused: true,
+    content_hovered: true,
+    content_focused: true,
+    generation: 9,
+  }
+  let native_closed = hover_card_test_update(
+    active,
+    HoverCardNativeChanged(false),
+  )
+  assert_true(!native_closed.open)
+  assert_true(!native_closed.trigger_hovered)
+  assert_true(!native_closed.trigger_focused)
+  assert_true(!native_closed.content_hovered)
+  assert_true(!native_closed.content_focused)
+  assert_eq(native_closed.generation, 10)
+}

--- a/rui/hover_card_test.mbt
+++ b/rui/hover_card_test.mbt
@@ -1,0 +1,204 @@
+///|
+#cfg(target="js")
+extern "js" fn install_hover_card_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_incremental_hover_card(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_hover_card_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_incremental_hover_card(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+test "hover card trigger is a native link" {
+  let html = render(
+    @rui.hover_card_trigger(
+      content_id="profile-card",
+      href="/people/ada",
+      open=true,
+      open_delay=125,
+      close_delay=45,
+      variant=Link,
+      size=Sm,
+      rel="author",
+      style=["color:rebeccapurple"],
+      "Ada Lovelace",
+    ),
+  )
+  assert_contains(html, "<a")
+  assert_contains(html, "href=\"/people/ada\"")
+  assert_contains(html, "rel=\"author\"")
+  assert_contains(html, "data-slot=\"hover-card-trigger\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-popup-open=\"\"")
+  assert_contains(html, "data-delay=\"125\"")
+  assert_contains(html, "data-close-delay=\"45\"")
+  assert_contains(html, "data-variant=\"link\"")
+  assert_contains(html, "data-size=\"sm\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "aria-controls=\"profile-card\"")
+  assert_contains(html, "text-decoration-line:underline")
+  assert_contains(html, "color:rebeccapurple")
+  assert_contains(html, ">Ada Lovelace</a>")
+}
+
+///|
+test "hover card content exposes native light-dismiss and Vega surface" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render(
+    @rui.hover_card_content(
+      id="profile-card",
+      trigger_id="profile-card-trigger",
+      open=true,
+      side=Right,
+      align=Start,
+      side_offset=9,
+      align_offset=3,
+      aria_labelledby="profile-title",
+      aria_describedby="profile-summary",
+      attrs~,
+      style=["width:20rem", "background:rebeccapurple"],
+      @html.div("Profile preview"),
+    ),
+  )
+  assert_contains(html, "id=\"profile-card\"")
+  assert_contains(html, "popover=\"auto\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "data-initial-focus=\"false\"")
+  assert_contains(html, "data-restore-focus=\"false\"")
+  assert_contains(html, "data-slot=\"hover-card-content\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-side=\"right\"")
+  assert_contains(html, "data-align=\"start\"")
+  assert_contains(html, "data-side-offset=\"9\"")
+  assert_contains(html, "data-align-offset=\"3\"")
+  assert_contains(html, "aria-labelledby=\"profile-title\"")
+  assert_contains(html, "aria-describedby=\"profile-summary\"")
+  assert_contains(html, "width:16rem")
+  assert_contains(html, "border:1px solid var(--rui-border")
+  assert_contains(html, "padding:1rem")
+  assert_contains(html, "box-shadow:0 4px 6px -1px")
+  assert_contains(html, "width:20rem;background:rebeccapurple")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-state")
+}
+
+///|
+test "closed hover card remains hidden without event binding" {
+  let html = render(
+    @rui.hover_card_content(
+      id="closed-profile-card",
+      trigger_id="closed-profile-card-trigger",
+      open=false,
+      "Hidden profile preview",
+    ),
+  )
+  assert_contains(html, "data-state=\"closed\"")
+  assert_contains(html, "visibility:hidden")
+  assert_contains(html, "opacity:0")
+  assert_contains(html, "pointer-events:none")
+}
+
+///|
+test "hover card owns incremental open delay and positioning state" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render_incremental_hover_card(() => {
+    @rui.hover_card(
+      id="next-profile",
+      href="/nextjs",
+      default_open=true,
+      open_delay=180,
+      close_delay=70,
+      hoverable=false,
+      side=Top,
+      align=End,
+      side_offset=8,
+      align_offset=2,
+      aria_labelledby="next-title",
+      aria_describedby="next-summary",
+      attrs~,
+      style=["--hover-card-test:1"],
+      trigger_style=["color:rebeccapurple"],
+      content_style=["width:18rem"],
+      "@nextjs",
+      @html.div([
+        @html.strong(id="next-title", "Next.js"),
+        @html.p(id="next-summary", "The React Framework for the Web"),
+      ]),
+    )
+  })
+  assert_contains(html, "id=\"next-profile-root\"")
+  assert_contains(html, "id=\"next-profile-trigger\"")
+  assert_contains(html, "id=\"next-profile\"")
+  assert_contains(html, "href=\"/nextjs\"")
+  assert_contains(html, "data-slot=\"hover-card\"")
+  assert_contains(html, "data-slot=\"hover-card-trigger\"")
+  assert_contains(html, "data-slot=\"hover-card-content\"")
+  assert_contains(html, "data-open-delay=\"180\"")
+  assert_contains(html, "data-delay=\"180\"")
+  assert_contains(html, "data-close-delay=\"70\"")
+  assert_contains(html, "data-hoverable=\"false\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "aria-controls=\"next-profile\"")
+  assert_contains(html, "aria-labelledby=\"next-title\"")
+  assert_contains(html, "aria-describedby=\"next-summary\"")
+  assert_contains(html, "data-side=\"top\"")
+  assert_contains(html, "data-align=\"end\"")
+  assert_contains(html, "data-side-offset=\"8\"")
+  assert_contains(html, "data-align-offset=\"2\"")
+  assert_contains(html, "popover=\"auto\"")
+  assert_contains(html, "--hover-card-test:1")
+  assert_contains(html, "color:rebeccapurple")
+  assert_contains(html, "width:18rem")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-state")
+}
+
+///|
+test "disabled hover card normalizes its initial state and delays" {
+  let html = render_incremental_hover_card(() => {
+    @rui.hover_card(
+      id="disabled-profile",
+      href="/unavailable",
+      default_open=true,
+      disabled=true,
+      open_delay=-1,
+      close_delay=-10,
+      "Unavailable profile",
+      "Cannot preview this profile",
+    )
+  })
+  assert_contains(html, "data-disabled=\"\"")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "aria-expanded=\"false\"")
+  assert_contains(html, "data-open-delay=\"0\"")
+  assert_contains(html, "data-close-delay=\"0\"")
+  assert_contains(html, "data-state=\"closed\"")
+  assert_not_contains(html, "data-popup-open")
+}

--- a/rui/icon_internal.mbt
+++ b/rui/icon_internal.mbt
@@ -1,0 +1,78 @@
+///|
+/// Internal Lucide-compatible stroke icon used by controls that must not rely
+/// on font glyph metrics. The surrounding span owns accessibility hiding and
+/// a stable one-rem layout box; callers provide the icon's semantic label on
+/// the interactive control itself.
+fn ui_stroke_icon(path : String) -> @html.Html {
+  @html.span(
+    style=[
+      UiBoxSizing,
+      "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;pointer-events:none",
+    ],
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(
+      width=16,
+      height=16,
+      view_box="0 0 24 24",
+      style=["display:block;width:100%;height:100%"],
+      [
+        @svg.path(
+          d=path,
+          fill="none",
+          stroke="currentColor",
+          stroke_width=2,
+          attrs=@svg.Attrs::build()
+            .stroke_linecap("round")
+            .stroke_linejoin("round"),
+        ),
+      ],
+    ),
+  )
+}
+
+///|
+fn ui_check_icon() -> @html.Html {
+  ui_stroke_icon("M20 6 9 17l-5-5")
+}
+
+///|
+fn ui_chevron_right_icon() -> @html.Html {
+  ui_stroke_icon("m9 18 6-6-6-6")
+}
+
+///|
+fn ui_chevron_left_icon() -> @html.Html {
+  ui_stroke_icon("m15 18-6-6 6-6")
+}
+
+///|
+fn ui_x_icon() -> @html.Html {
+  ui_stroke_icon("M18 6 6 18M6 6l12 12")
+}
+
+///|
+fn ui_chevron_down_icon() -> @html.Html {
+  ui_stroke_icon("m6 9 6 6 6-6")
+}
+
+///|
+fn ui_chevron_up_icon() -> @html.Html {
+  ui_stroke_icon("m18 15-6-6-6 6")
+}
+
+///|
+fn ui_minus_icon() -> @html.Html {
+  ui_stroke_icon("M5 12h14")
+}
+
+///|
+fn ui_search_icon() -> @html.Html {
+  ui_stroke_icon("m21 21-4.3-4.3M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z")
+}
+
+///|
+fn ui_calendar_icon() -> @html.Html {
+  ui_stroke_icon(
+    "M8 2v4M16 2v4M3 10h18M5 4h14a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z",
+  )
+}

--- a/rui/incremental_controls_test.mbt
+++ b/rui/incremental_controls_test.mbt
@@ -1,0 +1,41 @@
+///|
+test "checkbox owns checked and mixed state through incremental API" {
+  let html = render_incremental(() => {
+    @rui.checkbox(default_indeterminate=true, aria_label="Select all")
+  })
+  assert_contains(html, "data-slot=\"checkbox\"")
+  assert_contains(html, "aria-checked=\"mixed\"")
+  assert_contains(html, "data-state=\"indeterminate\"")
+}
+
+///|
+test "switch and toggle expose black-box initial state" {
+  let switch_html = render_incremental(() => {
+    @rui.switch(default_checked=true, aria_label="Notifications")
+  })
+  assert_contains(switch_html, "role=\"switch\"")
+  assert_contains(switch_html, "aria-checked=\"true\"")
+
+  let toggle_html = render_incremental(() => {
+    @rui.toggle(default_pressed=true, "Bold")
+  })
+  assert_contains(toggle_html, "aria-pressed=\"true\"")
+  assert_contains(toggle_html, "data-state=\"on\"")
+}
+
+///|
+test "radio group owns one shared selected value" {
+  let html = render_incremental(() => {
+    @rui.radio_group(default_value="pro", name="plan", aria_label="Plan", scope => {
+      [
+        @rui.radio_group_item(scope~, value="free", aria_label="Free"),
+        @rui.radio_group_item(scope~, value="pro", aria_label="Pro"),
+      ]
+    })
+  })
+  assert_contains(html, "role=\"radiogroup\"")
+  assert_contains(html, "data-value=\"pro\"")
+  assert_contains(html, "name=\"plan\"")
+  assert_contains(html, "value=\"pro\"")
+  assert_contains(html, "data-checked=\"\"")
+}

--- a/rui/input.mbt
+++ b/rui/input.mbt
@@ -1,0 +1,106 @@
+///|
+const InputBaseStyle : String = "display:flex;width:100%;height:2.25rem;min-width:0;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));padding:0.25rem 0.625rem;color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));font-size:1rem;line-height:1.5rem;outline-offset:2px"
+
+///|
+const InputInvalidStyle : String = "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+fn input_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    InputInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render a controlled native input using the shadcn/ui Vega field recipe.
+///
+/// `on_input` is the immediate value-change channel; `on_change` follows the
+/// browser's native change event. User styles are appended last.
+pub fn input(
+  input_type? : @html.InputType = @html.Text,
+  name? : String,
+  value? : String,
+  checked? : Bool,
+  read_only? : Bool,
+  multiple? : Bool,
+  accept? : String,
+  placeholder? : String,
+  auto_complete? : @html.AutoComplete,
+  max? : Int,
+  min? : Int,
+  step? : Int,
+  maxlength? : Int,
+  minlength? : Int,
+  pattern? : String,
+  size? : Int,
+  width? : Int,
+  height? : Int,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  disabled? : Bool = false,
+  required? : Bool,
+  autofocus? : Bool,
+  list? : String,
+  inputmode? : String,
+  invalid? : Bool = false,
+  on_change? : @cmd.Emit[String],
+  on_input? : @cmd.Emit[String],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "input",
+) -> @html.Html {
+  let attrs = ui_attrs(attrs).data_set("slot", slot)
+  if disabled {
+    ignore(attrs.disabled(true).data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  @html.input(
+    input_type~,
+    name?,
+    value?,
+    checked?,
+    read_only?,
+    multiple?,
+    accept?,
+    placeholder?,
+    auto_complete?,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        InputBaseStyle,
+        input_invalid_style(invalid),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    max?,
+    min?,
+    step?,
+    maxlength?,
+    minlength?,
+    pattern?,
+    size?,
+    width?,
+    height?,
+    id?,
+    class?,
+    title?,
+    hidden?,
+    required?,
+    autofocus?,
+    list?,
+    inputmode?,
+    on_change?,
+    on_input?,
+    attrs~,
+  )
+}

--- a/rui/input_group.mbt
+++ b/rui/input_group.mbt
@@ -1,0 +1,319 @@
+///|
+pub(all) enum InputGroupAddonAlign {
+  InputInlineStart
+  InputInlineEnd
+  InputBlockStart
+  InputBlockEnd
+} derive(Debug, Eq)
+
+///|
+pub(all) enum InputGroupButtonSize {
+  InputButtonXs
+  InputButtonSm
+  InputButtonIconXs
+  InputButtonIconSm
+} derive(Debug, Eq)
+
+///|
+fn input_group_align_value(align : InputGroupAddonAlign) -> String {
+  match align {
+    InputInlineStart => "inline-start"
+    InputInlineEnd => "inline-end"
+    InputBlockStart => "block-start"
+    InputBlockEnd => "block-end"
+  }
+}
+
+///|
+fn input_group_align_style(align : InputGroupAddonAlign) -> String {
+  match align {
+    InputInlineStart => "order:-1;padding-inline-start:0.5rem"
+    InputInlineEnd => "order:1;padding-inline-end:0.5rem"
+    InputBlockStart =>
+      "order:-1;width:100%;justify-content:flex-start;padding:0.5rem 0.625rem 0"
+    InputBlockEnd =>
+      "order:1;width:100%;justify-content:flex-start;padding:0 0.625rem 0.5rem"
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] input_group(
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let group_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "input-group")
+  if disabled {
+    ignore(group_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(group_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=group_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        "position:relative;display:flex;width:100%;height:2rem;min-width:0;min-height:2rem;align-items:center;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 0 #0000;border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:var(--rui-radius,0.625rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 0 #0000));outline:none",
+        if invalid {
+          InputInvalidStyle
+        } else {
+          ""
+        },
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] input_group_addon(
+  align? : InputGroupAddonAlign = InputInlineStart,
+  for_? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let addon_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "input-group-addon")
+    .data_set("align", input_group_align_value(align))
+  let addon_style = ui_styles(
+    [
+      "display:flex;height:auto;align-items:center;justify-content:center;gap:0.5rem;padding-block:0.375rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;font-weight:500;user-select:none;cursor:text",
+      input_group_align_style(align),
+    ],
+    style,
+  )
+  if for_ is Some(for_) {
+    @html.label(
+      for_~,
+      id?,
+      class?,
+      title?,
+      attrs=addon_attrs,
+      style=addon_style,
+      children,
+    )
+  } else {
+    @html.div(
+      id?,
+      class?,
+      title?,
+      attrs=addon_attrs,
+      style=addon_style,
+      children,
+    )
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] input_group_text(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "input-group-text"),
+    style=ui_styles(
+      [
+        "display:flex;align-items:center;gap:0.5rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+/// Adapt a custom form control to the Input Group surface.
+///
+/// The callback receives the complete public control-slot attributes and the
+/// shared nested-control style. Add only control-specific behavior through
+/// `style`; callers never need to know the Input Group's internal data slots.
+pub fn input_group_control(
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render : (@html.Attrs, Array[String]) -> @html.Html,
+) -> @html.Html {
+  let control_attrs = ui_attrs(attrs)
+    .data_set("slot", "input-group-control")
+    .data_set("input-group-control", "")
+  render(
+    control_attrs,
+    ui_styles(
+      [
+        "display:flex;width:100%;min-width:0;min-height:2rem;flex:1;border:0;border-radius:0;background:transparent;padding:0.625rem;color:inherit;font:inherit;box-shadow:none;outline:none",
+      ],
+      style,
+    ),
+  )
+}
+
+///|
+fn input_group_button_size(size : InputGroupButtonSize) -> (ButtonSize, String) {
+  match size {
+    InputButtonXs => (Xs, "xs")
+    InputButtonSm => (Sm, "sm")
+    InputButtonIconXs => (IconXs, "icon-xs")
+    InputButtonIconSm => (IconSm, "icon-sm")
+  }
+}
+
+///|
+fn input_group_button_size_style(size : InputGroupButtonSize) -> String {
+  match size {
+    InputButtonXs | InputButtonIconXs =>
+      "--rui-control-radius:calc(var(--rui-radius,0.625rem) - 0.1875rem)"
+    InputButtonSm | InputButtonIconSm => ""
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] input_group_button(
+  size? : InputGroupButtonSize = InputButtonXs,
+  variant? : ButtonVariant = Ghost,
+  disabled? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let (button_size, size_value) = input_group_button_size(size)
+  button(
+    variant~,
+    size=button_size,
+    disabled~,
+    slot="input-group-button",
+    on_click?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "input-group-button")
+      .data_set("size", size_value),
+    style=ui_styles(
+      ["--rui-button-base-shadow:none", input_group_button_size_style(size)],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn input_group_input(
+  input_type? : @html.InputType = @html.Text,
+  name? : String,
+  value? : String,
+  placeholder? : String,
+  read_only? : Bool,
+  disabled? : Bool = false,
+  required? : Bool,
+  autofocus? : Bool,
+  invalid? : Bool = false,
+  on_change? : @cmd.Emit[String],
+  on_input? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  input(
+    input_type~,
+    name?,
+    value?,
+    placeholder?,
+    read_only?,
+    disabled~,
+    required?,
+    autofocus?,
+    invalid~,
+    on_change?,
+    on_input?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("input-group-control", ""),
+    slot="input-group-control",
+    style=ui_styles(
+      [
+        "height:100%;min-height:0;flex:1;border:0;border-radius:0;background:transparent;box-shadow:none;outline:none",
+      ],
+      style,
+    ),
+  )
+}
+
+///|
+pub fn input_group_textarea(
+  name? : String,
+  value? : String,
+  rows? : Int,
+  cols? : Int,
+  placeholder? : String,
+  read_only? : Bool,
+  disabled? : Bool = false,
+  required? : Bool,
+  autofocus? : Bool,
+  invalid? : Bool = false,
+  on_change? : @cmd.Emit[String],
+  on_input? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  textarea(
+    name?,
+    value?,
+    rows?,
+    cols?,
+    placeholder?,
+    read_only?,
+    disabled~,
+    required?,
+    autofocus?,
+    invalid~,
+    on_change?,
+    on_input?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("input-group-control", ""),
+    slot="input-group-control",
+    style=ui_styles(
+      [
+        "min-height:5rem;flex:1;resize:none;border:0;border-radius:0;background:transparent;padding-block:0.5rem;box-shadow:none;outline:none",
+      ],
+      style,
+    ),
+  )
+}

--- a/rui/input_group_test.mbt
+++ b/rui/input_group_test.mbt
@@ -1,0 +1,213 @@
+///|
+#warnings("-alert_unstable")
+fn render_input_group_test(html : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+}
+
+///|
+test "input group root owns one compact unshadowed control surface" {
+  let html = render_input_group_test(
+    @rui.input_group(id="workspace-group", @html.nothing),
+  )
+  assert_true(html.contains("data-slot=\"input-group\""))
+  assert_true(html.contains("role=\"group\""))
+  assert_true(html.contains("height:2rem"))
+  assert_true(html.contains("min-height:2rem"))
+  assert_true(html.contains("border-radius:var(--rui-radius,0.625rem)"))
+  assert_true(html.contains("--rui-control-base-shadow:0 0 #0000"))
+  assert_true(
+    html.contains(
+      "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 0 #0000))",
+    ),
+  )
+  assert_true(!html.contains("0 1px 2px rgb(0 0 0 / 0.05)"))
+}
+
+///|
+test "input group addon is a label only when it targets a control" {
+  let label_html = render_input_group_test(
+    @rui.input_group_addon(for_="workspace", "https://"),
+  )
+  assert_true(label_html.contains("<label"))
+  assert_true(label_html.contains("for=\"workspace\""))
+  assert_true(label_html.contains("data-slot=\"input-group-addon\""))
+
+  let action_html = render_input_group_test(
+    @rui.input_group_addon(
+      align=@rui.InputInlineEnd,
+      @rui.input_group_button("Copy"),
+    ),
+  )
+  assert_true(action_html.contains("<div"))
+  assert_true(action_html.contains("data-slot=\"input-group-addon\""))
+  assert_true(action_html.contains("<button"))
+  assert_true(!action_html.contains("<label"))
+}
+
+///|
+test "input group addons expose all four alignment contracts" {
+  let html = render_input_group_test(
+    @html.div([
+      @rui.input_group_addon(align=@rui.InputInlineStart, "Inline start"),
+      @rui.input_group_addon(align=@rui.InputInlineEnd, "Inline end"),
+      @rui.input_group_addon(align=@rui.InputBlockStart, "Block start"),
+      @rui.input_group_addon(align=@rui.InputBlockEnd, "Block end"),
+    ]),
+  )
+  assert_true(html.contains("data-align=\"inline-start\""))
+  assert_true(html.contains("data-align=\"inline-end\""))
+  assert_true(html.contains("data-align=\"block-start\""))
+  assert_true(html.contains("data-align=\"block-end\""))
+  assert_true(html.contains("order:-1;padding-inline-start:0.5rem"))
+  assert_true(html.contains("order:1;padding-inline-end:0.5rem"))
+  assert_true(
+    html.contains(
+      "order:-1;width:100%;justify-content:flex-start;padding:0.5rem 0.625rem 0",
+    ),
+  )
+  assert_true(
+    html.contains(
+      "order:1;width:100%;justify-content:flex-start;padding:0 0.625rem 0.5rem",
+    ),
+  )
+}
+
+///|
+test "input group buttons map every public size to the compact button recipe" {
+  let xs = render_input_group_test(
+    @rui.input_group_button(size=@rui.InputButtonXs, "Extra small"),
+  )
+  let sm = render_input_group_test(
+    @rui.input_group_button(size=@rui.InputButtonSm, "Small"),
+  )
+  let icon_xs = render_input_group_test(
+    @rui.input_group_button(size=@rui.InputButtonIconXs, "X"),
+  )
+  let icon_sm = render_input_group_test(
+    @rui.input_group_button(size=@rui.InputButtonIconSm, "X"),
+  )
+  assert_true(xs.contains("data-slot=\"input-group-button\""))
+  assert_true(xs.contains("data-size=\"xs\""))
+  assert_true(sm.contains("data-size=\"sm\""))
+  assert_true(icon_xs.contains("data-size=\"icon-xs\""))
+  assert_true(icon_sm.contains("data-size=\"icon-sm\""))
+  assert_true(xs.contains("--rui-button-base-shadow:none"))
+  assert_true(
+    xs.contains(
+      "--rui-control-radius:calc(var(--rui-radius,0.625rem) - 0.1875rem)",
+    ),
+  )
+  assert_true(
+    icon_xs.contains(
+      "--rui-control-radius:calc(var(--rui-radius,0.625rem) - 0.1875rem)",
+    ),
+  )
+  assert_true(
+    !sm.contains(
+      "--rui-control-radius:calc(var(--rui-radius,0.625rem) - 0.1875rem)",
+    ),
+  )
+  assert_true(
+    !icon_sm.contains(
+      "--rui-control-radius:calc(var(--rui-radius,0.625rem) - 0.1875rem)",
+    ),
+  )
+}
+
+///|
+test "input group input clears nested chrome and fills the root height" {
+  let html = render_input_group_test(
+    @rui.input_group(@rui.input_group_input(id="workspace", value="rabbit-tea")),
+  )
+  assert_true(html.contains("data-slot=\"input-group-control\""))
+  assert_true(html.contains("data-input-group-control=\"\""))
+  assert_true(
+    html.contains(
+      "height:100%;min-height:0;flex:1;border:0;border-radius:0;background:transparent;box-shadow:none;outline:none",
+    ),
+  )
+  assert_true(!html.contains("border-radius:inherit"))
+}
+
+///|
+test "input group textarea uses the shared control slot and grows the surface" {
+  let html = render_input_group_test(
+    @rui.input_group(@rui.input_group_textarea(value="Notes", rows=4)),
+  )
+  assert_true(html.contains("data-slot=\"input-group-control\""))
+  assert_true(html.contains("data-input-group-control=\"\""))
+  assert_true(
+    html.contains(
+      "min-height:5rem;flex:1;resize:none;border:0;border-radius:0;background:transparent;padding-block:0.5rem;box-shadow:none;outline:none",
+    ),
+  )
+  assert_true(!html.contains("border-radius:inherit"))
+}
+
+///|
+test "input group custom control adapter owns its public slot and base chrome" {
+  let html = render_input_group_test(
+    @rui.input_group(
+      @rui.input_group_control(
+        style=["field-sizing:content;min-height:4rem;resize:none"],
+        (attrs, style) => {
+          @html.textarea(
+            id="custom-control",
+            rows=1,
+            attrs~,
+            style~,
+            ([] : Array[@html.Html]),
+          )
+        },
+      ),
+    ),
+  )
+  assert_true(html.contains("data-slot=\"input-group-control\""))
+  assert_true(html.contains("data-input-group-control=\"\""))
+  assert_true(
+    html.contains(
+      "display:flex;width:100%;min-width:0;min-height:2rem;flex:1;border:0;border-radius:0;background:transparent;padding:0.625rem;color:inherit;font:inherit;box-shadow:none;outline:none;field-sizing:content;min-height:4rem;resize:none",
+    ),
+  )
+}
+
+///|
+test "theme supplies input group layout focus invalid and nested-action rules" {
+  let html = render_input_group_test(@rui.theme(@html.nothing))
+  assert_true(
+    html.contains(
+      "[data-slot=\"input-group\"]:has(> [data-slot=\"input-group-control\"]:is(textarea))",
+    ),
+  )
+  assert_true(
+    html.contains(
+      "[data-slot=\"input-group\"]:has(> [data-slot=\"input-group-addon\"][data-align=\"block-start\"])",
+    ),
+  )
+  assert_true(html.contains("height:auto;\n    flex-direction:column"))
+  assert_true(
+    html.contains(
+      "[data-slot=\"input-group\"]:has([data-slot][aria-invalid=\"true\"])",
+    ),
+  )
+  assert_true(
+    html.contains(
+      "[data-slot=\"input-group\"]:has([data-slot=\"input-group-control\"]:focus-visible)",
+    ),
+  )
+  assert_true(
+    html.contains(
+      "[data-slot=\"input-group-addon\"][data-align=\"inline-start\"]:has(> button)",
+    ),
+  )
+  assert_true(
+    html.contains(
+      "[data-slot=\"input-group-addon\"] > button:is([data-size=\"xs\"],[data-size=\"icon-xs\"])",
+    ),
+  )
+  assert_true(
+    html.contains(
+      ":where([data-slot=\"input-group-addon\"],[data-slot=\"input-group-text\"]) :where(svg,[aria-hidden=\"true\"])",
+    ),
+  )
+}

--- a/rui/input_otp.mbt
+++ b/rui/input_otp.mbt
@@ -1,0 +1,358 @@
+///|
+priv struct InputOtpModel {
+  value : String
+} derive(Eq)
+
+///|
+priv enum InputOtpMsg {
+  SetOtpValue(String)
+}
+
+///|
+/// Opaque render scope owned by `input_otp`.
+struct InputOtpScope {
+  model : InputOtpModel
+  max_length : Int
+  invalid : Bool
+  disabled : Bool
+  input_id : String
+  emit : @cmd.Emit[InputOtpMsg]
+}
+
+///|
+fn otp_normalize(value : String, max_length : Int) -> String {
+  let mut result = ""
+  let mut count = 0
+  for character in value {
+    if count < max_length {
+      result = result + "\{character}"
+      count += 1
+    }
+  }
+  result
+}
+
+///|
+fn otp_chars(value : String) -> Array[Char] {
+  let chars : Array[Char] = []
+  for character in value {
+    chars.push(character)
+  }
+  chars
+}
+
+///|
+fn input_otp_control_attrs(
+  scope : InputOtpScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  let control_attrs = ui_attrs(attrs).data_set("slot", "input-otp-control")
+  if scope.disabled {
+    ignore(control_attrs.disabled(true))
+  }
+  control_attrs
+}
+
+///|
+pub fn[C : @html.IsChildren] input_otp_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "input-otp-group"),
+    style=ui_styles(["display:flex;align-items:center"], style),
+    children,
+  )
+}
+
+///|
+pub fn input_otp_slot(
+  scope~ : InputOtpScope,
+  index~ : Int,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let chars = otp_chars(scope.model.value)
+  let char_count = chars.length()
+  let active_index = if char_count >= scope.max_length {
+    scope.max_length - 1
+  } else {
+    char_count
+  }
+  let current = index == active_index
+  let value = if index >= 0 && index < char_count {
+    "\{chars[index]}"
+  } else {
+    ""
+  }
+  let slot_attrs = ui_attrs(attrs)
+    .aria_hidden("true")
+    .data_set("slot", "input-otp-slot")
+    .data_set("index", "\{index}")
+    .data_set("active", ui_bool(current))
+    .data_set("current", ui_bool(current))
+  if scope.invalid {
+    ignore(slot_attrs.aria_invalid("true"))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=slot_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiTransition,
+        "position:relative;display:flex;width:2.25rem;height:2.25rem;align-items:center;justify-content:center;border-block:1px solid var(--rui-otp-border,var(--rui-input,oklch(0.922 0 0)));border-inline-end:1px solid var(--rui-otp-border,var(--rui-input,oklch(0.922 0 0)));background:var(--rui-input-background,transparent);font-size:0.875rem;line-height:1.25rem;box-shadow:var(--rui-otp-shadow,0 1px 2px rgb(0 0 0 / 0.05));outline:none",
+        if scope.invalid {
+          "--rui-otp-border:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)))"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    [
+      @html.span(style=["display:contents"], value),
+      if current && index >= char_count {
+        @html.span(
+          attrs=@html.Attrs::build()
+            .aria_hidden("true")
+            .data_set("slot", "input-otp-caret"),
+          style=[
+            "pointer-events:none;position:absolute;inset:0;display:flex;align-items:center;justify-content:center",
+          ],
+          @html.span(
+            style=[
+              "display:block;width:1px;height:1rem;background:var(--rui-foreground,oklch(0.145 0 0));animation:rui-caret-blink 1s ease-out infinite",
+            ],
+            "",
+          ),
+        )
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+pub fn input_otp_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .role("separator")
+      .data_set("slot", "input-otp-separator"),
+    style=ui_styles(
+      [
+        "display:flex;width:1.5rem;height:1rem;flex:none;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0))",
+      ],
+      style,
+    ),
+    ui_minus_icon(),
+  )
+}
+
+///|
+fn input_otp_default_view(
+  scope : InputOtpScope,
+  separator_after : Int,
+) -> @html.Html {
+  let split = if separator_after > 0 && separator_after < scope.max_length {
+    separator_after
+  } else {
+    -1
+  }
+  if split < 0 {
+    let slots : Array[@html.Html] = []
+    for index in 0..<scope.max_length {
+      slots.push(input_otp_slot(scope~, index~))
+    }
+    return input_otp_group(slots)
+  }
+  let leading : Array[@html.Html] = []
+  let trailing : Array[@html.Html] = []
+  for index in 0..<split {
+    leading.push(input_otp_slot(scope~, index~))
+  }
+  for index in split..<scope.max_length {
+    trailing.push(input_otp_slot(scope~, index~))
+  }
+  @html.fragment([
+    input_otp_group(leading),
+    input_otp_separator(),
+    input_otp_group(trailing),
+  ])
+}
+
+///|
+fn render_input_otp(
+  scope : InputOtpScope,
+  separator_after : Int,
+  aria_label : String,
+  inputmode : String,
+  pattern : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  input_attrs : @html.Attrs?,
+  style : Array[String],
+  render : ((InputOtpScope) -> @html.Html)?,
+) -> @html.Html {
+  let content = if render is Some(render) {
+    render(scope)
+  } else {
+    input_otp_default_view(scope, separator_after)
+  }
+  @html.div(
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "input-otp"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "position:relative;display:inline-flex;width:fit-content;align-items:center;gap:0.5rem",
+        ui_disabled_visual_style(scope.disabled),
+      ],
+      style,
+    ),
+    [
+      @html.input(
+        input_type=@html.Text,
+        value=scope.model.value,
+        maxlength=scope.max_length,
+        inputmode~,
+        pattern?,
+        id=scope.input_id,
+        on_input=scope.emit.map(value => SetOtpValue(value)),
+        attrs=input_otp_control_attrs(scope, input_attrs)
+          .aria_label(aria_label)
+          .aria_invalid(ui_bool(scope.invalid)),
+        style=[
+          "box-sizing:border-box;position:absolute;inset:0;z-index:20;width:100%;height:100%;margin:0;border:0;background:transparent;padding:0;opacity:0.001;color:transparent;caret-color:transparent;cursor:text;appearance:none;-webkit-appearance:none",
+        ],
+      ),
+      content,
+    ],
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn input_otp(
+  id~ : String,
+  max_length? : Int = 6,
+  default_value? : String = "",
+  separator_after? : Int = -1,
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  aria_label? : String = "One-time password",
+  inputmode? : String = "numeric",
+  pattern? : String,
+  on_value_change? : @cmd.Emit[String],
+  on_complete? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  input_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render? : (InputOtpScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let initial_value = otp_normalize(default_value, max_length)
+  let (model, emit) = @rabbita.create_state({ value: initial_value }, update=fn(
+    _,
+    msg,
+    model,
+  ) {
+    match msg {
+      SetOtpValue(value) => {
+        let value = otp_normalize(value, max_length)
+        let commands : Array[@cmd.Cmd] = []
+        if on_value_change is Some(notify) {
+          commands.push(notify(value))
+        }
+        if value.char_length() == max_length &&
+          model.value.char_length() != max_length &&
+          on_complete is Some(complete) {
+          commands.push(complete(value))
+        }
+        ({ value, }, @cmd.batch(commands))
+      }
+    }
+  })
+  model.view(model => {
+    render_input_otp(
+      { model, max_length, invalid, disabled, input_id: id, emit },
+      separator_after,
+      aria_label,
+      inputmode,
+      pattern,
+      class,
+      title,
+      attrs,
+      input_attrs,
+      style,
+      render,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn input_otp(
+  id~ : String,
+  max_length? : Int = 6,
+  default_value? : String = "",
+  separator_after? : Int = -1,
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  aria_label? : String = "One-time password",
+  inputmode? : String = "numeric",
+  pattern? : String,
+  on_value_change? : @cmd.Emit[String],
+  on_complete? : @cmd.Emit[String],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  input_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render? : (InputOtpScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_change, on_complete))
+  let model = { value: otp_normalize(default_value, max_length) }
+  let emit = @cmd.Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_input_otp(
+      { model, max_length, invalid, disabled, input_id: id, emit },
+      separator_after,
+      aria_label,
+      inputmode,
+      pattern,
+      class,
+      title,
+      attrs,
+      input_attrs,
+      style,
+      render,
+    ),
+  )
+}

--- a/rui/input_otp_test.mbt
+++ b/rui/input_otp_test.mbt
@@ -1,0 +1,60 @@
+///|
+#cfg(target="js")
+extern "js" fn install_input_otp_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 }
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_input_otp_test(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  install_input_otp_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_input_otp_test(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn input_otp_assert_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected Input OTP HTML to contain `\{expected}`; got `\{actual}`")
+  }
+}
+
+///|
+test "input otp defaults to a numeric virtual keyboard" {
+  let html = render_input_otp_test(() => {
+    @rui.input_otp(id="numeric-otp", max_length=4)
+  })
+  input_otp_assert_contains(html, "inputmode=\"numeric\"")
+}
+
+///|
+test "input otp exposes native alphanumeric input constraints" {
+  let html = render_input_otp_test(() => {
+    @rui.input_otp(
+      id="alphanumeric-otp",
+      max_length=6,
+      default_value="A1B2",
+      inputmode="text",
+      pattern="[A-Za-z0-9]*",
+      input_attrs=@html.Attrs::build().inputmode("numeric"),
+    )
+  })
+  input_otp_assert_contains(html, "inputmode=\"text\"")
+  if html.contains("inputmode=\"numeric\"") {
+    fail("the public inputmode must replace a conflicting low-level attribute")
+  }
+  input_otp_assert_contains(html, "pattern=\"[A-Za-z0-9]*\"")
+  input_otp_assert_contains(html, "value=\"A1B2\"")
+  input_otp_assert_contains(html, ">A</span>")
+}

--- a/rui/interaction.mbt
+++ b/rui/interaction.mbt
@@ -1,0 +1,418 @@
+///|
+#cfg(target="js")
+priv struct DialogLayerBinding {
+  element : @dom.Element
+  dialog : @dom.HTMLDialogElement
+  request_close : Ref[() -> Unit]
+  return_focus : Ref[@dom.HTMLElement?]
+}
+
+///|
+#cfg(target="js")
+let dialog_layers : Map[String, DialogLayerBinding] = Map([])
+
+///|
+#cfg(target="js")
+let dialog_stack : Ref[Array[String]] = Ref([])
+
+///|
+#cfg(target="js")
+let dialog_bound_document : Ref[@dom.Document?] = Ref(None)
+
+///|
+#cfg(target="js")
+let dialog_outside_press_had_floating : Ref[Bool] = Ref(false)
+
+///|
+#cfg(target="js")
+fn dialog_update_stack(id : String, open : Bool) -> Unit {
+  let next : Array[String] = []
+  for current in dialog_stack.val {
+    if current != id {
+      next.push(current)
+    }
+  }
+  if open {
+    next.push(id)
+  }
+  dialog_stack.val = next
+}
+
+///|
+#cfg(target="js")
+fn dialog_live_layer(id : String) -> DialogLayerBinding? {
+  guard dialog_layers.get(id) is Some(layer) else { return None }
+  guard ui_element_by_id(id) is Some(element) else {
+    dialog_update_stack(id, false)
+    return None
+  }
+  if !element.get_is_connected() ||
+    !layer.element.is_same_node(element.as_node()) ||
+    !layer.dialog.open() {
+    dialog_update_stack(id, false)
+    return None
+  }
+  Some(layer)
+}
+
+///|
+#cfg(target="js")
+fn dialog_top_layer() -> DialogLayerBinding? {
+  let stack = dialog_stack.val
+  for index = stack.length() - 1; index >= 0; index = index - 1 {
+    let id = stack[index]
+    if dialog_live_layer(id) is Some(layer) {
+      return Some(layer)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn dialog_restore_focus(layer : DialogLayerBinding) -> Unit {
+  if layer.element.get_attribute("data-modal").unwrap_or("") != "false" ||
+    layer.element.get_attribute("data-restore-focus").unwrap_or("") == "false" {
+    return
+  }
+  let document = @dom.document()
+  if document.get_active_element() is Some(active) {
+    let active_is_body = if document.get_body() is Some(body) {
+      active.is_same_node(body.as_node())
+    } else {
+      false
+    }
+    if !active_is_body && !layer.element.contains(active.as_node()) {
+      return
+    }
+  }
+  let final_id = layer.element
+    .get_attribute("data-final-focus-id")
+    .unwrap_or("")
+  let target = if ui_element_by_id(final_id) is Some(element) &&
+    element.to_html_element() is Some(html) {
+    Some(html)
+  } else {
+    layer.return_focus.val
+  }
+  if target is Some(html) && html.get_is_connected() {
+    html.focus_with_options(prevent_scroll=true)
+  }
+}
+
+///|
+#cfg(target="js")
+fn dialog_bind_document_events() -> Unit {
+  let document = @dom.document()
+  if dialog_bound_document.val is Some(bound) &&
+    bound.to_node().is_same_node(document.to_node()) {
+    return
+  }
+  dialog_bound_document.val = Some(document)
+  document.add_event_listener_with_options(
+    "pointerdown",
+    _ => dialog_outside_press_had_floating.val = floating_top_layer() is Some(_),
+    capture=true,
+  )
+  document.add_event_listener("keydown", event => {
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    if keyboard.key() != "Escape" ||
+      event.get_default_prevented() ||
+      floating_top_layer() is Some(_) {
+      return
+    }
+    guard dialog_top_layer() is Some(layer) else { return }
+    if layer.element.get_attribute("data-close-on-escape").unwrap_or("") !=
+      "true" {
+      return
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    (layer.request_close.val)()
+  })
+  document.add_event_listener("click", event => {
+    if event.get_default_prevented() {
+      return
+    }
+    let had_floating = dialog_outside_press_had_floating.val
+    dialog_outside_press_had_floating.val = false
+    if had_floating || floating_top_layer() is Some(_) {
+      return
+    }
+    guard dialog_top_layer() is Some(layer) else { return }
+    if layer.element.get_attribute("data-modal").unwrap_or("") != "false" {
+      return
+    }
+    let selector = "[data-slot=\"dialog-content\"],[data-slot=\"sheet-content\"],[data-slot=\"drawer-content\"]"
+    if layer.element.query_selector(selector) is Some(content) &&
+      floating_event_inside(event, content) {
+      return
+    }
+    if layer.element.get_attribute("data-close-on-outside").unwrap_or("") ==
+      "true" {
+      (layer.request_close.val)()
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn bind_dialog_layer(id : String, request_close : () -> Unit) -> Unit {
+  guard ui_element_by_id(id) is Some(element) else { return }
+  guard element.to_html_dialog_element() is Some(dialog) else { return }
+  if dialog_layers.get(id) is Some(layer) &&
+    layer.element.is_same_node(element.as_node()) {
+    layer.request_close.val = request_close
+    return
+  }
+  let layer : DialogLayerBinding = {
+    element,
+    dialog,
+    request_close: Ref(request_close),
+    return_focus: Ref(None),
+  }
+  dialog_layers[id] = layer
+  dialog_bind_document_events()
+  dialog.add_event_listener("close", _ => {
+    dialog_update_stack(id, false)
+    if ui_has_window() {
+      @dom.window().queue_microtask(() => dialog_restore_focus(layer))
+    } else {
+      dialog_restore_focus(layer)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn should_close_dialog_outside() -> Bool {
+  let had_floating = dialog_outside_press_had_floating.val
+  dialog_outside_press_had_floating.val = false
+  !had_floating && floating_top_layer() is None
+}
+
+///|
+#cfg(target="js")
+fn ui_dialog_should_close_outside() -> Bool {
+  should_close_dialog_outside()
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_dialog_should_close_outside() -> Bool {
+  true
+}
+
+///|
+#cfg(target="js")
+fn mark_dialog_layer(id : String, open : Bool) -> Unit {
+  dialog_update_stack(id, open)
+  if !open {
+    return
+  }
+  guard dialog_layers.get(id) is Some(layer) else { return }
+  if @dom.document().get_active_element() is Some(active) &&
+    !layer.element.contains(active.as_node()) &&
+    active.to_html_element() is Some(html) {
+    layer.return_focus.val = Some(html)
+  }
+  if layer.element.get_attribute("data-modal").unwrap_or("") != "false" ||
+    layer.element.get_attribute("data-initial-focus").unwrap_or("") == "false" {
+    return
+  }
+  fn focus_initial() -> Unit {
+    if !layer.dialog.open() {
+      return
+    }
+    let requested_id = layer.element
+      .get_attribute("data-initial-focus-id")
+      .unwrap_or("")
+    let requested = ui_element_by_id(requested_id)
+    let selector = "button:not([disabled]),a[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex=\"-1\"])"
+    let target = if requested is Some(element) &&
+      layer.element.contains(element.as_node()) {
+      Some(element)
+    } else {
+      match layer.element.query_selector(selector) {
+        Some(element) => Some(element)
+        None => Some(layer.element)
+      }
+    }
+    if target is Some(element) {
+      ui_focus_element_without_scroll(element)
+    }
+  }
+
+  if ui_has_window() {
+    ignore(@dom.window().request_animation_frame(_ => focus_initial()))
+  } else {
+    focus_initial()
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_dialog_bind(id : String, request_close : @cmd.Cmd) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => bind_dialog_layer(id, () => scheduler.add(request_close)),
+      purpose="dialog-bind",
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_dialog_bind(id : String, request_close : @cmd.Cmd) -> @cmd.Cmd {
+  ignore((id, request_close))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_dialog_show(id : String, modal : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    ui_after_mount(
+      id,
+      () => {
+        if @dom.document().get_element_by_id(id).to_option() is Some(element) &&
+          element.to_html_element() is Some(html_element) &&
+          html_element.to_html_dialog_element() is Some(dialog) {
+          mark_dialog_layer(id, true)
+          if !dialog.open() {
+            if modal {
+              dialog.show_modal()
+            } else {
+              dialog.show()
+            }
+          }
+        }
+      },
+      purpose="dialog-show",
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_dialog_show(id : String, modal : Bool) -> @cmd.Cmd {
+  ignore((id, modal))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_dialog_close(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    if @dom.document().get_element_by_id(id).to_option() is Some(element) &&
+      element.to_html_element() is Some(html_element) &&
+      html_element.to_html_dialog_element() is Some(dialog) {
+      if dialog.open() {
+        dialog.close()
+      }
+      mark_dialog_layer(id, false)
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_dialog_close(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_dialog_request_close(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    if @dom.document().get_element_by_id(id).to_option() is Some(element) &&
+      element.to_html_element() is Some(html_element) &&
+      html_element.to_html_dialog_element() is Some(dialog) {
+      dialog.request_close()
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_dialog_request_close(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_popover_show(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    if @dom.document().get_element_by_id(id).to_option() is Some(element) &&
+      element.to_html_element() is Some(html_element) {
+      html_element.show_popover()
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_popover_show(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_popover_hide(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    if @dom.document().get_element_by_id(id).to_option() is Some(element) &&
+      element.to_html_element() is Some(html_element) {
+      html_element.hide_popover()
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_popover_hide(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_focus_id(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    if @dom.document().get_element_by_id(id).to_option() is Some(element) &&
+      element.to_html_element() is Some(html_element) {
+      html_element.focus()
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_focus_id(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn ui_scroll_id(id : String, end_ : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.after_render, _ => {
+    if @dom.document().get_element_by_id(id).to_option() is Some(element) {
+      if end_ {
+        element.set_scroll_top(element.get_scroll_height())
+      } else {
+        element.set_scroll_top(0.0)
+      }
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_scroll_id(id : String, end_ : Bool) -> @cmd.Cmd {
+  ignore((id, end_))
+  @cmd.none
+}

--- a/rui/interaction_wbtest.mbt
+++ b/rui/interaction_wbtest.mbt
@@ -1,0 +1,459 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_escape_fixture(
+  kind : String,
+  id : String,
+  popup_id : String,
+) -> Unit =
+  #| (kind, id, popupId) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const documentListeners = {}
+  #|   const addDocumentListener = (type, callback) => {
+  #|     const callbacks = documentListeners[type] ||= []
+  #|     callbacks.push(callback)
+  #|   }
+  #|   class FakeNode {
+  #|     constructor(nodeType = 0) {
+  #|       this.nodeType = nodeType
+  #|       this.parentNode = null
+  #|     }
+  #|     isSameNode(other) { return this === other }
+  #|   }
+  #|   class FakeElement extends FakeNode {
+  #|     constructor() {
+  #|       super(1)
+  #|       this.isConnected = true
+  #|       this.dataset = {}
+  #|       this.listeners = {}
+  #|     }
+  #|     getAttribute(name) {
+  #|       if (!name.startsWith("data-")) return this[name] ?? ""
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       return this.dataset[key] ?? ""
+  #|     }
+  #|     setAttribute(name, value) {
+  #|       if (!name.startsWith("data-")) {
+  #|         this[name] = String(value)
+  #|         return
+  #|       }
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       this.dataset[key] = String(value)
+  #|     }
+  #|     removeAttribute(name) {
+  #|       if (!name.startsWith("data-")) {
+  #|         delete this[name]
+  #|         return
+  #|       }
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       delete this.dataset[key]
+  #|     }
+  #|     hasAttribute(name) { return this.getAttribute(name) !== "" }
+  #|     addEventListener(type, callback) {
+  #|       const callbacks = this.listeners[type] ||= []
+  #|       callbacks.push(callback)
+  #|     }
+  #|     removeEventListener(type, callback) {
+  #|       this.listeners[type] = (this.listeners[type] || [])
+  #|         .filter(current => current !== callback)
+  #|     }
+  #|     emit(type, event) {
+  #|       for (const callback of this.listeners[type] || []) callback(event)
+  #|     }
+  #|     closest() { return null }
+  #|     contains(target) { return target === this }
+  #|     querySelector() { return null }
+  #|     querySelectorAll() { return [] }
+  #|     getBoundingClientRect() {
+  #|       return { left: 0, right: 100, top: 0, bottom: 100, width: 100, height: 100 }
+  #|     }
+  #|   }
+  #|   class FakeHTMLElement extends FakeElement {
+  #|     constructor() {
+  #|       super()
+  #|       this.popover = null
+  #|       this.style = {
+  #|         getPropertyValue: () => "",
+  #|         setProperty() {},
+  #|         removeProperty() { return "" },
+  #|       }
+  #|     }
+  #|     focus() {}
+  #|   }
+  #|   class FakeHTMLDialogElement extends FakeHTMLElement {
+  #|     constructor(dialogId) {
+  #|       super()
+  #|       this.id = dialogId
+  #|       this.open = true
+  #|       this.dataset = {
+  #|         modal: "true",
+  #|         closeOnEscape: "true",
+  #|         restoreFocus: "true",
+  #|       }
+  #|     }
+  #|     close() {
+  #|       if (!this.open) return
+  #|       this.open = false
+  #|       this.emit("close", new FakeEvent(this))
+  #|     }
+  #|     show() { this.open = true }
+  #|     showModal() { this.open = true }
+  #|   }
+  #|   class FakeEvent {
+  #|     constructor(target) {
+  #|       this.target = target
+  #|       this.currentTarget = null
+  #|       this.defaultPrevented = false
+  #|       this.timeStamp = 0
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|     stopPropagation() {}
+  #|     stopImmediatePropagation() {}
+  #|     composedPath() { return [this.target] }
+  #|   }
+  #|   class FakeKeyboardEvent extends FakeEvent {
+  #|     constructor(target, key) {
+  #|       super(target)
+  #|       this.key = key
+  #|     }
+  #|   }
+  #|   class FakeMouseEvent extends FakeEvent {
+  #|     constructor(target) {
+  #|       super(target)
+  #|       this.clientX = 0
+  #|       this.clientY = 0
+  #|     }
+  #|   }
+  #|   class FakeToggleEvent extends FakeEvent {
+  #|     constructor(target, newState) {
+  #|       super(target)
+  #|       this.newState = newState
+  #|       this.oldState = newState === "open" ? "closed" : "open"
+  #|     }
+  #|   }
+  #|   let dialog = null
+  #|   let popup = null
+  #|   const makePopup = (popupId, popover, dataset, open) =>
+  #|     Object.assign(new FakeHTMLElement(), {
+  #|       id: popupId,
+  #|       popover,
+  #|       dataset,
+  #|       __open: open,
+  #|       matches(selector) {
+  #|         return selector === ":popover-open" && this.__open
+  #|       },
+  #|       showPopover() {
+  #|         if (this.__open) return
+  #|         this.__open = true
+  #|         this.emit("toggle", new FakeToggleEvent(this, "open"))
+  #|       },
+  #|       hidePopover() {
+  #|         if (!this.__open) return
+  #|         this.__open = false
+  #|         globalThis.__ruiEscapeFixture.hidden += 1
+  #|         this.emit("toggle", new FakeToggleEvent(this, "closed"))
+  #|       },
+  #|     })
+  #|   if (kind === "dialog" || kind === "layered") {
+  #|     dialog = new FakeHTMLDialogElement(id)
+  #|   }
+  #|   if (kind === "floating" || kind === "fallback" || kind === "layered") {
+  #|     const resolvedPopupId = kind === "layered" ? popupId : id
+  #|     popup = makePopup(
+  #|       resolvedPopupId,
+  #|       kind === "fallback" ? null : "manual",
+  #|       {
+  #|         restoreFocus: "false",
+  #|         slot: "popover-content",
+  #|       },
+  #|       kind === "floating" || kind === "layered",
+  #|     )
+  #|   }
+  #|   const body = new FakeHTMLElement()
+  #|   const document = Object.assign(new FakeNode(9), {
+  #|     activeElement: null,
+  #|     body,
+  #|     documentElement: Object.assign(new FakeElement(), {
+  #|       clientWidth: 1024,
+  #|       clientHeight: 768,
+  #|     }),
+  #|     getElementById: value => {
+  #|       if (dialog && value === id) return dialog
+  #|       if (popup && value === (kind === "layered" ? popupId : id)) return popup
+  #|       return null
+  #|     },
+  #|     querySelector: () => null,
+  #|     addEventListener: addDocumentListener,
+  #|     removeEventListener() {},
+  #|   })
+  #|   const fixture = globalThis.__ruiEscapeFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     Element: globalThis.Element,
+  #|     hadElement: own("Element"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     HTMLDialogElement: globalThis.HTMLDialogElement,
+  #|     hadHTMLDialogElement: own("HTMLDialogElement"),
+  #|     Event: globalThis.Event,
+  #|     hadEvent: own("Event"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     MouseEvent: globalThis.MouseEvent,
+  #|     hadMouseEvent: own("MouseEvent"),
+  #|     ToggleEvent: globalThis.ToggleEvent,
+  #|     hadToggleEvent: own("ToggleEvent"),
+  #|     documentListeners,
+  #|     document,
+  #|     dialog,
+  #|     popup,
+  #|     requested: 0,
+  #|     hidden: 0,
+  #|     stopped: 0,
+  #|     prevented: false,
+  #|     FakeEvent,
+  #|     FakeKeyboardEvent,
+  #|     setPopupOpen: value => { popup.__open = value },
+  #|     replacePopup: () => {
+  #|       const previous = popup
+  #|       previous.isConnected = false
+  #|       fixture.previousPopup = previous
+  #|       popup = makePopup(
+  #|         previous.id,
+  #|         previous.popover,
+  #|         { ...previous.dataset, lightDismiss: "true" },
+  #|         true,
+  #|       )
+  #|       fixture.popup = popup
+  #|     },
+  #|   }
+  #|   globalThis.Node = FakeNode
+  #|   globalThis.Element = FakeElement
+  #|   globalThis.HTMLElement = FakeHTMLElement
+  #|   globalThis.HTMLDialogElement = FakeHTMLDialogElement
+  #|   globalThis.Event = FakeEvent
+  #|   globalThis.KeyboardEvent = FakeKeyboardEvent
+  #|   globalThis.MouseEvent = FakeMouseEvent
+  #|   globalThis.ToggleEvent = FakeToggleEvent
+  #|   globalThis.document = document
+  #|   globalThis.window = {
+  #|     queueMicrotask: callback => callback(),
+  #|     requestAnimationFrame: callback => { callback(0); return 1 },
+  #|     cancelAnimationFrame() {},
+  #|     performance: { now: () => 0 },
+  #|     addEventListener() {},
+  #|     removeEventListener() {},
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_escape_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiEscapeFixture
+  #|   const event = new fixture.FakeKeyboardEvent(fixture.document, "Escape")
+  #|   const original = event.preventDefault.bind(event)
+  #|   event.preventDefault = () => {
+  #|     original()
+  #|     fixture.prevented = true
+  #|   }
+  #|   for (const callback of fixture.documentListeners.keydown || []) callback(event)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_plain_closed_toggle_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiEscapeFixture
+  #|   fixture.setPopupOpen(false)
+  #|   fixture.popup.emit("toggle", new fixture.FakeEvent(fixture.popup))
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_replace_popup_fixture() -> Unit =
+  #| () => globalThis.__ruiEscapeFixture.replacePopup()
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_previous_closed_toggle_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiEscapeFixture
+  #|   fixture.previousPopup.__open = false
+  #|   fixture.previousPopup.emit(
+  #|     "toggle",
+  #|     new fixture.FakeEvent(fixture.previousPopup),
+  #|   )
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_outside_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiEscapeFixture
+  #|   const event = new fixture.FakeEvent(fixture.document.body)
+  #|   for (const callback of fixture.documentListeners.pointerdown || []) {
+  #|     callback(event)
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_escape_fixture_requested() -> Int =
+  #| () => globalThis.__ruiEscapeFixture?.requested ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_escape_fixture_hidden() -> Int =
+  #| () => globalThis.__ruiEscapeFixture?.hidden ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_escape_fixture_stopped() -> Int =
+  #| () => globalThis.__ruiEscapeFixture?.stopped ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_escape_fixture_prevented() -> Bool =
+  #| () => Boolean(globalThis.__ruiEscapeFixture?.prevented)
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mark_dialog_escape_fixture_requested() -> Unit =
+  #| () => { globalThis.__ruiEscapeFixture.requested += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mark_floating_positioning_stopped() -> Unit =
+  #| () => { globalThis.__ruiEscapeFixture.stopped += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_escape_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiEscapeFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("Node", fixture.hadNode, fixture.Node)
+  #|   restore("Element", fixture.hadElement, fixture.Element)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore(
+  #|     "HTMLDialogElement",
+  #|     fixture.hadHTMLDialogElement,
+  #|     fixture.HTMLDialogElement,
+  #|   )
+  #|   restore("Event", fixture.hadEvent, fixture.Event)
+  #|   restore("KeyboardEvent", fixture.hadKeyboardEvent, fixture.KeyboardEvent)
+  #|   restore("MouseEvent", fixture.hadMouseEvent, fixture.MouseEvent)
+  #|   restore("ToggleEvent", fixture.hadToggleEvent, fixture.ToggleEvent)
+  #|   delete globalThis.__ruiEscapeFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "Escape explicitly requests closing the top modal dialog" {
+  ffi_install_escape_fixture("dialog", "escape-dialog", "")
+  bind_dialog_layer("escape-dialog", ffi_mark_dialog_escape_fixture_requested)
+  mark_dialog_layer("escape-dialog", true)
+  ffi_fire_escape_fixture()
+  let requested = ffi_escape_fixture_requested()
+  let prevented = ffi_escape_fixture_prevented()
+  ffi_restore_escape_fixture()
+  assert_eq(requested, 1)
+  assert_true(prevented)
+}
+
+///|
+#cfg(target="js")
+test "Escape explicitly hides the top native popover" {
+  ffi_install_escape_fixture("floating", "escape-popover", "")
+  bind_floating_sync("escape-popover", _ => ())
+  ffi_fire_escape_fixture()
+  let hidden = ffi_escape_fixture_hidden()
+  let prevented = ffi_escape_fixture_prevented()
+  ffi_restore_escape_fixture()
+  assert_eq(hidden, 1)
+  assert_true(prevented)
+}
+
+///|
+#cfg(target="js")
+test "native light dismiss synchronizes from actual popover state" {
+  ffi_install_escape_fixture("floating", "plain-toggle-popover", "")
+  let mut closed = 0
+  bind_floating_sync("plain-toggle-popover", open => if !open { closed += 1 })
+  ffi_fire_plain_closed_toggle_fixture()
+  let stack_size = floating_stack.val.length()
+  ffi_restore_escape_fixture()
+  assert_eq(closed, 1)
+  assert_eq(stack_size, 0)
+}
+
+///|
+#cfg(target="js")
+test "floating dismissal rebinds a replaced physical element" {
+  ffi_install_escape_fixture("floating", "replaced-floating-popover", "")
+  let mut closed = 0
+  bind_floating_sync("replaced-floating-popover", open => {
+    if !open {
+      closed += 1
+    }
+  })
+  ffi_replace_popup_fixture()
+  ffi_fire_previous_closed_toggle_fixture()
+  assert_eq(closed, 0)
+  assert_eq(floating_stack.val.length(), 1)
+  ffi_fire_outside_pointer_fixture()
+  let hidden = ffi_escape_fixture_hidden()
+  let stack_size = floating_stack.val.length()
+  ffi_restore_escape_fixture()
+  assert_eq(hidden, 1)
+  assert_eq(closed, 1)
+  assert_eq(stack_size, 0)
+}
+
+///|
+#cfg(target="js")
+test "fallback floating layer stays in the stack and closes through one lifecycle" {
+  ffi_install_escape_fixture("fallback", "fallback-popover", "")
+  let mut closed = 0
+  bind_floating_sync("fallback-popover", open => if !open { closed += 1 })
+  floating_set_stop_positioning(
+    "fallback-popover", ffi_mark_floating_positioning_stopped,
+  )
+  ignore(set_floating_open("fallback-popover", true))
+  let open_stack = floating_stack.val.length()
+  ffi_fire_escape_fixture()
+  let closed_stack = floating_stack.val.length()
+  let stopped = ffi_escape_fixture_stopped()
+  let prevented = ffi_escape_fixture_prevented()
+  ffi_restore_escape_fixture()
+  assert_eq(open_stack, 1)
+  assert_eq(closed_stack, 0)
+  assert_eq(closed, 1)
+  assert_eq(stopped, 1)
+  assert_true(prevented)
+}
+
+///|
+#cfg(target="js")
+test "Escape closes only the floating layer above a modal dialog" {
+  ffi_install_escape_fixture("layered", "layered-dialog", "layered-popover")
+  bind_dialog_layer("layered-dialog", ffi_mark_dialog_escape_fixture_requested)
+  mark_dialog_layer("layered-dialog", true)
+  bind_floating_sync("layered-popover", _ => ())
+  ffi_fire_escape_fixture()
+  let requested = ffi_escape_fixture_requested()
+  let hidden = ffi_escape_fixture_hidden()
+  ffi_restore_escape_fixture()
+  assert_eq(requested, 0)
+  assert_eq(hidden, 1)
+}

--- a/rui/item.mbt
+++ b/rui/item.mbt
@@ -1,0 +1,391 @@
+///|
+pub(all) enum ItemVariant {
+  ItemDefault
+  ItemOutline
+  ItemMuted
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ItemSize {
+  ItemDefaultSize
+  ItemSm
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ItemMediaVariant {
+  ItemMediaDefault
+  ItemMediaIcon
+  ItemMediaImage
+} derive(Debug, Eq)
+
+///|
+const ItemGroupStyle : String = "display:flex;flex-direction:column"
+
+///|
+const ItemBaseStyle : String = "display:flex;flex-wrap:wrap;align-items:center;border:1px solid var(--rui-item-border,var(--rui-item-base-border,transparent));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-item-bg,var(--rui-item-base-bg,transparent));color:var(--rui-item-fg,var(--rui-foreground,oklch(0.145 0 0)));box-shadow:var(--rui-item-shadow,none);font-size:0.875rem;line-height:1.25rem;text-align:start;outline:none"
+
+///|
+fn item_variant_value(variant : ItemVariant) -> String {
+  match variant {
+    ItemDefault => "default"
+    ItemOutline => "outline"
+    ItemMuted => "muted"
+  }
+}
+
+///|
+fn item_variant_style(variant : ItemVariant) -> String {
+  match variant {
+    ItemDefault =>
+      "--rui-item-base-bg:transparent;--rui-item-base-border:transparent"
+    ItemOutline =>
+      "--rui-item-base-bg:transparent;--rui-item-base-border:var(--rui-border,oklch(0.922 0 0))"
+    ItemMuted =>
+      "--rui-item-base-bg:color-mix(in oklch,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent);--rui-item-base-border:transparent"
+  }
+}
+
+///|
+fn item_size_value(size : ItemSize) -> String {
+  match size {
+    ItemDefaultSize => "default"
+    ItemSm => "sm"
+  }
+}
+
+///|
+fn item_size_style(size : ItemSize) -> String {
+  match size {
+    ItemDefaultSize => "gap:1rem;padding:1rem"
+    ItemSm => "gap:0.625rem;padding:0.75rem 1rem"
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] item_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).role("list").data_set("slot", "item-group"),
+    style=ui_styles([UiBoxSizing, ItemGroupStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item(
+  variant? : ItemVariant = ItemDefault,
+  size? : ItemSize = ItemDefaultSize,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "item")
+      .data_set("variant", item_variant_value(variant))
+      .data_set("size", item_size_value(size)),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        ItemBaseStyle,
+        item_variant_style(variant),
+        item_size_style(size),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn item_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn item_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+/// Render the `asChild` anchor path from the Vega item recipe as a native link.
+pub fn[C : @html.IsChildren] item_link(
+  href~ : String,
+  variant? : ItemVariant = ItemDefault,
+  size? : ItemSize = ItemDefaultSize,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "item")
+    .data_set("variant", item_variant_value(variant))
+    .data_set("size", item_size_value(size))
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  item_bind_disabled_link(element_attrs, disabled)
+  @html.a(
+    id?,
+    class?,
+    title?,
+    href~,
+    target~,
+    rel?,
+    download?,
+    attrs=element_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        ItemBaseStyle,
+        item_variant_style(variant),
+        item_size_style(size),
+        "text-decoration:none;cursor:pointer",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    children,
+    escape~,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_media(
+  variant? : ItemMediaVariant = ItemMediaDefault,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let value = match variant {
+    ItemMediaDefault => "default"
+    ItemMediaIcon => "icon"
+    ItemMediaImage => "image"
+  }
+  let variant_style = match variant {
+    ItemMediaDefault => "background:transparent"
+    ItemMediaIcon =>
+      "width:2rem;height:2rem;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:0.25rem;background:var(--rui-muted,oklch(0.97 0 0));--rui-icon-size:1rem"
+    ItemMediaImage =>
+      "width:2.5rem;height:2.5rem;overflow:hidden;border-radius:0.25rem"
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "item-media")
+      .data_set("variant", value),
+    style=ui_styles(
+      [
+        "display:flex;flex-shrink:0;align-items:center;justify-content:center;gap:0.5rem",
+        variant_style,
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-content"),
+    style=ui_styles(
+      ["display:flex;min-width:0;flex:1;flex-direction:column;gap:0.25rem"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-title"),
+    style=ui_styles(
+      [
+        "display:flex;width:fit-content;max-width:100%;min-width:0;align-items:center;gap:0.5rem;font-size:0.875rem;line-height:1.375;font-weight:500;overflow-wrap:anywhere",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-description"),
+    style=ui_styles(
+      [
+        "display:-webkit-box;overflow:hidden;margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.5;font-weight:400;text-wrap:balance;overflow-wrap:anywhere;-webkit-box-orient:vertical;-webkit-line-clamp:2",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_actions(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-actions"),
+    style=ui_styles(["display:flex;align-items:center;gap:0.5rem"], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-header"),
+    style=ui_styles(
+      [
+        "display:flex;flex-basis:100%;align-items:center;justify-content:space-between;gap:0.5rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] item_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-footer"),
+    style=ui_styles(
+      [
+        "display:flex;flex-basis:100%;align-items:center;justify-content:space-between;gap:0.5rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn item_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  separator(
+    slot="item-separator",
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "item-separator"),
+    style~,
+  )
+}

--- a/rui/kbd.mbt
+++ b/rui/kbd.mbt
@@ -1,0 +1,43 @@
+///|
+const KbdStyle : String = "display:inline-flex;width:fit-content;min-width:1.25rem;height:1.25rem;align-items:center;justify-content:center;gap:0.25rem;border-radius:0.25rem;background:var(--rui-muted,oklch(0.97 0 0));padding-inline:0.25rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;font-weight:500;user-select:none;pointer-events:none;--rui-icon-size:0.75rem"
+
+///|
+const KbdGroupStyle : String = "display:inline-flex;align-items:center;gap:0.25rem"
+
+///|
+pub fn[C : @html.IsChildren] kbd(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.kbd(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "kbd"),
+    style=ui_styles([UiBoxSizing, UiFontSans, KbdStyle], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] kbd_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.kbd(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "kbd-group"),
+    style=ui_styles([UiBoxSizing, KbdGroupStyle], style),
+    children,
+  )
+}

--- a/rui/label.mbt
+++ b/rui/label.mbt
@@ -1,0 +1,41 @@
+///|
+const LabelBaseStyle : String = "display:flex;align-items:center;gap:0.5rem;color:var(--rui-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1;font-weight:500;user-select:none"
+
+///|
+/// Render a native label. `disabled` supplies the standalone equivalent of
+/// shadcn/ui's field-context disabled state.
+pub fn[C : @html.IsChildren] label(
+  for_? : String,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let attrs = ui_attrs(attrs).data_set("slot", "label")
+  if disabled {
+    ignore(attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  @html.label(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        LabelBaseStyle,
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    for_?,
+    attrs~,
+    children,
+  )
+}

--- a/rui/marker.mbt
+++ b/rui/marker.mbt
@@ -1,0 +1,171 @@
+///|
+pub(all) enum MarkerVariant {
+  MarkerDefault
+  MarkerSeparator
+  MarkerBorder
+} derive(Debug, Eq)
+
+///|
+const MarkerBaseStyle : String = "position:relative;display:flex;width:100%;min-height:1rem;align-items:center;gap:0.5rem;color:var(--rui-marker-fg,var(--rui-muted-foreground,oklch(0.556 0 0)));box-shadow:var(--rui-marker-shadow,none);font-size:0.875rem;line-height:1.25rem;text-align:start;outline:none"
+
+///|
+fn marker_variant_value(variant : MarkerVariant) -> String {
+  match variant {
+    MarkerDefault => "default"
+    MarkerSeparator => "separator"
+    MarkerBorder => "border"
+  }
+}
+
+///|
+fn marker_variant_style(variant : MarkerVariant) -> String {
+  match variant {
+    MarkerDefault => ""
+    MarkerSeparator => "justify-content:center"
+    MarkerBorder =>
+      "border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));padding-bottom:0.5rem"
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] marker(
+  variant? : MarkerVariant = MarkerDefault,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "marker")
+      .data_set("variant", marker_variant_value(variant)),
+    style=ui_styles([MarkerBaseStyle, marker_variant_style(variant)], style),
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn marker_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn marker_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+/// Render the marker `asChild` anchor path as a native, focusable link.
+pub fn[C : @html.IsChildren] marker_link(
+  href~ : String,
+  variant? : MarkerVariant = MarkerDefault,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "marker")
+    .data_set("variant", marker_variant_value(variant))
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  marker_bind_disabled_link(element_attrs, disabled)
+  @html.a(
+    href~,
+    target~,
+    rel?,
+    download?,
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        MarkerBaseStyle,
+        marker_variant_style(variant),
+        "text-decoration:underline;text-underline-offset:3px;cursor:pointer",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    children,
+    escape~,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] marker_icon(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "marker-icon").aria_hidden("true"),
+    style=ui_styles(
+      [
+        "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center;--rui-icon-size:1rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] marker_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "marker-content"),
+    style=ui_styles(["min-width:0;overflow-wrap:anywhere"], style),
+    children,
+  )
+}

--- a/rui/menu_interaction_wbtest.mbt
+++ b/rui/menu_interaction_wbtest.mbt
@@ -1,0 +1,1854 @@
+///|
+test "submenu state keeps ancestors open and closes only the requested branch" {
+  let parent = "parent::submenu-0"
+  let child = "child::submenu-1"
+  let opened_parent = menu_update_submenus([], MenuOpenSubmenu(parent))
+  let opened_child = menu_update_submenus(opened_parent, MenuOpenSubmenu(child))
+  assert_eq(opened_child, [parent, child])
+  assert_eq(menu_update_submenus(opened_child, MenuCloseSubmenu(child)), [
+    parent,
+  ])
+  assert_eq(menu_update_submenus(opened_child, MenuCloseSubmenu(parent)), [])
+}
+
+///|
+test "submenu state ignores duplicate opens and can close the whole tree" {
+  let key = "share::submenu-2"
+  let opened = menu_update_submenus([key], MenuOpenSubmenu(key))
+  assert_eq(opened, [key])
+  assert_true(menu_submenu_open(opened, key))
+  assert_eq(menu_update_submenus(opened, MenuCloseAllSubmenus), [])
+}
+
+///|
+test "submenu switching replaces only the active sibling branch" {
+  let parent = "parent::submenu-0"
+  let child_a = "child-a::submenu-1"
+  let grandchild = "grandchild::submenu-2"
+  let child_b = "child-b::submenu-3"
+  assert_eq(
+    menu_update_submenus(
+      [parent, child_a, grandchild],
+      MenuSwitchSubmenu(parent, child_b),
+    ),
+    [parent, child_b],
+  )
+  assert_eq(
+    menu_update_submenus(
+      [parent, child_a, grandchild],
+      MenuCloseSubmenusUnder(parent),
+    ),
+    [parent],
+  )
+}
+
+///|
+test "root submenu switching is atomic during rapid pointer movement" {
+  let first = "first::submenu-0"
+  let second = "second::submenu-1"
+  assert_eq(menu_update_submenus([first], MenuSwitchSubmenu("", second)), [
+    second,
+  ])
+  assert_eq(menu_update_submenus([second], MenuCloseSubmenusUnder("")), [])
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_manual_light_dismiss_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const documentListeners = {}
+  #|   const popupListeners = {}
+  #|   const triggerListeners = {}
+  #|   const style = {}
+  #|   class FakeNode {
+  #|     constructor() { this.parentNode = null }
+  #|     isSameNode(other) { return this === other }
+  #|   }
+  #|   class FakeElement extends FakeNode {
+  #|     constructor() {
+  #|       super()
+  #|       this.dataset = {}
+  #|       this.isConnected = true
+  #|       this.clientLeft = 0
+  #|       this.clientTop = 0
+  #|     }
+  #|     getAttribute(name) {
+  #|       if (!name.startsWith("data-")) return this[name] ?? ""
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       return this.dataset[key] ?? ""
+  #|     }
+  #|     setAttribute(name, value) {
+  #|       if (!name.startsWith("data-")) {
+  #|         this[name] = String(value)
+  #|         return
+  #|       }
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       this.dataset[key] = String(value)
+  #|     }
+  #|     removeAttribute(name) {
+  #|       if (!name.startsWith("data-")) {
+  #|         delete this[name]
+  #|         return
+  #|       }
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       delete this.dataset[key]
+  #|     }
+  #|     hasAttribute(name) { return this.getAttribute(name) !== "" }
+  #|   }
+  #|   class FakeHTMLElement extends FakeElement {
+  #|     focus() {}
+  #|   }
+  #|   class FakeHTMLDialogElement extends FakeHTMLElement {}
+  #|   class FakeEvent {
+  #|     constructor(target) {
+  #|       this.target = target
+  #|       this.defaultPrevented = false
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|     stopPropagation() {}
+  #|     composedPath() { return [this.target] }
+  #|   }
+  #|   class FakeMouseEvent extends FakeEvent {
+  #|     constructor(target, clientX, clientY) {
+  #|       super(target)
+  #|       this.clientX = clientX
+  #|       this.clientY = clientY
+  #|     }
+  #|   }
+  #|   class FakeKeyboardEvent extends FakeEvent {}
+  #|   class FakeToggleEvent extends FakeEvent {
+  #|     constructor(target, newState) {
+  #|       super(target)
+  #|       this.newState = newState
+  #|       this.oldState = newState === "open" ? "closed" : "open"
+  #|     }
+  #|   }
+  #|   class FakeTransitionEvent extends FakeEvent {
+  #|     constructor(target, propertyName) {
+  #|       super(target)
+  #|       this.propertyName = propertyName
+  #|     }
+  #|   }
+  #|   const inside = new FakeNode()
+  #|   let open = false
+  #|   let hides = 0
+  #|   const trigger = Object.assign(new FakeHTMLElement(), {
+  #|     isConnected: true,
+  #|     addEventListener: (type, callback) => { triggerListeners[type] = callback },
+  #|     clientWidth: 80,
+  #|     clientHeight: 32,
+  #|     getBoundingClientRect: () => ({
+  #|       left: 40,
+  #|       top: 40,
+  #|       right: 120,
+  #|       bottom: 72,
+  #|       width: 80,
+  #|       height: 32,
+  #|     }),
+  #|   })
+  #|   const popup = Object.assign(new FakeHTMLElement(), {
+  #|     isConnected: true,
+  #|     popover: "manual",
+  #|     dataset: {
+  #|       lightDismiss: "true",
+  #|       restoreFocus: "false",
+  #|       triggerId: `${id}-trigger`,
+  #|       state: "open",
+  #|     },
+  #|     matches: selector => selector === ":popover-open" && open,
+  #|     addEventListener: (type, callback) => { popupListeners[type] = callback },
+  #|     removeEventListener: (type, callback) => {
+  #|       if (popupListeners[type] === callback) delete popupListeners[type]
+  #|     },
+  #|     contains: target => target === inside,
+  #|     closest: () => null,
+  #|     offsetWidth: 120,
+  #|     offsetHeight: 100,
+  #|     getBoundingClientRect: () => ({ width: 120, height: 100 }),
+  #|     style: {
+  #|       setProperty: (key, value) => { style[key] = value },
+  #|       getPropertyValue: key => style[key] || "",
+  #|       removeProperty: key => { delete style[key]; return "" },
+  #|     },
+  #|     showPopover() {
+  #|       if (open) return
+  #|       open = true
+  #|       popupListeners.toggle?.(new FakeToggleEvent(popup, "open"))
+  #|     },
+  #|     hidePopover() {
+  #|       if (!open) return
+  #|       open = false
+  #|       hides += 1
+  #|       popupListeners.toggle?.(new FakeToggleEvent(popup, "closed"))
+  #|     },
+  #|   })
+  #|   const frameQueue = []
+  #|   const timeoutQueue = new Map()
+  #|   let nextTimeout = 1
+  #|   const visualViewport = {
+  #|     offsetLeft: 0,
+  #|     offsetTop: 0,
+  #|     width: 320,
+  #|     height: 240,
+  #|     addEventListener() {},
+  #|     removeEventListener() {},
+  #|   }
+  #|   const window = {
+  #|     visualViewport,
+  #|     performance: { now: () => 10 },
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: name => name === "opacity"
+  #|         ? "0"
+  #|         : name === "transition-duration" ? "0.1s"
+  #|         : name === "transition-delay" ? "0s"
+  #|         : "",
+  #|     }),
+  #|     matchMedia: () => ({ matches: false }),
+  #|     requestAnimationFrame: callback => {
+  #|       frameQueue.push(callback)
+  #|       return frameQueue.length
+  #|     },
+  #|     cancelAnimationFrame() {},
+  #|     queueMicrotask: callback => callback(),
+  #|     setTimeout: callback => {
+  #|       const handle = nextTimeout++
+  #|       timeoutQueue.set(handle, callback)
+  #|       return handle
+  #|     },
+  #|     clearTimeout: handle => timeoutQueue.delete(handle),
+  #|     addEventListener() {},
+  #|     removeEventListener() {},
+  #|   }
+  #|   const body = new FakeHTMLElement()
+  #|   const document = Object.assign(new FakeNode(), {
+  #|     activeElement: null,
+  #|     body,
+  #|     documentElement: Object.assign(new FakeElement(), {
+  #|       clientWidth: 320,
+  #|       clientHeight: 240,
+  #|     }),
+  #|     getElementById: value => value === id
+  #|       ? popup
+  #|       : value === `${id}-trigger` ? trigger : null,
+  #|     addEventListener: (type, callback) => { documentListeners[type] = callback },
+  #|   })
+  #|   const fixture = globalThis.__ruiManualLightDismissFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     Element: globalThis.Element,
+  #|     hadElement: own("Element"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     HTMLDialogElement: globalThis.HTMLDialogElement,
+  #|     hadHTMLDialogElement: own("HTMLDialogElement"),
+  #|     Event: globalThis.Event,
+  #|     hadEvent: own("Event"),
+  #|     MouseEvent: globalThis.MouseEvent,
+  #|     hadMouseEvent: own("MouseEvent"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     ToggleEvent: globalThis.ToggleEvent,
+  #|     hadToggleEvent: own("ToggleEvent"),
+  #|     TransitionEvent: globalThis.TransitionEvent,
+  #|     hadTransitionEvent: own("TransitionEvent"),
+  #|     floatingStack: globalThis.__ruiFloatingStack,
+  #|     hadFloatingStack: own("__ruiFloatingStack"),
+  #|     computedStyle: globalThis.getComputedStyle,
+  #|     hadComputedStyle: own("getComputedStyle"),
+  #|     documentListeners,
+  #|     popupListeners,
+  #|     popup,
+  #|     trigger,
+  #|     inside,
+  #|     style,
+  #|     triggerListeners,
+  #|     point: { x: -1, y: -1 },
+  #|     hides: () => hides,
+  #|     open: () => open,
+  #|     closes: 0,
+  #|     closeRequests: 0,
+  #|     FakeEvent,
+  #|     FakeMouseEvent,
+  #|     FakeTransitionEvent,
+  #|   }
+  #|   globalThis.Node = FakeNode
+  #|   globalThis.Element = FakeElement
+  #|   globalThis.HTMLElement = FakeHTMLElement
+  #|   globalThis.HTMLDialogElement = FakeHTMLDialogElement
+  #|   globalThis.Event = FakeEvent
+  #|   globalThis.MouseEvent = FakeMouseEvent
+  #|   globalThis.KeyboardEvent = FakeKeyboardEvent
+  #|   globalThis.ToggleEvent = FakeToggleEvent
+  #|   globalThis.TransitionEvent = FakeTransitionEvent
+  #|   globalThis.__ruiFloatingStack = []
+  #|   globalThis.document = document
+  #|   globalThis.window = window
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_manual_light_dismiss_fixture(inside : Bool) -> Unit =
+  #| inside => {
+  #|   const fixture = globalThis.__ruiManualLightDismissFixture
+  #|   const target = inside ? fixture.inside : {}
+  #|   fixture.documentListeners.pointerdown?.(new fixture.FakeEvent(target))
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_context_press_open_release_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiManualLightDismissFixture
+  #|   fixture.documentListeners.pointerdown?.(
+  #|     new fixture.FakeEvent(fixture.trigger),
+  #|   )
+  #|   fixture.triggerListeners.contextmenu?.(
+  #|     new fixture.FakeMouseEvent(fixture.trigger, 300, 200),
+  #|   )
+  #|   fixture.documentListeners.pointerup?.({
+  #|     target: fixture.trigger,
+  #|     composedPath: () => [fixture.trigger],
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_light_dismiss_fixture_open() -> Bool =
+  #| () => Boolean(globalThis.__ruiManualLightDismissFixture?.open())
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_light_dismiss_position(key : String) -> String =
+  #| key => globalThis.__ruiManualLightDismissFixture?.style?.[key] || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_context_point(axis : String) -> Int =
+  #| axis => globalThis.__ruiManualLightDismissFixture?.point?.[axis] ?? -1
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_context_record_point(x : Int, y : Int) -> Unit =
+  #| (x, y) => { globalThis.__ruiManualLightDismissFixture.point = { x, y } }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_light_dismiss_fixture_closed() -> Int =
+  #| () => globalThis.__ruiManualLightDismissFixture?.closes ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mark_manual_light_dismiss_fixture_closed() -> Unit =
+  #| () => { globalThis.__ruiManualLightDismissFixture.closes += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_light_dismiss_fixture_hides() -> Int =
+  #| () => globalThis.__ruiManualLightDismissFixture?.hides() ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mark_manual_context_close_requested() -> Unit =
+  #| () => { globalThis.__ruiManualLightDismissFixture.closeRequests += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_manual_context_close_requests() -> Int =
+  #| () => globalThis.__ruiManualLightDismissFixture?.closeRequests ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mark_manual_context_closed_state() -> Unit =
+  #| () => { globalThis.__ruiManualLightDismissFixture.popup.dataset.state = "closed" }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_manual_context_transition_end() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiManualLightDismissFixture
+  #|   fixture.popupListeners.transitionend?.(
+  #|     new fixture.FakeTransitionEvent(fixture.popup, "opacity"),
+  #|   )
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_manual_light_dismiss_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiManualLightDismissFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("Node", fixture.hadNode, fixture.Node)
+  #|   restore("Element", fixture.hadElement, fixture.Element)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore(
+  #|     "HTMLDialogElement",
+  #|     fixture.hadHTMLDialogElement,
+  #|     fixture.HTMLDialogElement,
+  #|   )
+  #|   restore("Event", fixture.hadEvent, fixture.Event)
+  #|   restore("MouseEvent", fixture.hadMouseEvent, fixture.MouseEvent)
+  #|   restore("KeyboardEvent", fixture.hadKeyboardEvent, fixture.KeyboardEvent)
+  #|   restore("ToggleEvent", fixture.hadToggleEvent, fixture.ToggleEvent)
+  #|   restore(
+  #|     "TransitionEvent",
+  #|     fixture.hadTransitionEvent,
+  #|     fixture.TransitionEvent,
+  #|   )
+  #|   restore(
+  #|     "__ruiFloatingStack",
+  #|     fixture.hadFloatingStack,
+  #|     fixture.floatingStack,
+  #|   )
+  #|   restore(
+  #|     "getComputedStyle",
+  #|     fixture.hadComputedStyle,
+  #|     fixture.computedStyle,
+  #|   )
+  #|   delete globalThis.__ruiManualLightDismissFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "right-button press contextmenu and release keeps manual menu open" {
+  ffi_install_manual_light_dismiss_fixture("manual-context-menu")
+  bind_floating_sync("manual-context-menu", open => {
+    if !open {
+      ffi_mark_manual_light_dismiss_fixture_closed()
+    }
+  })
+  bind_context_menu_close(
+    "manual-context-menu", ffi_mark_manual_context_close_requested,
+  )
+  bind_context_menu_trigger("manual-context-menu-trigger", (
+    x,
+    y,
+    point_x,
+    point_y,
+  ) => {
+    ffi_manual_context_record_point(point_x, point_y)
+    show_context_menu("manual-context-menu", x, y, point_x, point_y)
+  })
+  ffi_fire_context_press_open_release_fixture()
+  let open_after_release = ffi_manual_light_dismiss_fixture_open()
+  let release_hides = ffi_manual_light_dismiss_fixture_hides()
+  let left = ffi_manual_light_dismiss_position("--rui-floating-left")
+  let top = ffi_manual_light_dismiss_position("--rui-floating-top")
+  let point_x = ffi_manual_context_point("x")
+  let point_y = ffi_manual_context_point("y")
+  ffi_fire_manual_light_dismiss_fixture(true)
+  let inside_hides = ffi_manual_light_dismiss_fixture_hides()
+  ffi_fire_manual_light_dismiss_fixture(false)
+  let outside_hides = ffi_manual_light_dismiss_fixture_hides()
+  let close_requests = ffi_manual_context_close_requests()
+  let open_before_exit = ffi_manual_light_dismiss_fixture_open()
+  ffi_mark_manual_context_closed_state()
+  hide_context_menu_after_transition("manual-context-menu")
+  let hides_before_transition_end = ffi_manual_light_dismiss_fixture_hides()
+  let open_before_transition_end = ffi_manual_light_dismiss_fixture_open()
+  ffi_fire_manual_context_transition_end()
+  let hides_after_transition_end = ffi_manual_light_dismiss_fixture_hides()
+  let open_after_transition_end = ffi_manual_light_dismiss_fixture_open()
+  let closes = ffi_manual_light_dismiss_fixture_closed()
+  ffi_restore_manual_light_dismiss_fixture()
+  assert_true(open_after_release)
+  assert_eq(release_hides, 0)
+  assert_eq(left, "192px")
+  assert_eq(top, "132px")
+  assert_eq(point_x, 80)
+  assert_eq(point_y, 32)
+  assert_eq(inside_hides, 0)
+  assert_eq(outside_hides, 0)
+  assert_eq(close_requests, 1)
+  assert_true(open_before_exit)
+  assert_eq(hides_before_transition_end, 0)
+  assert_true(open_before_transition_end)
+  assert_eq(hides_after_transition_end, 1)
+  assert_false(open_after_transition_end)
+  assert_eq(closes, 1)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_submenu_position_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const props = {}
+  #|   const listeners = {}
+  #|   const viewportListeners = {}
+  #|   const fixture = globalThis.__ruiSubmenuPositionFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     css: globalThis.CSS,
+  #|     hadCss: own("CSS"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     computed: globalThis.getComputedStyle,
+  #|     hadComputed: own("getComputedStyle"),
+  #|     raf: globalThis.requestAnimationFrame,
+  #|     hadRaf: own("requestAnimationFrame"),
+  #|     props,
+  #|     listeners,
+  #|     viewportListeners,
+  #|     pendingFrame: null,
+  #|     submenuOpen: false,
+  #|     showCount: 0,
+  #|     visibilitySnapshots: { show: "", hide: "" },
+  #|     supportsQueries: [],
+  #|     triggerRect: { left: 280, right: 312, top: 180, bottom: 212 },
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   const dataKey = name => name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|   const makeElement = properties => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     dataset: {},
+  #|     getAttribute(name) {
+  #|       return name.startsWith("data-") ? this.dataset[dataKey(name)] ?? "" : ""
+  #|     },
+  #|     setAttribute(name, value) {
+  #|       if (name.startsWith("data-")) this.dataset[dataKey(name)] = String(value)
+  #|     },
+  #|     hasAttribute: () => false,
+  #|     closest: () => null,
+  #|     getClientRects: () => [{}],
+  #|   }, properties)
+  #|   const wrapper = makeElement({
+  #|     isConnected: true,
+  #|     dataset: { submenuKey: "submenu-key" },
+  #|     getBoundingClientRect: () => ({
+  #|       left: 0,
+  #|       right: 0,
+  #|       top: 0,
+  #|       bottom: 0,
+  #|     }),
+  #|   })
+  #|   const trigger = makeElement({
+  #|     isConnected: true,
+  #|     dataset: { menuIndex: "3", submenuKey: "submenu-key" },
+  #|     getBoundingClientRect: () => fixture.triggerRect,
+  #|   })
+  #|   const content = makeElement({
+  #|     isConnected: true,
+  #|     dataset: { state: "open", submenuOwner: "submenu-key" },
+  #|     offsetWidth: 120,
+  #|     offsetHeight: 100,
+  #|     getBoundingClientRect: () => ({ width: 120, height: 100 }),
+  #|     matches: selector => selector === ":popover-open" && fixture.submenuOpen,
+  #|     showPopover: () => {
+  #|       fixture.showCount += 1
+  #|       fixture.visibilitySnapshots.show = [
+  #|         props["--rui-submenu-left"] || "",
+  #|         props["--rui-submenu-top"] || "",
+  #|       ].join(",")
+  #|       fixture.submenuOpen = true
+  #|     },
+  #|     hidePopover: () => {
+  #|       fixture.visibilitySnapshots.hide = [
+  #|         props["--rui-submenu-left"] || "",
+  #|         props["--rui-submenu-top"] || "",
+  #|       ].join(",")
+  #|       fixture.submenuOpen = false
+  #|     },
+  #|     style: {
+  #|       setProperty: (key, value) => { props[key] = value },
+  #|       removeProperty: key => { delete props[key] },
+  #|     },
+  #|   })
+  #|   const root = makeElement({
+  #|     isConnected: true,
+  #|     querySelectorAll: selector => selector === "[data-submenu-owner]"
+  #|       ? [content]
+  #|       : selector === "[data-submenu-key]" ? [wrapper, trigger]
+  #|       : selector === "[data-menu-index][data-submenu-key]" ? [trigger] : [],
+  #|   })
+  #|   globalThis.document = {
+  #|     documentElement: makeElement({ clientWidth: 320, clientHeight: 240 }),
+  #|     getElementById: value => value === id ? root : null,
+  #|   }
+  #|   globalThis.window = {
+  #|     addEventListener: (type, callback) => { listeners[type] = callback },
+  #|     visualViewport: null,
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: name => name === "direction" ? "ltr" : "",
+  #|     }),
+  #|     requestAnimationFrame: callback => {
+  #|       fixture.pendingFrame = callback
+  #|       return 1
+  #|     },
+  #|   }
+  #|   globalThis.CSS = {
+  #|     supports: (property, value) => {
+  #|       fixture.supportsQueries.push(`${property}:${value}`)
+  #|       return property !== "position-area"
+  #|     },
+  #|   }
+  #|   globalThis.getComputedStyle = () => ({ direction: "ltr" })
+  #|   globalThis.requestAnimationFrame = callback => {
+  #|     fixture.pendingFrame = callback
+  #|     return 1
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_submenu_position_value(key : String) -> String =
+  #| key => globalThis.__ruiSubmenuPositionFixture?.props?.[key] || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_submenu_position_side() -> String =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSubmenuPositionFixture
+  #|   const root = globalThis.document?.getElementById?.("submenu-root")
+  #|   const content = root?.querySelectorAll?.("[data-submenu-owner]")?.[0]
+  #|   return content?.dataset?.side || ""
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_submenu_fixture_open() -> Bool =
+  #| () => Boolean(globalThis.__ruiSubmenuPositionFixture?.submenuOpen)
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_submenu_fixture_show_count() -> Int =
+  #| () => globalThis.__ruiSubmenuPositionFixture?.showCount || 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_implicitly_close_submenu_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSubmenuPositionFixture
+  #|   if (fixture) fixture.submenuOpen = false
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_submenu_visibility_snapshot(kind : String) -> String =
+  #| kind => globalThis.__ruiSubmenuPositionFixture?.visibilitySnapshots?.[kind] || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_submenu_css_support_queries() -> String =
+  #| () => globalThis.__ruiSubmenuPositionFixture?.supportsQueries?.join("|") || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mark_submenu_fixture_closed() -> Unit =
+  #| () => {
+  #|   const root = globalThis.document?.getElementById?.("submenu-root")
+  #|   const content = root?.querySelectorAll?.("[data-submenu-owner]")?.[0]
+  #|   if (content) content.dataset.state = "closed"
+  #|   // A state render rewrites the authored style attribute and therefore
+  #|   // clears compatibility-fallback custom properties. The closing pass
+  #|   // must restore them before hidePopover() starts the exit transition.
+  #|   const props = globalThis.__ruiSubmenuPositionFixture?.props
+  #|   if (props) {
+  #|     delete props["--rui-submenu-left"]
+  #|     delete props["--rui-submenu-top"]
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_move_and_scroll_submenu_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSubmenuPositionFixture
+  #|   fixture.triggerRect = { left: 20, right: 52, top: 40, bottom: 72 }
+  #|   fixture.listeners.scroll?.()
+  #|   const frame = fixture.pendingFrame
+  #|   fixture.pendingFrame = null
+  #|   frame?.()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_submenu_position_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSubmenuPositionFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("CSS", fixture.hadCss, fixture.css)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore("getComputedStyle", fixture.hadComputed, fixture.computed)
+  #|   restore("requestAnimationFrame", fixture.hadRaf, fixture.raf)
+  #|   delete globalThis.__ruiSubmenuPositionFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "submenu fallback flips at viewport edges and follows scroll" {
+  ffi_install_submenu_position_fixture("submenu-root")
+  position_menu_submenus("submenu-root")
+  let support_queries = ffi_submenu_css_support_queries()
+  let opened = ffi_submenu_fixture_open()
+  let first_side = ffi_submenu_position_side()
+  let first_left = ffi_submenu_position_value("--rui-submenu-left")
+  let first_top = ffi_submenu_position_value("--rui-submenu-top")
+  let shown_at = ffi_submenu_visibility_snapshot("show")
+  ffi_move_and_scroll_submenu_fixture()
+  let moved_side = ffi_submenu_position_side()
+  let moved_left = ffi_submenu_position_value("--rui-submenu-left")
+  let moved_top = ffi_submenu_position_value("--rui-submenu-top")
+  ffi_mark_submenu_fixture_closed()
+  position_menu_submenus("submenu-root")
+  let hidden_at = ffi_submenu_visibility_snapshot("hide")
+  let closed = !ffi_submenu_fixture_open()
+  ffi_restore_submenu_position_fixture()
+  assert_true(opened)
+  assert_true(
+    support_queries.contains("position-area:inline-end span-block-end"),
+  )
+  assert_eq(first_side, "left")
+  assert_eq(first_left, "156px")
+  assert_eq(first_top, "132px")
+  assert_eq(shown_at, "156px,132px")
+  assert_eq(moved_side, "right")
+  assert_eq(moved_left, "56px")
+  assert_eq(moved_top, "40px")
+  assert_eq(hidden_at, "56px,40px")
+  assert_true(closed)
+}
+
+///|
+#cfg(target="js")
+test "submenu reopens after the browser implicitly closes its popover" {
+  ffi_install_submenu_position_fixture("submenu-reopen-root")
+  position_menu_submenus("submenu-reopen-root")
+  let first_show_count = ffi_submenu_fixture_show_count()
+  ffi_implicitly_close_submenu_fixture()
+  position_menu_submenus("submenu-reopen-root")
+  let second_show_count = ffi_submenu_fixture_show_count()
+  let reopened = ffi_submenu_fixture_open()
+  ffi_restore_submenu_position_fixture()
+  assert_eq(first_show_count, 1)
+  assert_eq(second_show_count, 2)
+  assert_true(reopened)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_menu_focus_dom_fixture(
+  id : String,
+  delayed : Bool,
+) -> Unit =
+  #| (id, delayed) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   globalThis.__ruiMenuFocusFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     visible: !delayed,
+  #|     focusedIndex: -1,
+  #|   }
+  #|   const fixture = globalThis.__ruiMenuFocusFixture
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   const makeItem = index => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     dataset: { menuIndex: String(index) },
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? String(index) : "",
+  #|     closest: () => null,
+  #|     getClientRects: () => fixture.visible ? [{}] : [],
+  #|     focus() {
+  #|       fixture.focusedIndex = index
+  #|       globalThis.document.activeElement = this
+  #|     },
+  #|   })
+  #|   const items = [makeItem(7), makeItem(9)]
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     dataset: { state: "open" },
+  #|     getAttribute: name => name === "data-state" ? "open" : "",
+  #|     querySelectorAll: () => items,
+  #|   }
+  #|   globalThis.document = {
+  #|     activeElement: null,
+  #|     getElementById: value => value === id ? root : null,
+  #|   }
+  #|   const getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     fixture.visible = true
+  #|     callback(1)
+  #|     return 1
+  #|   }
+  #|   globalThis.window = {
+  #|     getComputedStyle,
+  #|     requestAnimationFrame,
+  #|     setTimeout: () => 1,
+  #|     clearTimeout: () => {},
+  #|     performance: { now: () => 1 },
+  #|   }
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #| }
+
+///|
+#cfg(target="js")
+fn install_menu_focus_fixture(
+  id : String,
+  delayed : Bool,
+  edge : String,
+) -> Unit {
+  ffi_install_menu_focus_dom_fixture(id, delayed)
+  if edge == "" {
+    menu_pending_edges.remove(id)
+  } else {
+    menu_pending_edges[id] = edge
+  }
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menu_focus_fixture_index() -> Int =
+  #| () => globalThis.__ruiMenuFocusFixture?.focusedIndex ?? -1
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_menu_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenuFocusFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore("KeyboardEvent", fixture.hadKeyboardEvent, fixture.KeyboardEvent)
+  #|   restore(
+  #|     "requestAnimationFrame",
+  #|     fixture.hadRequestAnimationFrame,
+  #|     fixture.requestAnimationFrame,
+  #|   )
+  #|   restore("getComputedStyle", fixture.hadGetComputedStyle, fixture.getComputedStyle)
+  #|   delete globalThis.__ruiMenuFocusFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_menu_trigger_focus_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const listeners = {}
+  #|   const fixture = globalThis.__ruiMenuFocusFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     focusedIndex: -1,
+  #|     invalidated: false,
+  #|     listeners,
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   globalThis.KeyboardEvent = function KeyboardEvent() {}
+  #|   const contentId = `${id}-content`
+  #|   const content = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     querySelectorAll: () => [item],
+  #|   })
+  #|   const item = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     textContent: "New tab",
+  #|     dataset: { menuIndex: "7" },
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? "7" : "",
+  #|     getClientRects: () => [{}],
+  #|     closest: selector => selector === '[role="menu"]' ? content : null,
+  #|     focus: () => {
+  #|       if (!fixture.invalidated) fixture.focusedIndex = 7
+  #|     },
+  #|   })
+  #|   const trigger = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "aria-controls" ? contentId : "",
+  #|     closest: selector => selector === '[data-slot="dropdown-menu-trigger"]'
+  #|       ? trigger
+  #|       : null,
+  #|     click: () => { root.dataset.state = "open" },
+  #|   })
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     dataset: { state: "closed" },
+  #|     getAttribute: name => name === "data-state" ? root.dataset.state : "",
+  #|     querySelectorAll: () => [],
+  #|     addEventListener: (type, callback) => { listeners[type] = callback },
+  #|   }
+  #|   globalThis.document = {
+  #|     getElementById: value => value === id ? root : value === contentId ? content : null,
+  #|   }
+  #|   const getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     callback(1)
+  #|     return 1
+  #|   }
+  #|   globalThis.window = {
+  #|     getComputedStyle,
+  #|     requestAnimationFrame,
+  #|     setTimeout: () => 1,
+  #|     clearTimeout: () => {},
+  #|     performance: { now: () => 1 },
+  #|   }
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #|   fixture.trigger = trigger
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_invalidate_menu_focus_fixture_item() -> Unit =
+  #| () => { globalThis.__ruiMenuFocusFixture.invalidated = true }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_menu_trigger_arrow_down() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenuFocusFixture
+  #|   fixture.listeners.keydown(Object.assign(new globalThis.KeyboardEvent(), {
+  #|     key: "ArrowDown",
+  #|     target: fixture.trigger,
+  #|     defaultPrevented: false,
+  #|     preventDefault() { this.defaultPrevented = true },
+  #|   }))
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_menubar_switch_focus_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     id,
+  #|     listeners: {},
+  #|     frames: 0,
+  #|     liveFocuses: 0,
+  #|     rtl: false,
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   globalThis.KeyboardEvent = function KeyboardEvent() {}
+  #|   const trigger = index => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     dataset: { menubarIndex: String(index), menubarValue: `menu-${index}` },
+  #|     hasAttribute: () => false,
+  #|     getAttribute(name) {
+  #|       if (name === "data-menubar-index") return String(index)
+  #|       if (name === "data-menubar-value") return `menu-${index}`
+  #|       if (name === "data-state") return this.dataset.state || ""
+  #|       return ""
+  #|     },
+  #|     closest(selector) {
+  #|       return selector === '[data-slot="menubar-trigger"]' ? this : null
+  #|     },
+  #|     focus() { globalThis.document.activeElement = this },
+  #|   })
+  #|   const oldTrigger = trigger(0)
+  #|   const nextTrigger = trigger(1)
+  #|   const oldContent = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     dataset: { menubarIndex: "0", menubarValue: "menu-0" },
+  #|     addEventListener() {},
+  #|     getAttribute: name => name === "data-menubar-index" ? "0"
+  #|       : name === "data-menubar-value" ? "menu-0" : "",
+  #|     matches: () => true,
+  #|   })
+  #|   const liveContent = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     dataset: { menubarIndex: "1", menubarValue: "menu-1", state: "open" },
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menubar-index" ? "1"
+  #|       : name === "data-menubar-value" ? "menu-1"
+  #|       : name === "data-state" ? "open" : "",
+  #|     getClientRects: () => [{}],
+  #|     closest: () => null,
+  #|   })
+  #|   const liveItem = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     dataset: { menuIndex: "4" },
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? "4" : "",
+  #|     getClientRects: () => [{}],
+  #|     closest: selector => selector === '[role="menu"]' ? liveContent : null,
+  #|     focus() {
+  #|       fixture.liveFocuses += 1
+  #|       globalThis.document.activeElement = fixture.liveFocuses === 1
+  #|         ? fixture.oldTrigger
+  #|         : this
+  #|     },
+  #|   })
+  #|   liveContent.querySelectorAll = selector => selector === "[data-menu-index]"
+  #|     ? [liveItem]
+  #|     : []
+  #|   const oldItem = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     dataset: { menuIndex: "0" },
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? "0" : "",
+  #|     closest: selector => {
+  #|       if (selector === '[data-slot="menubar-content"]') return oldContent
+  #|       if (selector === "[data-menu-index]") return oldItem
+  #|       return null
+  #|     },
+  #|   })
+  #|   const oldRoot = {
+  #|     nodeType: 1,
+  #|     dataset: { state: "open" },
+  #|     getAttribute: name => name === "data-state" ? "open" : "",
+  #|     querySelectorAll(selector) {
+  #|       if (selector === '[data-slot="menubar-trigger"]') return [oldTrigger, nextTrigger]
+  #|       if (selector === '[data-slot="menubar-content"]') return [oldContent]
+  #|       return []
+  #|     },
+  #|     addEventListener(type, callback) { fixture.listeners[type] = callback },
+  #|   }
+  #|   const liveRoot = {
+  #|     nodeType: 1,
+  #|     querySelectorAll: selector => selector === '[data-slot="menubar-content"]'
+  #|       ? [liveContent]
+  #|       : [],
+  #|   }
+  #|   fixture.oldRoot = oldRoot
+  #|   fixture.liveRoot = oldRoot
+  #|   fixture.nextRoot = liveRoot
+  #|   fixture.oldTrigger = oldTrigger
+  #|   fixture.nextTrigger = nextTrigger
+  #|   fixture.liveItem = liveItem
+  #|   globalThis.document = {
+  #|     activeElement: null,
+  #|     getElementById: value => value === id ? fixture.liveRoot : null,
+  #|   }
+  #|   const getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "direction" ? fixture.rtl ? "rtl" : "ltr"
+  #|       : name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     fixture.frames += 1
+  #|     if (fixture.frames === 1) globalThis.document.activeElement = oldTrigger
+  #|     callback(fixture.frames)
+  #|     return fixture.frames
+  #|   }
+  #|   globalThis.window = {
+  #|     getComputedStyle,
+  #|     requestAnimationFrame,
+  #|     performance: { now: () => 10 },
+  #|   }
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #|   fixture.event = Object.assign(new globalThis.KeyboardEvent(), {
+  #|     key: "ArrowRight",
+  #|     target: oldItem,
+  #|     defaultPrevented: false,
+  #|     preventDefault() { this.defaultPrevented = true },
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_switch_mount_next() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   fixture.liveRoot = fixture.nextRoot
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_menubar_switch_right() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   fixture.listeners.keydown(fixture.event)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_menubar_switch_hover() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   globalThis.document.activeElement = fixture.oldTrigger
+  #|   fixture.listeners.pointermove({
+  #|     target: fixture.nextTrigger,
+  #|     timeStamp: 10,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_make_menubar_switch_rtl() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   fixture.event.key = "ArrowLeft"
+  #|   fixture.rtl = true
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_switch_has_live_focus() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   return globalThis.document.activeElement === fixture.liveItem
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_switch_has_next_trigger_focus() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   return globalThis.document.activeElement === fixture.nextTrigger
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_switch_live_focuses() -> Int =
+  #| () => globalThis.__ruiMenubarSwitchFixture.liveFocuses
+
+///|
+#cfg(target="js")
+fn age_menubar_hover_switch(id : String, elapsed : Int) -> Unit {
+  if menubar_hover_switches.get(id) is Some(switched) {
+    menubar_hover_switches[id] = {
+      value: switched.value,
+      index: switched.index,
+      at: switched.at - elapsed.to_double(),
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_menubar_switch_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarSwitchFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore("KeyboardEvent", fixture.hadKeyboardEvent, fixture.KeyboardEvent)
+  #|   restore(
+  #|     "requestAnimationFrame",
+  #|     fixture.hadRequestAnimationFrame,
+  #|     fixture.requestAnimationFrame,
+  #|   )
+  #|   restore("getComputedStyle", fixture.hadGetComputedStyle, fixture.getComputedStyle)
+  #|   delete globalThis.__ruiMenubarSwitchFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_menu_item_replacement_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiMenuItemReplacementFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     generation: 0,
+  #|     focuses: 0,
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   const body = Object.assign(new globalThis.HTMLElement(), { nodeType: 1 })
+  #|   const oldContent = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     dataset: { state: "closed" },
+  #|     getAttribute: name => name === "data-state" ? "closed" : "",
+  #|   })
+  #|   const content = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     dataset: { state: "open" },
+  #|     contains: node => node === content,
+  #|   })
+  #|   const makeItem = generation => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     isConnected: true,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? "0" : "",
+  #|     getClientRects: () => [{}],
+  #|     closest: selector => selector === '[role="menu"]' ? content : null,
+  #|     focus() {
+  #|       fixture.focuses += 1
+  #|       globalThis.document.activeElement = this
+  #|       if (generation === 0) {
+  #|         fixture.generation = 1
+  #|         this.isConnected = false
+  #|         globalThis.document.activeElement = body
+  #|       }
+  #|     },
+  #|   })
+  #|   fixture.items = [makeItem(0), makeItem(1)]
+  #|   const oldItem = Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     isConnected: true,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? "0" : "",
+  #|     getClientRects: () => [{}],
+  #|     closest: selector => selector === '[role="menu"]' ? oldContent : null,
+  #|     focus() { globalThis.document.activeElement = this },
+  #|   })
+  #|   content.querySelectorAll = () => [fixture.items[fixture.generation]]
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     querySelectorAll: () => [oldItem, fixture.items[fixture.generation]],
+  #|   }
+  #|   globalThis.document = {
+  #|     body,
+  #|     activeElement: body,
+  #|     getElementById: value => value === id
+  #|       ? root
+  #|       : value === `${id}-content` ? content : null,
+  #|   }
+  #|   const getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     callback(1)
+  #|     return 1
+  #|   }
+  #|   globalThis.window = { getComputedStyle, requestAnimationFrame }
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menu_item_replacement_is_focused() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenuItemReplacementFixture
+  #|   return fixture.generation === 1
+  #|     && globalThis.document.activeElement === fixture.items[1]
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menu_item_replacement_focuses() -> Int =
+  #| () => globalThis.__ruiMenuItemReplacementFixture.focuses
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_menu_item_replacement_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenuItemReplacementFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore(
+  #|     "requestAnimationFrame",
+  #|     fixture.hadRequestAnimationFrame,
+  #|     fixture.requestAnimationFrame,
+  #|   )
+  #|   restore("getComputedStyle", fixture.hadGetComputedStyle, fixture.getComputedStyle)
+  #|   delete globalThis.__ruiMenuItemReplacementFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_menubar_nested_focus_fixture(
+  id : String,
+  active_content_id : String,
+  inactive_content_id : String,
+  index : Int,
+) -> Unit =
+  #| (id, activeContentId, inactiveContentId, index) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiMenubarNestedFocusFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     activeFocuses: 0,
+  #|     inactiveFocuses: 0,
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   const activeContent = Object.assign(new globalThis.HTMLElement(), { nodeType: 1 })
+  #|   const inactiveContent = Object.assign(new globalThis.HTMLElement(), { nodeType: 1 })
+  #|   const nestedMenu = Object.assign(new globalThis.HTMLElement(), { nodeType: 1 })
+  #|   const makeItem = (owner, focus) => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     isConnected: true,
+  #|     dataset: { menuIndex: String(index) },
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-menu-index" ? String(index) : "",
+  #|     getClientRects: () => [{}],
+  #|     closest: selector => selector === '[role="menu"]' ? owner : null,
+  #|     focus,
+  #|   })
+  #|   const inactiveItem = makeItem(inactiveContent, function() {
+  #|     fixture.inactiveFocuses += 1
+  #|     globalThis.document.activeElement = this
+  #|   })
+  #|   const activeItem = makeItem(nestedMenu, function() {
+  #|     fixture.activeFocuses += 1
+  #|     globalThis.document.activeElement = this
+  #|   })
+  #|   activeContent.querySelectorAll = () => [activeItem]
+  #|   activeContent.contains = node => node === nestedMenu || node === activeItem
+  #|   inactiveContent.querySelectorAll = () => [inactiveItem]
+  #|   inactiveContent.contains = node => node === inactiveItem
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     querySelectorAll: () => [inactiveItem, activeItem],
+  #|   }
+  #|   fixture.activeItem = activeItem
+  #|   fixture.inactiveItem = inactiveItem
+  #|   globalThis.document = {
+  #|     activeElement: null,
+  #|     getElementById: value => value === id
+  #|       ? root
+  #|       : value === activeContentId
+  #|         ? activeContent
+  #|         : value === inactiveContentId ? inactiveContent : null,
+  #|   }
+  #|   const getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     callback(1)
+  #|     return 1
+  #|   }
+  #|   globalThis.window = { getComputedStyle, requestAnimationFrame }
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_nested_item_is_focused() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarNestedFocusFixture
+  #|   return globalThis.document.activeElement === fixture.activeItem
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_nested_active_focuses() -> Int =
+  #| () => globalThis.__ruiMenubarNestedFocusFixture.activeFocuses
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_menubar_nested_inactive_focuses() -> Int =
+  #| () => globalThis.__ruiMenubarNestedFocusFixture.inactiveFocuses
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_menubar_nested_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiMenubarNestedFocusFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore(
+  #|     "requestAnimationFrame",
+  #|     fixture.hadRequestAnimationFrame,
+  #|     fixture.requestAnimationFrame,
+  #|   )
+  #|   restore("getComputedStyle", fixture.hadGetComputedStyle, fixture.getComputedStyle)
+  #|   delete globalThis.__ruiMenubarNestedFocusFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "focus-first retries after the popover becomes visible" {
+  let found = Ref(-1)
+  install_menu_focus_fixture("delayed-menu", true, "")
+  focus_first_menu_item("delayed-menu", index => found.val = index)
+  let focused = ffi_menu_focus_fixture_index()
+  ffi_restore_menu_focus_fixture()
+  assert_eq(found.val, 7)
+  assert_eq(focused, 7)
+}
+
+///|
+#cfg(target="js")
+test "focus-first preserves the pending ArrowUp edge" {
+  let found = Ref(-1)
+  install_menu_focus_fixture("last-edge-menu", false, "last")
+  focus_first_menu_item("last-edge-menu", index => found.val = index)
+  let focused = ffi_menu_focus_fixture_index()
+  ffi_restore_menu_focus_fixture()
+  assert_eq(found.val, 9)
+  assert_eq(focused, 9)
+}
+
+///|
+#cfg(target="js")
+test "trigger edge focuses before an active-state render can replace the item" {
+  ffi_install_menu_trigger_focus_fixture("trigger-edge-menu")
+  bind_menu_surface("trigger-edge-menu", (kind, _, _, _) => {
+    if kind == 0 {
+      ffi_invalidate_menu_focus_fixture_item()
+    }
+  })
+  ffi_fire_menu_trigger_arrow_down()
+  let focused = ffi_menu_focus_fixture_index()
+  ffi_restore_menu_focus_fixture()
+  assert_eq(focused, 7)
+}
+
+///|
+#cfg(target="js")
+test "menubar horizontal switch resolves live content and survives focus restore" {
+  ffi_install_menubar_switch_focus_fixture("switching-menubar")
+  bind_menubar(
+    "switching-menubar",
+    (_, _, focus_content) => {
+      ffi_menubar_switch_mount_next()
+      if focus_content {
+        ui_after_ready("test-menubar-focus", () => {
+          focus_menubar_content("switching-menubar", 1)
+        })
+      }
+    },
+    (_, _, _) => (),
+    () => (),
+    _ => (),
+  )
+  ffi_fire_menubar_switch_right()
+  let focused = ffi_menubar_switch_has_live_focus()
+  let focus_count = ffi_menubar_switch_live_focuses()
+  ffi_restore_menubar_switch_focus_fixture()
+  assert_true(focused)
+  assert_true(focus_count >= 2)
+}
+
+///|
+#cfg(target="js")
+test "menubar horizontal switch follows RTL inline direction" {
+  ffi_install_menubar_switch_focus_fixture("rtl-switching-menubar")
+  ffi_make_menubar_switch_rtl()
+  bind_menubar(
+    "rtl-switching-menubar",
+    (_, _, focus_content) => {
+      ffi_menubar_switch_mount_next()
+      if focus_content {
+        ui_after_ready("test-rtl-menubar-focus", () => {
+          focus_menubar_content("rtl-switching-menubar", 1)
+        })
+      }
+    },
+    (_, _, _) => (),
+    () => (),
+    _ => (),
+  )
+  ffi_fire_menubar_switch_right()
+  let focused = ffi_menubar_switch_has_live_focus()
+  ffi_restore_menubar_switch_focus_fixture()
+  assert_true(focused)
+}
+
+///|
+#cfg(target="js")
+test "menubar hover switch transfers focus to the newly active trigger" {
+  ffi_install_menubar_switch_focus_fixture("hover-switching-menubar")
+  let activated = Ref("")
+  bind_menubar(
+    "hover-switching-menubar",
+    (value, _, _) => activated.val = value,
+    (_, _, _) => (),
+    () => (),
+    _ => (),
+  )
+  ffi_fire_menubar_switch_hover()
+  let focused = ffi_menubar_switch_has_next_trigger_focus()
+  ffi_restore_menubar_switch_focus_fixture()
+  assert_true(focused)
+  assert_eq(activated.val, "menu-1")
+}
+
+///|
+#cfg(target="js")
+test "menubar click confirms an immediately hover-switched trigger" {
+  let id = "hover-click-switching-menubar"
+  ffi_install_menubar_switch_focus_fixture(id)
+  bind_menubar(id, (_, _, _) => (), (_, _, _) => (), () => (), _ => ())
+  ffi_fire_menubar_switch_hover()
+  let first_click_toggles = menubar_should_toggle(
+    id,
+    Some("menu-1"),
+    "menu-1",
+    1,
+  )
+  let second_click_toggles = menubar_should_toggle(
+    id,
+    Some("menu-1"),
+    "menu-1",
+    1,
+  )
+  ffi_restore_menubar_switch_focus_fixture()
+  assert_false(first_click_toggles)
+  assert_true(second_click_toggles)
+}
+
+///|
+#cfg(target="js")
+test "menubar click still switches when hover activation has not committed" {
+  let id = "pending-hover-click-menubar"
+  ffi_install_menubar_switch_focus_fixture(id)
+  bind_menubar(id, (_, _, _) => (), (_, _, _) => (), () => (), _ => ())
+  ffi_fire_menubar_switch_hover()
+  let click_toggles = menubar_should_toggle(id, Some("menu-0"), "menu-1", 1)
+  let current_trigger_toggles = menubar_should_toggle(
+    id,
+    Some("menu-1"),
+    "menu-1",
+    1,
+  )
+  ffi_restore_menubar_switch_focus_fixture()
+  assert_true(click_toggles)
+  assert_true(current_trigger_toggles)
+}
+
+///|
+#cfg(target="js")
+test "menubar expired hover switch lets the current trigger close" {
+  let id = "expired-hover-click-menubar"
+  ffi_install_menubar_switch_focus_fixture(id)
+  bind_menubar(id, (_, _, _) => (), (_, _, _) => (), () => (), _ => ())
+  ffi_fire_menubar_switch_hover()
+  age_menubar_hover_switch(id, MenubarHoverClickWindowMs + 1)
+  let click_toggles = menubar_should_toggle(id, Some("menu-1"), "menu-1", 1)
+  ffi_restore_menubar_switch_focus_fixture()
+  assert_true(click_toggles)
+}
+
+///|
+#cfg(target="js")
+test "menu item focus stays in active content after its focused node is replaced" {
+  ffi_install_menu_item_replacement_fixture("replacing-menu")
+  ui_after_ready("test-replacing-menu-item", () => {
+    focus_menu_item("replacing-menu", "replacing-menu-content", 0)
+  })
+  let focused = ffi_menu_item_replacement_is_focused()
+  let focus_count = ffi_menu_item_replacement_focuses()
+  ffi_restore_menu_item_replacement_fixture()
+  assert_true(focused)
+  assert_eq(focus_count, 2)
+}
+
+///|
+#cfg(target="js")
+test "menubar item focus includes nested menus but stays in active content" {
+  let id = "scoped-menubar"
+  let active_content_id = id + "-content-1"
+  let inactive_content_id = id + "-content-0"
+  let shared_index = 3
+  ffi_install_menubar_nested_focus_fixture(
+    id, active_content_id, inactive_content_id, shared_index,
+  )
+  ui_after_ready("test-menubar-nested-focus", () => {
+    focus_menu_item(id, active_content_id, shared_index)
+  })
+  let focused = ffi_menubar_nested_item_is_focused()
+  let active_focuses = ffi_menubar_nested_active_focuses()
+  let inactive_focuses = ffi_menubar_nested_inactive_focuses()
+  ffi_restore_menubar_nested_focus_fixture()
+  assert_true(focused)
+  assert_eq(active_focuses, 1)
+  assert_eq(inactive_focuses, 0)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_rtl_menu_keyboard_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiRtlMenuKeyboardFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     computed: globalThis.getComputedStyle,
+  #|     hadComputed: own("getComputedStyle"),
+  #|     raf: globalThis.requestAnimationFrame,
+  #|     hadRaf: own("requestAnimationFrame"),
+  #|     listeners: {},
+  #|     dispatched: [],
+  #|     frames: [],
+  #|     submenuReady: false,
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   globalThis.KeyboardEvent = function KeyboardEvent() {}
+  #|   const dataKey = name => name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|   const visible = () => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     isConnected: true,
+  #|     dataset: {},
+  #|     hasAttribute: () => false,
+  #|     getAttribute(name) {
+  #|       if (name === "aria-expanded") return "false"
+  #|       return name.startsWith("data-") ? this.dataset[dataKey(name)] ?? "" : ""
+  #|     },
+  #|     closest: () => null,
+  #|     getClientRects: () => [{}],
+  #|     focus() { globalThis.document.activeElement = this },
+  #|   })
+  #|   const menu = {
+  #|     nodeType: 1,
+  #|     getAttribute: () => "",
+  #|     querySelectorAll(selector) {
+  #|       if (selector === "[data-menu-index]") return [item]
+  #|       if (selector === "[data-menu-index][data-submenu-key]") return [item]
+  #|       return []
+  #|     },
+  #|   }
+  #|   const submenu = Object.assign(visible(), {
+  #|     dataset: { submenuOwner: "rtl-submenu" },
+  #|     querySelectorAll: () => [child],
+  #|     getClientRects: () => fixture.submenuReady ? [{}] : [],
+  #|   })
+  #|   const item = Object.assign(visible(), {
+  #|     dataset: { menuIndex: "3", submenuKey: "rtl-submenu" },
+  #|     closest(selector) {
+  #|       if (selector === "[data-menu-index]") return item
+  #|       if (selector === '[role="menu"]') return menu
+  #|       if (selector === "[data-submenu-owner]") return null
+  #|       return null
+  #|     },
+  #|   })
+  #|   const child = Object.assign(visible(), {
+  #|     dataset: { menuIndex: "4" },
+  #|     closest(selector) {
+  #|       if (selector === "[data-menu-index]") return child
+  #|       if (selector === '[role="menu"]') return submenu
+  #|       if (selector === "[data-submenu-owner]") return submenu
+  #|       return null
+  #|     },
+  #|   })
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     getAttribute: () => "",
+  #|     querySelectorAll(selector) {
+  #|       if (selector === "[data-submenu-owner]") return [submenu]
+  #|       if (selector === "[data-menu-index][data-submenu-key]") return [item]
+  #|       return []
+  #|     },
+  #|     addEventListener(type, callback) { fixture.listeners[type] = callback },
+  #|   }
+  #|   fixture.item = item
+  #|   fixture.child = child
+  #|   globalThis.document = {
+  #|     activeElement: null,
+  #|     getElementById: value => value === id ? root : null,
+  #|   }
+  #|   const getComputedStyle = () => ({
+  #|     getPropertyValue: name => name === "direction" ? "rtl"
+  #|       : name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     fixture.frames.push(callback)
+  #|     return fixture.frames.length
+  #|   }
+  #|   globalThis.window = {
+  #|     getComputedStyle,
+  #|     requestAnimationFrame,
+  #|     setTimeout: () => 1,
+  #|     clearTimeout: () => {},
+  #|     performance: { now: () => 1 },
+  #|   }
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_rtl_menu_key(target : Int, key : String) -> Bool =
+  #| (target, key) => {
+  #|   const fixture = globalThis.__ruiRtlMenuKeyboardFixture
+  #|   const event = Object.assign(new globalThis.KeyboardEvent(), {
+  #|     key,
+  #|     target: target === 0 ? fixture.item : fixture.child,
+  #|     defaultPrevented: false,
+  #|     metaKey: false,
+  #|     ctrlKey: false,
+  #|     altKey: false,
+  #|     preventDefault() { this.defaultPrevented = true },
+  #|     stopPropagation() {},
+  #|   })
+  #|   fixture.listeners.keydown(event)
+  #|   return event.defaultPrevented
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_rtl_menu_dispatch_at(index : Int) -> Int =
+  #| index => globalThis.__ruiRtlMenuKeyboardFixture?.dispatched?.[index] ?? -1
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_run_rtl_menu_frame(ready : Bool) -> Unit =
+  #| ready => {
+  #|   const fixture = globalThis.__ruiRtlMenuKeyboardFixture
+  #|   fixture.submenuReady = ready
+  #|   fixture.frames.shift()?.()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_rtl_menu_focused(target : Int) -> Bool =
+  #| target => {
+  #|   const fixture = globalThis.__ruiRtlMenuKeyboardFixture
+  #|   const expected = target === 0 ? fixture.item : fixture.child
+  #|   return globalThis.document.activeElement === expected
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_rtl_menu_keyboard_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiRtlMenuKeyboardFixture
+  #|   if (!fixture) return
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore("KeyboardEvent", fixture.hadKeyboardEvent, fixture.KeyboardEvent)
+  #|   restore("getComputedStyle", fixture.hadComputed, fixture.computed)
+  #|   restore("requestAnimationFrame", fixture.hadRaf, fixture.raf)
+  #|   delete globalThis.__ruiRtlMenuKeyboardFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "submenu horizontal keys follow RTL inline direction" {
+  ffi_install_rtl_menu_keyboard_fixture("rtl-menu")
+  bind_menu_surface("rtl-menu", (kind, _, _, _) => {
+    ffi_rtl_menu_record_dispatch(kind)
+  })
+  let opened = ffi_fire_rtl_menu_key(0, "ArrowLeft")
+  let closed = ffi_fire_rtl_menu_key(1, "ArrowRight")
+  let first = ffi_rtl_menu_dispatch_at(0)
+  let second = ffi_rtl_menu_dispatch_at(1)
+  ffi_restore_rtl_menu_keyboard_fixture()
+  assert_true(opened)
+  assert_true(closed)
+  assert_eq(first, 4)
+  assert_eq(second, 3)
+}
+
+///|
+#cfg(target="js")
+test "submenu focus waits for its own content instead of falling back to root" {
+  ffi_install_rtl_menu_keyboard_fixture("delayed-rtl-submenu")
+  bind_menu_surface("delayed-rtl-submenu", (kind, _, _, _) => {
+    ffi_rtl_menu_record_dispatch(kind)
+  })
+  ignore(ffi_fire_rtl_menu_key(0, "ArrowLeft"))
+  ffi_run_rtl_menu_frame(false)
+  let root_focused_while_missing = ffi_rtl_menu_focused(0)
+  ffi_run_rtl_menu_frame(true)
+  let child_focused = ffi_rtl_menu_focused(1)
+  ffi_restore_rtl_menu_keyboard_fixture()
+  assert_false(root_focused_while_missing)
+  assert_true(child_focused)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_rtl_menu_record_dispatch(kind : Int) -> Unit =
+  #| kind => globalThis.__ruiRtlMenuKeyboardFixture?.dispatched?.push(kind)

--- a/rui/menu_internal.mbt
+++ b/rui/menu_internal.mbt
@@ -1,0 +1,1711 @@
+///|
+struct MenuCoreModel {
+  open : Bool
+  active : Int
+  checked : Array[String]
+  radios : Array[(String, String)]
+  submenus : Array[String]
+} derive(Eq)
+
+///|
+enum MenuSubmenuChange {
+  MenuOpenSubmenu(String)
+  MenuSwitchSubmenu(String, String)
+  MenuCloseSubmenu(String)
+  MenuCloseSubmenusUnder(String)
+  MenuCloseAllSubmenus
+} derive(Eq)
+
+///|
+struct MenuScope {
+  id : String
+  content_id : String
+  trigger_id : String
+  model : MenuCoreModel
+  counter : Ref[Int]
+  open_command : @cmd.Cmd
+  close_command : @cmd.Cmd
+  toggle_command : @cmd.Cmd
+  set_active : @cmd.Emit[Int]
+  toggle_checked : @cmd.Emit[String]
+  set_radio : @cmd.Emit[(String, String)]
+  set_submenu : @cmd.Emit[MenuSubmenuChange]
+}
+
+///|
+enum MenuIndicatorPlacement {
+  MenuIndicatorInlineStart
+  MenuIndicatorInlineEnd
+} derive(Eq)
+
+///|
+const MenuRootStyle : String = "display:contents"
+
+///|
+const MenuContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:flex;width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem));max-width:calc(100vw - 1rem);max-height:var(--rui-menu-available-height,calc(100vh - 1rem));transform-origin:var(--rui-floating-transform-origin,center);flex-direction:column;gap:0.125rem;overflow-x:hidden;overflow-y:auto;margin:0;border:1px solid color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:0.25rem;color:var(--rui-popover-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem;box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const MenuSubContentStyle : String = "position:fixed;inset:auto;left:var(--rui-submenu-left,auto);top:var(--rui-submenu-top,auto);z-index:51;display:flex;width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem));max-width:min(18rem,calc(100vw - 1rem));max-height:calc(100vh - 1rem);transform-origin:var(--rui-floating-transform-origin,0% 0%);flex-direction:column;gap:0.125rem;overflow-x:hidden;overflow-y:auto;border:1px solid color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:0.25rem;color:var(--rui-popover-foreground,oklch(0.145 0 0));box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const MenuItemStyle : String = "position:relative;display:flex;width:100%;min-height:2rem;cursor:default;align-items:center;gap:0.5rem;border:0;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent));padding:0.375rem 0.5rem;color:var(--rui-menu-item-fg,var(--rui-menu-item-base-fg,inherit));font:inherit;line-height:1.25rem;text-align:start;white-space:nowrap;outline:none;user-select:none"
+
+///|
+const MenuItemInsetStyle : String = "padding-inline-start:2rem"
+
+///|
+const MenuItemDestructiveStyle : String = "--rui-menu-item-base-fg:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+
+///|
+const MenuItemHighlightedStyle : String = "--rui-menu-item-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-menu-item-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+
+///|
+const MenuLabelStyle : String = "padding:0.375rem 0.5rem;font-size:0.75rem;line-height:1rem;font-weight:500;color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+
+///|
+const MenuSeparatorStyle : String = "height:1px;margin:0.25rem -0.25rem;background:var(--rui-border,oklch(0.922 0 0));pointer-events:none"
+
+///|
+const MenuShortcutStyle : String = "margin-inline-start:auto;flex:none;padding-inline-start:1.5rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;letter-spacing:0.08em"
+
+///|
+const MenuItemEndIndicatorStyle : String = "padding-inline-end:2rem"
+
+///|
+const MenuIndicatorStartStyle : String = "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;font-size:0.75rem;line-height:1"
+
+///|
+const MenuIndicatorEndStyle : String = "position:absolute;inset-inline-end:0.5rem;display:inline-flex;width:1rem;height:1rem;align-items:center;justify-content:center;font-size:0.75rem;line-height:1;pointer-events:none"
+
+///|
+fn menu_core_model(
+  open : Bool,
+  checked : Array[String],
+  radios : Array[(String, String)],
+) -> MenuCoreModel {
+  { open, active: -1, checked, radios, submenus: [] }
+}
+
+///|
+fn menu_contains(values : Array[String], value : String) -> Bool {
+  for current in values {
+    if current == value {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn menu_toggle_value(values : Array[String], value : String) -> Array[String] {
+  let next : Array[String] = []
+  let mut found = false
+  for current in values {
+    if current == value {
+      found = true
+    } else {
+      next.push(current)
+    }
+  }
+  if !found {
+    next.push(value)
+  }
+  next
+}
+
+///|
+fn menu_submenu_open(values : Array[String], value : String) -> Bool {
+  menu_contains(values, value)
+}
+
+///|
+fn menu_update_submenus(
+  values : Array[String],
+  change : MenuSubmenuChange,
+) -> Array[String] {
+  match change {
+    MenuOpenSubmenu(value) =>
+      if menu_contains(values, value) {
+        values
+      } else {
+        let next = values.copy()
+        next.push(value)
+        next
+      }
+    MenuSwitchSubmenu(parent, value) =>
+      if parent == "" {
+        if values == [value] {
+          values
+        } else {
+          [value]
+        }
+      } else {
+        let next : Array[String] = []
+        for current in values {
+          next.push(current)
+          if current == parent {
+            next.push(value)
+            return if next == values { values } else { next }
+          }
+        }
+        values
+      }
+    MenuCloseSubmenu(value) => {
+      let next : Array[String] = []
+      for current in values {
+        if current == value {
+          return next
+        }
+        next.push(current)
+      }
+      values
+    }
+    MenuCloseSubmenusUnder(parent) =>
+      if parent == "" {
+        []
+      } else {
+        let next : Array[String] = []
+        for current in values {
+          next.push(current)
+          if current == parent {
+            return if next == values { values } else { next }
+          }
+        }
+        values
+      }
+    MenuCloseAllSubmenus => []
+  }
+}
+
+///|
+fn menu_submenu_key(scope : MenuScope, value : String) -> String {
+  scope.id + "::" + value + "::submenu-\{scope.counter.val}"
+}
+
+///|
+fn menu_submenu_anchor_style(key : String) -> String {
+  "position-anchor:\{popup_anchor_name(key)};position-area:inline-end span-block-end;position-try-fallbacks:flip-inline,flip-block,flip-inline flip-block;position-visibility:always;margin-inline-start:0.25rem;--rui-floating-transform-origin:0% 0%"
+}
+
+///|
+fn menu_submenu_trigger_id(key : String) -> String {
+  popup_anchor_name(key) + "-trigger"
+}
+
+///|
+fn menu_submenu_content_id(key : String) -> String {
+  popup_anchor_name(key) + "-content"
+}
+
+///|
+fn menu_radio_value(
+  radios : Array[(String, String)],
+  group : String,
+) -> String? {
+  for entry in radios {
+    if entry.0 == group {
+      return Some(entry.1)
+    }
+  }
+  None
+}
+
+///|
+fn menu_set_radio_value(
+  radios : Array[(String, String)],
+  group : String,
+  value : String,
+) -> Array[(String, String)] {
+  let next : Array[(String, String)] = []
+  let mut replaced = false
+  for entry in radios {
+    if entry.0 == group {
+      if !replaced {
+        next.push((group, value))
+        replaced = true
+      }
+    } else {
+      next.push(entry)
+    }
+  }
+  if !replaced {
+    next.push((group, value))
+  }
+  next
+}
+
+///|
+fn menu_scope_next_index(scope : MenuScope) -> Int {
+  let index = scope.counter.val
+  scope.counter.val += 1
+  index
+}
+
+///|
+fn[A] menu_noop_emit() -> @cmd.Emit[A] {
+  @cmd.Emit(_ => @cmd.none)
+}
+
+///|
+fn menu_state_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  open : Bool,
+) -> @html.Attrs {
+  popup_state_attrs(attrs, slot, open)
+}
+
+///|
+#cfg(target="js")
+priv struct MenuSurfaceBinding {
+  id : String
+  root : @dom.Element
+  dispatch : Ref[(Int, Int, String, String) -> Unit]
+  typeahead : Ref[String]
+  typeahead_at : Ref[Double]
+  typeahead_timer : Ref[Int]
+}
+
+///|
+#cfg(target="js")
+let menu_surface_bindings : Map[String, MenuSurfaceBinding] = Map([])
+
+///|
+#cfg(target="js")
+let menu_pending_edges : Map[String, String] = Map([])
+
+///|
+#cfg(target="js")
+fn menu_request_frame(callback : () -> Unit) -> Unit {
+  ui_after_request_frame(callback)
+}
+
+///|
+#cfg(target="js")
+fn menu_element_is_visible(element : @dom.Element) -> Bool {
+  if !ui_element_is_enabled(element) ||
+    element.closest("[hidden]") is Some(_) ||
+    element.closest("[inert]") is Some(_) ||
+    element.closest("[aria-hidden=\"true\"]") is Some(_) ||
+    element.get_client_rects().length() == 0 {
+    return false
+  }
+  if ui_has_window() {
+    let style = @dom.window().get_computed_style(element)
+    style.get_property_value("display") != "none" &&
+    style.get_property_value("visibility") != "hidden"
+  } else {
+    true
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_enabled_items(
+  binding : MenuSurfaceBinding,
+  container : @dom.Element?,
+) -> Array[@dom.Element] {
+  let scope = container.unwrap_or(binding.root)
+  scope
+  .query_selector_all("[data-menu-index]")
+  .filter(item => {
+    if !menu_element_is_visible(item) {
+      false
+    } else if container is Some(container) {
+      item.closest("[role=\"menu\"]") is Some(owner) &&
+      owner.is_same_node(container.as_node())
+    } else {
+      true
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn menu_send_active(binding : MenuSurfaceBinding, item : @dom.Element?) -> Unit {
+  if item is Some(item) && ui_element_is_enabled(item) {
+    let index = ui_parse_int_or(
+      item.get_attribute("data-menu-index").unwrap_or(""),
+      -1,
+    )
+    if index >= 0 {
+      (binding.dispatch.val)(0, index, "", "")
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_submenu_parent(item : @dom.Element) -> String {
+  if item.closest("[role=\"menu\"]") is Some(owner) {
+    owner.get_attribute("data-submenu-owner").unwrap_or("")
+  } else {
+    ""
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_focus_submenu_trigger(
+  binding : MenuSurfaceBinding,
+  key : String,
+) -> Unit {
+  menu_request_frame(() => {
+    let target = ui_find_element(
+      binding.root.query_selector_all("[data-menu-index][data-submenu-key]"),
+      node => {
+        node.get_attribute("data-submenu-key").unwrap_or("") == key &&
+        menu_element_is_visible(node)
+      },
+    )
+    if target is Some(target) {
+      ui_focus_element(target)
+      menu_send_active(binding, Some(target))
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn menu_focus_submenu_first(
+  binding : MenuSurfaceBinding,
+  key : String,
+  attempt : Int,
+) -> Unit {
+  menu_request_frame(() => {
+    let owner = ui_find_element(
+      binding.root.query_selector_all("[data-submenu-owner]"),
+      node => {
+        node.get_attribute("data-submenu-owner").unwrap_or("") == key &&
+        menu_element_is_visible(node)
+      },
+    )
+    if owner is Some(owner) {
+      if menu_enabled_items(binding, Some(owner)).get(0) is Some(target) {
+        ui_focus_element(target)
+        menu_send_active(binding, Some(target))
+      } else if attempt < 20 {
+        menu_focus_submenu_first(binding, key, attempt + 1)
+      }
+    } else if attempt < 20 {
+      menu_focus_submenu_first(binding, key, attempt + 1)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn menu_switch_submenu(
+  binding : MenuSurfaceBinding,
+  item : @dom.Element?,
+  focus_first : Bool,
+) -> Bool {
+  guard item is Some(item) else { return false }
+  let key = item.get_attribute("data-submenu-key").unwrap_or("")
+  if key == "" || !ui_element_is_enabled(item) {
+    return false
+  }
+  let index = ui_parse_int_or(
+    item.get_attribute("data-menu-index").unwrap_or(""),
+    -1,
+  )
+  (binding.dispatch.val)(4, index, key, menu_submenu_parent(item))
+  if focus_first {
+    menu_focus_submenu_first(binding, key, 0)
+  }
+  true
+}
+
+///|
+#cfg(target="js")
+fn menu_focus_dropdown_edge(
+  binding : MenuSurfaceBinding,
+  content_id : String,
+  edge : String,
+  attempt : Int,
+) -> Unit {
+  menu_request_frame(() => {
+    guard ui_element_by_id(binding.id) is Some(live_root) else { return }
+    let content = ui_element_by_id(content_id)
+    let items = menu_enabled_items(binding, content)
+    if live_root.get_attribute("data-state").unwrap_or("") != "open" ||
+      items.length() == 0 {
+      if attempt < 20 {
+        menu_focus_dropdown_edge(binding, content_id, edge, attempt + 1)
+      }
+      return
+    }
+    let requested_edge = menu_pending_edges.get(binding.id).unwrap_or(edge)
+    let target = if requested_edge == "last" {
+      items.get(items.length() - 1)
+    } else {
+      items.get(0)
+    }
+    if target is Some(target) {
+      ui_focus_element(target)
+      menu_send_active(binding, Some(target))
+      if ui_has_window() {
+        ignore(
+          @dom.window().set_timeout(
+            () => {
+              if menu_pending_edges.get(binding.id) == Some(edge) {
+                menu_pending_edges.remove(binding.id)
+              }
+            },
+            250,
+          ),
+        )
+      }
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn menu_typeahead_query(buffer : String) -> String {
+  guard buffer.get_char(0) is Some(first) else { return "" }
+  let mut repeated = true
+  for character in buffer {
+    if character != first {
+      repeated = false
+    }
+  }
+  if repeated {
+    "\{first}"
+  } else {
+    buffer
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_typeahead_label(item : @dom.Element) -> String {
+  let labelled = item.get_attribute("data-menu-label").unwrap_or("")
+  if labelled != "" {
+    labelled
+  } else {
+    item.get_property("textContent").to_option().unwrap_or("")
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_handle_keydown(
+  binding : MenuSurfaceBinding,
+  event : @dom.KeyboardEvent,
+) -> Unit {
+  if event.get_default_prevented() {
+    return
+  }
+  guard event.target().to_element() is Some(event_target) else { return }
+  let key = event.key()
+  let dropdown_trigger = event_target.closest(
+    "[data-slot=\"dropdown-menu-trigger\"]",
+  )
+  if dropdown_trigger is Some(dropdown_trigger) &&
+    (key == "ArrowDown" || key == "ArrowUp") {
+    event.prevent_default()
+    let edge = if key == "ArrowUp" { "last" } else { "first" }
+    let content_id = dropdown_trigger
+      .get_attribute("aria-controls")
+      .unwrap_or("")
+    menu_pending_edges[binding.id] = edge
+    if ui_has_window() {
+      ignore(
+        @dom.window().set_timeout(
+          () => {
+            if menu_pending_edges.get(binding.id) == Some(edge) {
+              menu_pending_edges.remove(binding.id)
+            }
+          },
+          1000,
+        ),
+      )
+    }
+    if binding.root.get_attribute("data-state").unwrap_or("") != "open" {
+      ui_click_element(dropdown_trigger)
+    }
+    menu_focus_dropdown_edge(binding, content_id, edge, 0)
+    return
+  }
+  let current = event_target.closest("[data-menu-index]")
+  let container = if current is Some(current) {
+    current.closest("[role=\"menu\"]").unwrap_or(binding.root)
+  } else {
+    binding.root
+  }
+  let items = menu_enabled_items(binding, Some(container))
+  let active_submenu = event_target.closest("[data-submenu-owner]")
+  let rtl = ui_element_is_rtl(container)
+  let open_submenu_key = if rtl { "ArrowLeft" } else { "ArrowRight" }
+  let close_submenu_key = if rtl { "ArrowRight" } else { "ArrowLeft" }
+  if key == "Escape" && active_submenu is Some(active_submenu) {
+    event.prevent_default()
+    event.stop_propagation()
+    let submenu_key = active_submenu
+      .get_attribute("data-submenu-owner")
+      .unwrap_or("")
+    (binding.dispatch.val)(3, -1, submenu_key, "")
+    menu_focus_submenu_trigger(binding, submenu_key)
+    return
+  }
+  if key == "Escape" {
+    event.prevent_default()
+    (binding.dispatch.val)(1, -1, "", "")
+    return
+  }
+  if items.length() == 0 {
+    return
+  }
+  let mut position = -1
+  if current is Some(current) {
+    for item_index, item in items {
+      if item.is_same_node(current.as_node()) {
+        position = item_index
+      }
+    }
+  }
+  let mut target : @dom.Element? = None
+  if key == "ArrowDown" {
+    target = items.get(
+      if position < 0 {
+        0
+      } else {
+        (position + 1) % items.length()
+      },
+    )
+  } else if key == "ArrowUp" {
+    target = items.get(
+      if position < 0 {
+        items.length() - 1
+      } else if position == 0 {
+        items.length() - 1
+      } else {
+        position - 1
+      },
+    )
+  } else if key == "Home" {
+    target = items.get(0)
+  } else if key == "End" {
+    target = items.get(items.length() - 1)
+  }
+  if current is Some(current) &&
+    current.get_attribute("data-submenu-key").unwrap_or("") != "" &&
+    (key == open_submenu_key || key == "Enter" || key == " ") {
+    event.prevent_default()
+    ignore(menu_switch_submenu(binding, Some(current), true))
+    return
+  }
+  if key == close_submenu_key && active_submenu is Some(active_submenu) {
+    event.prevent_default()
+    event.stop_propagation()
+    let submenu_key = active_submenu
+      .get_attribute("data-submenu-owner")
+      .unwrap_or("")
+    (binding.dispatch.val)(3, -1, submenu_key, "")
+    menu_focus_submenu_trigger(binding, submenu_key)
+    return
+  }
+  if target is None &&
+    key.char_length_eq(1) &&
+    !event.meta_key() &&
+    !event.ctrl_key() &&
+    !event.alt_key() {
+    if key == " " && binding.typeahead.val == "" {
+      return
+    }
+    let now = event.get_time_stamp()
+    if binding.typeahead_at.val <= 0.0 ||
+      now - binding.typeahead_at.val > 1000.0 {
+      binding.typeahead.val = ""
+    }
+    binding.typeahead_at.val = now
+    binding.typeahead.val = binding.typeahead.val + key.to_lower()
+    if ui_has_window() {
+      if binding.typeahead_timer.val != 0 {
+        @dom.window().clear_timeout(binding.typeahead_timer.val)
+      }
+      binding.typeahead_timer.val = @dom.window().set_timeout(
+        () => {
+          binding.typeahead.val = ""
+          binding.typeahead_at.val = 0.0
+          binding.typeahead_timer.val = 0
+        },
+        1000,
+      )
+    }
+    let query = menu_typeahead_query(binding.typeahead.val)
+    let ordered : Array[@dom.Element] = []
+    if position < 0 {
+      for item in items {
+        ordered.push(item)
+      }
+    } else {
+      for offset in 1..<=items.length() {
+        if items.get((position + offset) % items.length()) is Some(item) {
+          ordered.push(item)
+        }
+      }
+    }
+    target = ui_find_element(ordered, item => {
+      menu_typeahead_label(item).trim().to_owned().to_lower().has_prefix(query)
+    })
+    event.prevent_default()
+  }
+  if target is Some(target) {
+    event.prevent_default()
+    ui_focus_element(target)
+    menu_send_active(binding, Some(target))
+  }
+}
+
+///|
+#cfg(target="js")
+fn bind_menu_surface(
+  id : String,
+  dispatch : (Int, Int, String, String) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  if menu_surface_bindings.get(id) is Some(existing) &&
+    existing.root.is_same_node(root.as_node()) {
+    existing.dispatch.val = dispatch
+    return
+  }
+  let binding : MenuSurfaceBinding = {
+    id,
+    root,
+    dispatch: Ref(dispatch),
+    typeahead: Ref(""),
+    typeahead_at: Ref(0.0),
+    typeahead_timer: Ref(0),
+  }
+  menu_surface_bindings[id] = binding
+  root.add_event_listener("focusin", event => {
+    if event.target().to_element() is Some(target) {
+      menu_send_active(binding, target.closest("[data-menu-index]"))
+    }
+  })
+  root.add_event_listener("pointermove", event => {
+    guard event.target().to_element() is Some(target) else { return }
+    let item = target.closest("[data-menu-index]")
+    menu_send_active(binding, item)
+    if item is Some(item) {
+      if item.get_attribute("data-submenu-key").unwrap_or("") != "" &&
+        ui_element_is_enabled(item) {
+        ignore(menu_switch_submenu(binding, Some(item), false))
+      } else {
+        (binding.dispatch.val)(
+          5,
+          ui_parse_int_or(
+            item.get_attribute("data-menu-index").unwrap_or(""),
+            -1,
+          ),
+          "",
+          menu_submenu_parent(item),
+        )
+      }
+    }
+  })
+  root.add_event_listener_with_options(
+    "click",
+    event => {
+      if event.target().to_element() is Some(target) {
+        ignore(
+          menu_switch_submenu(
+            binding,
+            target.closest("[data-menu-index][data-submenu-key]"),
+            false,
+          ),
+        )
+      }
+    },
+    capture=true,
+  )
+  root.add_event_listener("keydown", event => {
+    if event.to_keyboard_event() is Some(keyboard_event) {
+      menu_handle_keydown(binding, keyboard_event)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+priv struct MenuFocusStability {
+  item : @dom.Element?
+  frames : Int
+}
+
+///|
+#cfg(target="js")
+let menu_focus_stability : Map[String, MenuFocusStability] = Map([])
+
+///|
+#cfg(target="js")
+fn menu_resolve_focus_item(
+  id : String,
+  content_id : String,
+  index : Int,
+) -> @dom.Element? {
+  guard ui_element_by_id(id) is Some(root) else { return None }
+  let content = if content_id == "" {
+    None
+  } else {
+    ui_element_by_id(content_id)
+  }
+  if content_id != "" && content is None {
+    return None
+  }
+  let scope = content.unwrap_or(root)
+  let candidates = scope
+    .query_selector_all("[data-menu-index=\"\{index}\"]")
+    .filter(menu_element_is_visible)
+  if content is Some(content) {
+    ui_find_element(candidates, item => {
+      if item.closest("[role=\"menu\"]") is Some(owner) {
+        owner.is_same_node(content.as_node()) ||
+        content.contains(owner.as_node())
+      } else {
+        false
+      }
+    })
+  } else {
+    let open_item = ui_find_element(candidates, item => {
+      if item.closest("[role=\"menu\"]") is Some(owner) {
+        owner.get_attribute("data-state").unwrap_or("") == "open"
+      } else {
+        false
+      }
+    })
+    if open_item is Some(_) {
+      open_item
+    } else {
+      candidates.get(0)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn focus_menu_item(id : String, content_id : String, index : Int) -> Bool {
+  let stability_key = id + ":" + content_id + ":\{index}"
+  guard menu_resolve_focus_item(id, content_id, index) is Some(item) &&
+    item.get_is_connected() else {
+    menu_focus_stability.remove(stability_key)
+    return false
+  }
+  let document = @dom.document()
+  if document.get_active_element() is None ||
+    !document.get_active_element().unwrap().is_same_node(item.as_node()) {
+    ui_focus_element_without_scroll(item)
+  }
+  let live_item = menu_resolve_focus_item(id, content_id, index)
+  let stable = live_item is Some(live_item) &&
+    live_item.is_same_node(item.as_node()) &&
+    item.get_is_connected() &&
+    document.get_active_element() is Some(active) &&
+    active.is_same_node(item.as_node())
+  if !stable {
+    menu_focus_stability[stability_key] = { item: live_item, frames: 0 }
+    return false
+  }
+  let frames = if menu_focus_stability.get(stability_key) is Some(previous) &&
+    previous.item is Some(previous_item) &&
+    previous_item.is_same_node(item.as_node()) {
+    previous.frames + 1
+  } else {
+    1
+  }
+  if frames < 3 {
+    menu_focus_stability[stability_key] = { item: Some(item), frames }
+    false
+  } else {
+    menu_focus_stability.remove(stability_key)
+    true
+  }
+}
+
+///|
+#cfg(target="js")
+fn focus_first_menu_item(id : String, found : (Int) -> Unit) -> Unit {
+  fn focus_when_visible(attempt : Int) -> Unit {
+    guard ui_element_by_id(id) is Some(root) else { return }
+    let binding = if menu_surface_bindings.get(id) is Some(binding) &&
+      binding.root.is_same_node(root.as_node()) {
+      binding
+    } else {
+      {
+        id,
+        root,
+        dispatch: Ref((_, _, _, _) => ()),
+        typeahead: Ref(""),
+        typeahead_at: Ref(0.0),
+        typeahead_timer: Ref(0),
+      }
+    }
+    let items = menu_enabled_items(binding, None)
+    if root.get_attribute("data-state").unwrap_or("") == "open" &&
+      items.length() > 0 {
+      let item = if menu_pending_edges.get(id) == Some("last") {
+        items.get(items.length() - 1)
+      } else {
+        items.get(0)
+      }
+      menu_pending_edges.remove(id)
+      if item is Some(item) {
+        let index = ui_parse_int_or(
+          item.get_attribute("data-menu-index").unwrap_or(""),
+          -1,
+        )
+        ui_focus_element(item)
+        if index >= 0 {
+          found(index)
+        }
+      }
+    } else if attempt < 20 {
+      menu_request_frame(() => focus_when_visible(attempt + 1))
+    }
+  }
+
+  menu_request_frame(() => focus_when_visible(0))
+}
+
+///|
+#cfg(target="js")
+fn find_open_menu_content(
+  id : String,
+  slot : String,
+  found : (String, Int) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  guard ui_find_descendant(root, element => {
+      element.get_attribute("data-slot").unwrap_or("") == slot &&
+      element.get_attribute("data-state").unwrap_or("") == "open"
+    })
+    is Some(content) else {
+    return
+  }
+  let content_id = content.get_attribute("id").unwrap_or("")
+  if content_id == "" {
+    return
+  }
+  let menubar_index = content.get_attribute("data-menubar-index").unwrap_or("")
+  let navigation_index = content
+    .get_attribute("data-navigation-index")
+    .unwrap_or("")
+  let index = if menubar_index != "" {
+    ui_parse_int_or(menubar_index, -1)
+  } else {
+    ui_parse_int_or(navigation_index, -1)
+  }
+  found(content_id, index)
+}
+
+///|
+#cfg(target="js")
+let menu_submenu_roots : Map[String, @dom.Element] = Map([])
+
+///|
+#cfg(target="js")
+let menu_submenu_events_bound : Ref[Bool] = Ref(false)
+
+///|
+#cfg(target="js")
+let menu_submenu_frame : Ref[Double] = Ref(0.0)
+
+///|
+#cfg(target="js")
+fn menu_position_submenu_root(root : @dom.Element) -> Unit {
+  if !root.get_is_connected() {
+    return
+  }
+  let position_area = "inline-end span-block-end"
+  let css_anchored = @dom.CSS::supports("anchor-name", "--rui-anchor") &&
+    @dom.CSS::supports("position-anchor", "--rui-anchor") &&
+    @dom.CSS::supports("position-area", position_area) &&
+    @dom.CSS::supports("position-try-fallbacks", "flip-inline")
+  let triggers = root.query_selector_all("[data-menu-index][data-submenu-key]")
+  for content in root.query_selector_all("[data-submenu-owner]") {
+    let key = content.get_attribute("data-submenu-owner").unwrap_or("")
+    let requested_open = content.get_attribute("data-state").unwrap_or("") ==
+      "open"
+    // The browser owns the top-layer state. A parent popover can implicitly
+    // close a submenu without a Rabbita render, so a cached open bit must not
+    // override the actual :popover-open state on a later reopen.
+    let native_open = content.matches(":popover-open")
+    if !requested_open && !native_open {
+      content.set_attribute("data-positioned", "false")
+      continue
+    }
+    let trigger = ui_find_element(triggers, item => {
+      item.get_attribute("data-submenu-key").unwrap_or("") == key
+    })
+    if trigger is None || !trigger.unwrap().get_is_connected() {
+      if native_open && content.to_html_element() is Some(html) {
+        html.hide_popover()
+      }
+      content.set_attribute("data-positioned", "false")
+      continue
+    }
+    let trigger = trigger.unwrap()
+    guard content.to_html_element() is Some(content_html) else { continue }
+    let style = content_html.get_style()
+    if css_anchored {
+      ignore(style.remove_property("--rui-submenu-left"))
+      ignore(style.remove_property("--rui-submenu-top"))
+      ignore(style.remove_property("margin"))
+      content.set_attribute("data-positioning", "css-anchor")
+      content.set_attribute("data-positioned", "true")
+    } else {
+      let anchor = trigger.get_bounding_client_rect()
+      let measured = content.get_bounding_client_rect()
+      let measured_width = content_html.get_offset_width()
+      let measured_height = content_html.get_offset_height()
+      let floating_width = if measured_width > 0.0 {
+        measured_width
+      } else {
+        measured.get_width()
+      }
+      let floating_height = if measured_height > 0.0 {
+        measured_height
+      } else {
+        measured.get_height()
+      }
+      let viewport = if ui_has_window() {
+        @dom.window().get_visual_viewport()
+      } else {
+        None
+      }
+      let viewport_left = viewport
+        .map(viewport => viewport.get_offset_left())
+        .unwrap_or(0.0)
+      let viewport_top = viewport
+        .map(viewport => viewport.get_offset_top())
+        .unwrap_or(0.0)
+      let document_root = @dom.document().get_document_element()
+      let viewport_width = viewport
+        .map(viewport => viewport.get_width())
+        .unwrap_or_else(() => {
+          document_root.map(root => root.get_client_width()).unwrap_or(0.0)
+        })
+      let viewport_height = viewport
+        .map(viewport => viewport.get_height())
+        .unwrap_or_else(() => {
+          document_root.map(root => root.get_client_height()).unwrap_or(0.0)
+        })
+      let clip_left = viewport_left + 8.0
+      let clip_top = viewport_top + 8.0
+      let clip_right = viewport_left + viewport_width - 8.0
+      let clip_bottom = viewport_top + viewport_height - 8.0
+      let rtl = ui_element_is_rtl(trigger)
+      let inline_end_side = if rtl { "left" } else { "right" }
+      let inline_end_left = if rtl {
+        anchor.get_left() - floating_width - 4.0
+      } else {
+        anchor.get_right() + 4.0
+      }
+      let inline_start_side = if rtl { "right" } else { "left" }
+      let inline_start_left = if rtl {
+        anchor.get_right() + 4.0
+      } else {
+        anchor.get_left() - floating_width - 4.0
+      }
+      fn overflow(left : Double) -> Double {
+        (clip_left - left).max(0.0) +
+        (left + floating_width - clip_right).max(0.0)
+      }
+
+      let use_inline_end = overflow(inline_end_left) <= 0.0 ||
+        overflow(inline_end_left) <= overflow(inline_start_left)
+      let placed_side = if use_inline_end {
+        inline_end_side
+      } else {
+        inline_start_side
+      }
+      let placed_left = if use_inline_end {
+        inline_end_left
+      } else {
+        inline_start_left
+      }
+      let left = placed_left
+        .max(clip_left)
+        .min((clip_right - floating_width).max(clip_left))
+      let top = anchor
+        .get_top()
+        .max(clip_top)
+        .min((clip_bottom - floating_height).max(clip_top))
+      style.set_property("margin", "0")
+      style.set_property("--rui-submenu-left", "\{left.round().to_int()}px")
+      style.set_property("--rui-submenu-top", "\{top.round().to_int()}px")
+      style.set_property(
+        "--rui-floating-transform-origin",
+        if placed_side == "right" {
+          "0% 0%"
+        } else {
+          "100% 0%"
+        },
+      )
+      content.set_attribute("data-side", placed_side)
+      content.set_attribute("data-positioning", "javascript-fallback")
+      content.set_attribute("data-positioned", "true")
+    }
+    // Coordinates are established before the top-layer state changes so no
+    // frame can expose the submenu at an unpositioned fixed origin.
+    if requested_open && !native_open {
+      content_html.show_popover()
+      if !content.matches(":popover-open") {
+        content.set_attribute("data-positioned", "false")
+      }
+    } else if !requested_open && native_open {
+      content_html.hide_popover()
+    }
+    if !requested_open {
+      content.set_attribute("data-positioned", "false")
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_run_submenu_positions() -> Unit {
+  menu_submenu_frame.val = 0.0
+  let stale : Array[String] = []
+  for id, registered_root in menu_submenu_roots {
+    if ui_element_by_id(id) is Some(root) &&
+      root.is_same_node(registered_root.as_node()) &&
+      root.get_is_connected() {
+      menu_position_submenu_root(root)
+    } else {
+      stale.push(id)
+    }
+  }
+  for id in stale {
+    menu_submenu_roots.remove(id)
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_schedule_submenu_positions() -> Unit {
+  if menu_submenu_frame.val != 0.0 {
+    return
+  }
+  if ui_has_window() {
+    menu_submenu_frame.val = @dom.window().request_animation_frame(_ => {
+      menu_run_submenu_positions()
+    })
+  } else {
+    menu_run_submenu_positions()
+  }
+}
+
+///|
+#cfg(target="js")
+fn menu_bind_submenu_position_events() -> Unit {
+  if menu_submenu_events_bound.val || !ui_has_window() {
+    return
+  }
+  menu_submenu_events_bound.val = true
+  let window = @dom.window()
+  window.add_event_listener_with_options(
+    "scroll",
+    _ => menu_schedule_submenu_positions(),
+    capture=true,
+    passive=true,
+  )
+  window.add_event_listener_with_options(
+    "resize",
+    _ => menu_schedule_submenu_positions(),
+    passive=true,
+  )
+  if window.get_visual_viewport() is Some(viewport) {
+    viewport.add_event_listener_with_options(
+      "scroll",
+      _ => menu_schedule_submenu_positions(),
+      passive=true,
+    )
+    viewport.add_event_listener_with_options(
+      "resize",
+      _ => menu_schedule_submenu_positions(),
+      passive=true,
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+fn position_menu_submenus(id : String) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else {
+    menu_submenu_roots.remove(id)
+    return
+  }
+  menu_submenu_roots[id] = root
+  menu_bind_submenu_position_events()
+  menu_position_submenu_root(root)
+}
+
+///|
+#cfg(target="js")
+fn menu_position_submenus_cmd(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => position_menu_submenus(id))
+}
+
+///|
+#cfg(not(target="js"))
+fn menu_position_submenus_cmd(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn menu_bind_surface_cmd(
+  id : String,
+  set_active : @cmd.Emit[Int],
+  close_command : @cmd.Cmd,
+  set_submenu : @cmd.Emit[MenuSubmenuChange],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        bind_menu_surface(id, (kind, index, key, parent) => {
+          let command = match kind {
+            0 => set_active(index)
+            1 => close_command
+            2 => set_submenu(MenuOpenSubmenu(key))
+            3 => set_submenu(MenuCloseSubmenu(key))
+            4 => set_submenu(MenuSwitchSubmenu(parent, key))
+            5 => set_submenu(MenuCloseSubmenusUnder(parent))
+            _ => set_submenu(MenuCloseAllSubmenus)
+          }
+          scheduler.add(command)
+        })
+      },
+      purpose="menu-surface-bind",
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn menu_bind_surface_cmd(
+  id : String,
+  set_active : @cmd.Emit[Int],
+  close_command : @cmd.Cmd,
+  set_submenu : @cmd.Emit[MenuSubmenuChange],
+) -> @cmd.Cmd {
+  ignore((id, set_active, close_command, set_submenu))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn menu_focus_item_cmd(
+  id : String,
+  index : Int,
+  content_id? : String = "",
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    ui_after_ready("menu-focus-item:" + id, () => {
+      focus_menu_item(id, content_id, index)
+    })
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn menu_focus_item_cmd(
+  id : String,
+  index : Int,
+  content_id? : String = "",
+) -> @cmd.Cmd {
+  ignore((id, index, content_id))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn menu_focus_first_cmd(id : String, set_active : @cmd.Emit[Int]) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    focus_first_menu_item(id, index => scheduler.add(set_active(index)))
+  })
+}
+
+///|
+#cfg(target="js")
+fn menu_open_marked_cmd(
+  id : String,
+  slot : String,
+  set_index : @cmd.Emit[Int],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        find_open_menu_content(id, slot, (content_id, index) => {
+          ignore(set_floating_open(content_id, true))
+          position_floating(content_id)
+          if index >= 0 {
+            scheduler.add(set_index(index))
+          }
+        })
+      },
+      purpose="menu-open-marked",
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn menu_open_marked_cmd(
+  id : String,
+  slot : String,
+  set_index : @cmd.Emit[Int],
+) -> @cmd.Cmd {
+  ignore((id, slot, set_index))
+  @cmd.none
+}
+
+///|
+#cfg(not(target="js"))
+fn menu_focus_first_cmd(id : String, set_active : @cmd.Emit[Int]) -> @cmd.Cmd {
+  ignore((id, set_active))
+  @cmd.none
+}
+
+///|
+fn[C : @html.IsChildren] menu_root_surface(
+  slot : String,
+  id : String,
+  open : Bool,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles([UiBoxSizing, MenuRootStyle], style),
+    id~,
+    attrs=menu_state_attrs(attrs, slot, open),
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_trigger_button(
+  slot : String,
+  scope : MenuScope,
+  variant : ButtonVariant,
+  size : ButtonSize,
+  disabled : Bool,
+  aria_label : String?,
+  on_click : @cmd.Cmd?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  let element_attrs = menu_state_attrs(attrs, slot, scope.model.open)
+    .aria_haspopup("menu")
+    .aria_expanded(ui_bool(scope.model.open))
+    .aria_controls(scope.content_id)
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  } else {
+    if on_click is Some(on_click) {
+      ignore(element_attrs.on_click(_ => on_click))
+    }
+    ignore(element_attrs.on_click(_ => scope.toggle_command))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+        popup_anchor_style(scope.trigger_id),
+      ],
+      style,
+    ),
+    id=scope.trigger_id,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_content_surface(
+  slot : String,
+  scope : MenuScope,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+  aria_label : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  let is_context_menu = slot == "context-menu-content"
+  let element_attrs = menu_state_attrs(attrs, slot, scope.model.open)
+    .popover(if is_context_menu { "manual" } else { "auto" })
+    .data_set("light-dismiss", "true")
+    .role("menu")
+    .tabindex(-1)
+    .aria_orientation("vertical")
+    .data_set("trigger-id", scope.trigger_id)
+    .data_set("requested-side", popup_side_value(side))
+    .data_set("requested-align", popup_align_value(align))
+    .data_set("side", popup_side_value(side))
+    .data_set("align", popup_align_value(align))
+    .data_set("side-offset", "\{side_offset}")
+    .data_set("align-offset", "\{align_offset}")
+    .data_set("active-index", "\{scope.model.active}")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  } else {
+    ignore(element_attrs.aria_labelledby(scope.trigger_id))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        MenuContentStyle,
+        PopupTransition100Style,
+        if is_context_menu {
+          popup_floating_anchor_style(
+            context_menu_point_id(scope.trigger_id),
+            Bottom,
+            Start,
+            0,
+            0,
+          )
+        } else {
+          popup_floating_anchor_style(
+            scope.trigger_id,
+            side,
+            align,
+            side_offset,
+            align_offset,
+          )
+        },
+        popup_state_style(scope.model.open),
+      ],
+      style,
+    ),
+    id=scope.content_id,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_group_surface(
+  slot : String,
+  aria_label : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("slot", slot).role("group")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  @html.div(
+    style=ui_styles([UiBoxSizing, "display:flex;flex-direction:column"], style),
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_label_surface(
+  slot : String,
+  inset : Bool,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, MenuLabelStyle, if inset { MenuItemInsetStyle } else { "" }],
+      style,
+    ),
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", slot),
+    children,
+  )
+}
+
+///|
+fn menu_separator_surface(
+  slot : String,
+  class : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, MenuSeparatorStyle], style),
+    class?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", slot)
+      .role("separator")
+      .aria_orientation("horizontal"),
+    @html.nothing,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_shortcut_surface(
+  slot : String,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles([UiBoxSizing, MenuShortcutStyle], style),
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", slot).aria_hidden("true"),
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_item_surface(
+  slot : String,
+  scope : MenuScope,
+  role : String,
+  checked : Bool?,
+  indicator_placement : MenuIndicatorPlacement,
+  disabled : Bool,
+  inset : Bool,
+  destructive : Bool,
+  submenu_key : String?,
+  close_on_select : Bool,
+  action : @cmd.Cmd?,
+  on_select : @cmd.Cmd?,
+  aria_label : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  let index = menu_scope_next_index(scope)
+  let highlighted = scope.model.active == index
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("variant", if destructive { "destructive" } else { "default" })
+    .data_set("menu-index", "\{index}")
+    .data_set("highlighted", ui_bool(highlighted))
+    .role(role)
+    .tabindex(if highlighted { 0 } else { -1 })
+  if highlighted {
+    ignore(element_attrs.data_set("active", ""))
+  }
+  if checked is Some(checked) {
+    ignore(
+      element_attrs
+      .aria_checked(ui_bool(checked))
+      .data_set("state", if checked { "checked" } else { "unchecked" }),
+    )
+  }
+  if submenu_key is Some(key) {
+    let open = menu_submenu_open(scope.model.submenus, key)
+    ignore(
+      element_attrs
+      .id(menu_submenu_trigger_id(key))
+      .data_set("submenu-key", key)
+      .data_set("state", if open { "open" } else { "closed" })
+      .aria_haspopup("menu")
+      .aria_expanded(ui_bool(open))
+      .aria_controls(menu_submenu_content_id(key)),
+    )
+  }
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label).data_set("menu-label", label))
+  }
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  } else {
+    if on_select is Some(on_select) {
+      ignore(element_attrs.on_click(_ => on_select))
+    }
+    if action is Some(action) {
+      ignore(element_attrs.on_click(_ => action))
+    }
+    if close_on_select {
+      ignore(element_attrs.on_click(_ => scope.close_command))
+    }
+  }
+  let body = @html.span(
+    style=[UiBoxSizing, "display:contents"],
+    attrs=@html.Attrs::build().data_set("slot", slot + "-body"),
+    children,
+  )
+  let row = if checked is Some(checked) {
+    [
+      @html.span(
+        style=[
+          UiBoxSizing,
+          match indicator_placement {
+            MenuIndicatorInlineStart => MenuIndicatorStartStyle
+            MenuIndicatorInlineEnd => MenuIndicatorEndStyle
+          },
+        ],
+        attrs=@html.Attrs::build()
+          .data_set("slot", slot + "-indicator")
+          .aria_hidden("true"),
+        if checked {
+          ui_check_icon()
+        } else {
+          @html.nothing
+        },
+      ),
+      body,
+    ]
+  } else if submenu_key is Some(_) {
+    [
+      body,
+      @html.span(
+        style=[UiBoxSizing, MenuIndicatorEndStyle],
+        attrs=@html.Attrs::build()
+          .aria_hidden("true")
+          .data_set("icon", "inline-end"),
+        ui_chevron_right_icon(),
+      ),
+    ]
+  } else {
+    [body]
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        MenuItemStyle,
+        if (checked is Some(_) && indicator_placement == MenuIndicatorInlineEnd) ||
+          submenu_key is Some(_) {
+          MenuItemEndIndicatorStyle
+        } else {
+          ""
+        },
+        if inset {
+          MenuItemInsetStyle
+        } else {
+          ""
+        },
+        if destructive {
+          MenuItemDestructiveStyle
+        } else {
+          ""
+        },
+        if highlighted {
+          MenuItemHighlightedStyle
+        } else {
+          ""
+        },
+        match submenu_key {
+          Some(key) => popup_anchor_style(key)
+          None => ""
+        },
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    row,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_sub_root_surface(
+  slot : String,
+  open : Bool,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, "position:relative;display:contents"], style),
+    attrs=menu_state_attrs(attrs, slot, open),
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] menu_sub_content_surface(
+  slot : String,
+  key : String,
+  open : Bool,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        MenuSubContentStyle,
+        PopupTransition100Style,
+        menu_submenu_anchor_style(key),
+        popup_state_style(open),
+      ],
+      style,
+    ),
+    class?,
+    title?,
+    attrs=menu_state_attrs(attrs, slot, open)
+      .id(menu_submenu_content_id(key))
+      .popover("manual")
+      .data_set("restore-focus", "false")
+      .data_set("submenu-owner", key)
+      .data_set("requested-side", "inline-end")
+      .data_set("requested-align", "start")
+      .data_set("positioned", if open { "pending" } else { "false" })
+      .role("menu")
+      .aria_orientation("vertical")
+      .aria_labelledby(menu_submenu_trigger_id(key))
+      .tabindex(-1),
+    children,
+  )
+}

--- a/rui/menu_test.mbt
+++ b/rui/menu_test.mbt
@@ -1,0 +1,613 @@
+///|
+fn assert_element_tag_contains(
+  html : String,
+  marker : String,
+  expected : String,
+) -> Unit raise {
+  guard html.split_once(marker) is Some((before, after)) else {
+    fail("expected rendered HTML to contain marker `\{marker}`")
+  }
+  guard before.to_owned().rev_split_once("<button") is Some((_, start)) else {
+    fail("expected marker `\{marker}` to occur inside a button")
+  }
+  guard after.to_owned().split_once(">") is Some((end, _)) else {
+    fail("expected marker `\{marker}` to occur in a complete start tag")
+  }
+  let tag = "<button" + start.to_owned() + marker + end.to_owned() + ">"
+  assert_contains(tag, expected)
+}
+
+///|
+fn assert_span_tag_contains(
+  html : String,
+  marker : String,
+  expected : String,
+) -> Unit raise {
+  guard html.split_once(marker) is Some((before, after)) else {
+    fail("expected rendered HTML to contain marker `\{marker}`")
+  }
+  guard before.to_owned().rev_split_once("<span") is Some((_, start)) else {
+    fail("expected marker `\{marker}` to occur inside a span")
+  }
+  guard after.to_owned().split_once(">") is Some((end, _)) else {
+    fail("expected marker `\{marker}` to occur in a complete start tag")
+  }
+  let tag = "<span" + start.to_owned() + marker + end.to_owned() + ">"
+  assert_contains(tag, expected)
+}
+
+///|
+fn assert_div_tag_contains(
+  html : String,
+  marker : String,
+  expected : String,
+) -> Unit raise {
+  guard html.split_once(marker) is Some((before, after)) else {
+    fail("expected rendered HTML to contain marker `\{marker}`")
+  }
+  guard before.to_owned().rev_split_once("<div") is Some((_, start)) else {
+    fail("expected marker `\{marker}` to occur inside a div")
+  }
+  guard after.to_owned().split_once(">") is Some((end, _)) else {
+    fail("expected marker `\{marker}` to occur in a complete start tag")
+  }
+  let tag = "<div" + start.to_owned() + marker + end.to_owned() + ">"
+  assert_contains(tag, expected)
+}
+
+///|
+test "dropdown menu composes official parts with owned selection state" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render_incremental(() => {
+    @rui.dropdown_menu(
+      id="account-menu",
+      default_open=true,
+      default_checked_values=["status"],
+      default_radio_values=[("theme", "dark")],
+      attrs~,
+      style=["--menu-test:1"],
+      scope => {
+        @html.div([
+          @rui.dropdown_menu_trigger(scope, "Account"),
+          @rui.dropdown_menu_portal([
+            @rui.dropdown_menu_content(scope, style=["width:14rem"], [
+              @rui.dropdown_menu_label("Preferences"),
+              @rui.dropdown_menu_group(aria_label="Actions", [
+                @rui.dropdown_menu_item(scope, [
+                  @html.span("Profile"),
+                  @rui.dropdown_menu_shortcut("\u2318P"),
+                ]),
+                @rui.dropdown_menu_item(
+                  scope,
+                  destructive=true,
+                  aria_label="Delete account",
+                  "Delete",
+                ),
+              ]),
+              @rui.dropdown_menu_checkbox_item(
+                scope,
+                value="status",
+                "Show status",
+              ),
+              @rui.dropdown_menu_radio_group(scope, value="theme", radio => {
+                @html.div([
+                  @rui.dropdown_menu_radio_item(radio, value="light", "Light"),
+                  @rui.dropdown_menu_radio_item(radio, value="dark", "Dark"),
+                ])
+              }),
+              @rui.dropdown_menu_separator(),
+              @rui.dropdown_menu_sub(scope, value="share", sub => {
+                @html.div([
+                  @rui.dropdown_menu_sub_trigger(sub, "Share"),
+                  @rui.dropdown_menu_sub_content(
+                    sub,
+                    @rui.dropdown_menu_item(scope, "Copy link"),
+                  ),
+                ])
+              }),
+            ]),
+          ]),
+        ])
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"dropdown-menu\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-slot=\"dropdown-menu-trigger\"")
+  assert_contains(html, "aria-haspopup=\"menu\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "popover=\"auto\"")
+  assert_contains(html, "role=\"menu\"")
+  assert_contains(html, "role=\"menuitem\"")
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-item\"", "data-variant=\"default\"",
+  )
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-item\"", "background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent))",
+  )
+  assert_element_tag_contains(
+    html, "aria-label=\"Delete account\"", "data-variant=\"destructive\"",
+  )
+  assert_element_tag_contains(
+    html, "aria-label=\"Delete account\"", "--rui-menu-item-base-fg:var(--rui-destructive",
+  )
+  assert_contains(html, "role=\"menuitemcheckbox\"")
+  assert_contains(html, "aria-checked=\"true\"")
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-checkbox-item\"", "padding-inline-end:2rem",
+  )
+  assert_contains(html, "data-slot=\"dropdown-menu-checkbox-item-indicator\"")
+  assert_contains(
+    html, "position:absolute;inset-inline-end:0.5rem;display:inline-flex;width:1rem;height:1rem",
+  )
+  assert_contains(html, "role=\"menuitemradio\"")
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-radio-item\"", "padding-inline-end:2rem",
+  )
+  assert_contains(html, "data-slot=\"dropdown-menu-radio-group\"")
+  assert_contains(html, "data-slot=\"dropdown-menu-sub-trigger\"")
+  assert_contains(html, "data-slot=\"dropdown-menu-sub-content\"")
+  assert_div_tag_contains(
+    html, "data-slot=\"dropdown-menu-content\"", "width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem))",
+  )
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-content\"", "data-light-dismiss=\"true\"",
+  )
+  assert_div_tag_contains(
+    html, "data-slot=\"dropdown-menu-sub-content\"", "width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem))",
+  )
+  assert_contains(html, "popover=\"manual\"")
+  assert_contains(html, "data-restore-focus=\"false\"")
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-sub-trigger\"", "data-state=\"closed\"",
+  )
+  assert_element_tag_contains(
+    html, "data-slot=\"dropdown-menu-sub-trigger\"", "aria-controls=\"",
+  )
+  assert_contains(html, "aria-labelledby=\"")
+  assert_contains(html, "aria-haspopup=\"menu\"")
+  assert_contains(html, "data-slot=\"dropdown-menu-shortcut\"")
+  assert_span_tag_contains(
+    html, "data-slot=\"dropdown-menu-shortcut\"", "margin-inline-start:auto;flex:none;padding-inline-start:1.5rem",
+  )
+  assert_contains(html, "width:14rem")
+  assert_contains(html, "--menu-test:1")
+  assert_contains(html, "anchor-name:--rui-anchor_")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_contains(html, "position-area:bottom span-x-end")
+  assert_contains(html, "position-area:inline-end span-block-end")
+  assert_not_contains(html, "position-area:inline-end span-y-end")
+  assert_not_contains(html, "-10000px")
+  assert_not_contains(html, "dropdown-menu-portal")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+}
+
+///|
+test "context menu exposes right-click target and complete menu semantics" {
+  let html = render_incremental(() => {
+    @rui.context_menu(id="editor-menu", scope => {
+      @html.div([
+        @rui.context_menu_trigger(
+          scope,
+          style=["min-height:10rem"],
+          "Right click the editor",
+        ),
+        @rui.context_menu_portal([
+          @rui.context_menu_content(scope, aria_label="Editor actions", [
+            @rui.context_menu_label("Edit"),
+            @rui.context_menu_group(@rui.context_menu_item(scope, "Undo")),
+            @rui.context_menu_checkbox_item(scope, value="wrap", "Word wrap"),
+            @rui.context_menu_radio_group(scope, value="indent", radio => {
+              @rui.context_menu_radio_item(radio, value="spaces", "Spaces")
+            }),
+            @rui.context_menu_separator(),
+            @rui.context_menu_sub(scope, value="more", sub => {
+              @html.div([
+                @rui.context_menu_sub_trigger(sub, "More"),
+                @rui.context_menu_sub_content(
+                  sub,
+                  @rui.context_menu_item(scope, [
+                    @html.span("Inspect"),
+                    @rui.context_menu_shortcut("F12"),
+                  ]),
+                ),
+              ])
+            }),
+          ]),
+        ]),
+      ])
+    })
+  })
+  assert_contains(html, "data-slot=\"context-menu\"")
+  assert_contains(html, "data-slot=\"context-menu-trigger\"")
+  assert_contains(html, "data-slot=\"context-menu-anchor\"")
+  assert_contains(
+    html, "position:absolute;width:0;height:0;pointer-events:none",
+  )
+  assert_contains(html, "left:0px;top:0px")
+  assert_contains(html, "anchor-name:--rui-anchor_")
+  assert_contains(html, "tabindex=\"0\"")
+  assert_contains(html, "aria-haspopup=\"menu\"")
+  assert_contains(html, "data-slot=\"context-menu-content\"")
+  assert_contains(html, "popover=\"manual\"")
+  assert_not_contains(html, " hidden")
+  assert_contains(html, "data-light-dismiss=\"true\"")
+  assert_contains(
+    html, "transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease",
+  )
+  assert_contains(
+    html, "visibility:hidden;opacity:0;pointer-events:none;transform:scale(0.95)",
+  )
+  assert_contains(html, "role=\"menu\"")
+  assert_contains(html, "aria-label=\"Editor actions\"")
+  assert_contains(html, "role=\"menuitemcheckbox\"")
+  assert_contains(html, "role=\"menuitemradio\"")
+  assert_element_tag_contains(
+    html, "data-slot=\"context-menu-checkbox-item\"", "padding-inline-end:2rem",
+  )
+  assert_contains(html, "data-slot=\"context-menu-checkbox-item-indicator\"")
+  assert_contains(html, "inset-inline-end:0.5rem")
+  assert_contains(html, "data-slot=\"context-menu-sub-content\"")
+  assert_div_tag_contains(
+    html, "data-slot=\"context-menu-content\"", "width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem))",
+  )
+  assert_div_tag_contains(
+    html, "data-slot=\"context-menu-sub-content\"", "width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem))",
+  )
+  assert_span_tag_contains(
+    html, "data-slot=\"context-menu-shortcut\"", "margin-inline-start:auto;flex:none;padding-inline-start:1.5rem",
+  )
+  assert_contains(html, "min-height:10rem")
+  assert_contains(html, "position:fixed;inset:auto")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_contains(html, "position-area:bottom span-x-end")
+  assert_contains(html, "position-area:inline-end span-block-end")
+  assert_contains(html, "position-try-fallbacks:flip-inline")
+  assert_not_contains(html, "context-menu-portal")
+}
+
+///|
+test "menubar owns one active menu and all official item variants" {
+  let html = render_incremental(() => {
+    @rui.menubar(
+      id="app-menubar",
+      default_value="edit",
+      default_checked_values=["sidebar"],
+      default_radio_values=[("theme", "system")],
+      scope => {
+        @html.fragment([
+          @rui.menubar_menu(scope, value="file", menu => {
+            @html.fragment([
+              @rui.menubar_trigger(menu, "File"),
+              @rui.menubar_portal([
+                @rui.menubar_content(menu, [
+                  @rui.menubar_label("Workspace"),
+                  @rui.menubar_group(
+                    @rui.menubar_item(menu, [
+                      @html.span("New"),
+                      @rui.menubar_shortcut("\u2318N"),
+                    ]),
+                  ),
+                  @rui.menubar_checkbox_item(menu, value="sidebar", "Sidebar"),
+                  @rui.menubar_radio_group(menu, value="theme", radio => {
+                    @rui.menubar_radio_item(radio, value="system", "System")
+                  }),
+                  @rui.menubar_separator(),
+                  @rui.menubar_sub(menu, value="recent", sub => {
+                    @html.fragment([
+                      @rui.menubar_sub_trigger(sub, "Recent"),
+                      @rui.menubar_sub_content(
+                        sub,
+                        @rui.menubar_item(menu, "Project A"),
+                      ),
+                    ])
+                  }),
+                ]),
+              ]),
+            ])
+          }),
+          @rui.menubar_menu(scope, value="edit", menu => {
+            @html.fragment([
+              @rui.menubar_trigger(menu, "Edit"),
+              @rui.menubar_content(menu, @rui.menubar_item(menu, "Copy")),
+            ])
+          }),
+        ])
+      },
+    )
+  })
+  assert_contains(html, "role=\"menubar\"")
+  assert_contains(html, "aria-orientation=\"horizontal\"")
+  assert_contains(html, "max-width:100%;min-width:0;flex-wrap:wrap")
+  assert_contains(html, "data-slot=\"menubar-menu\"")
+  assert_contains(html, "data-value=\"edit\"")
+  assert_contains(html, "data-slot=\"menubar-trigger\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_element_tag_contains(
+    html, "data-menubar-value=\"file\"", "data-state=\"closed\"",
+  )
+  assert_element_tag_contains(
+    html, "data-menubar-value=\"edit\"", "data-state=\"open\"",
+  )
+  assert_element_tag_contains(
+    html, "data-menubar-value=\"edit\"", "--rui-menu-item-base-bg:var(--rui-accent",
+  )
+  assert_contains(html, "data-slot=\"menubar-content\"")
+  assert_contains(html, "role=\"menuitemcheckbox\"")
+  assert_contains(html, "role=\"menuitemradio\"")
+  assert_contains(html, "data-slot=\"menubar-checkbox-item-indicator\"")
+  assert_element_tag_contains(
+    html, "data-slot=\"menubar-checkbox-item\"", "padding-inline-end:2rem",
+  )
+  assert_element_tag_contains(
+    html, "data-slot=\"menubar-radio-item\"", "padding-inline-end:2rem",
+  )
+  assert_span_tag_contains(
+    html, "data-slot=\"menubar-checkbox-item-indicator\"", "position:absolute;inset-inline-end:0.5rem",
+  )
+  assert_span_tag_contains(
+    html, "data-slot=\"menubar-radio-item-indicator\"", "position:absolute;inset-inline-end:0.5rem",
+  )
+  assert_element_tag_contains(
+    html, "data-slot=\"menubar-sub-trigger\"", "padding-inline-end:2rem",
+  )
+  assert_span_tag_contains(
+    html, "data-icon=\"inline-end\"", "position:absolute;inset-inline-end:0.5rem",
+  )
+  assert_span_tag_contains(
+    html, "data-slot=\"menubar-shortcut\"", "margin-inline-start:auto;flex:none;padding-inline-start:1.5rem",
+  )
+  assert_contains(html, "data-slot=\"menubar-sub-content\"")
+  assert_div_tag_contains(
+    html, "data-slot=\"menubar-content\"", "width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem))",
+  )
+  assert_div_tag_contains(
+    html, "data-slot=\"menubar-sub-content\"", "width:max-content;min-width:min(var(--rui-menu-min-width,12rem),calc(100vw - 1rem))",
+  )
+  assert_contains(html, "popover=\"manual\"")
+  assert_not_contains(html, "menubar-portal")
+}
+
+///|
+test "navigation menu maps list item trigger content viewport link indicator" {
+  let html = render_incremental(() => {
+    @rui.navigation_menu(
+      id="docs-navigation",
+      default_value="products",
+      style=["max-width:60rem"],
+      scope => {
+        @html.div([
+          @rui.navigation_menu_list(scope, [
+            @rui.navigation_menu_item(scope, value="overview", item => {
+              @html.fragment([
+                @rui.navigation_menu_trigger(item, "Overview"),
+                @rui.navigation_menu_content(
+                  item,
+                  @rui.navigation_menu_link(href="/overview", "Overview"),
+                ),
+              ])
+            }),
+            @rui.navigation_menu_item(scope, value="products", item => {
+              @html.fragment([
+                @rui.navigation_menu_trigger(item, "Products"),
+                @rui.navigation_menu_indicator(item),
+                @rui.navigation_menu_content(item, [
+                  @rui.navigation_menu_link(
+                    href="/products/one",
+                    active=true,
+                    "Product one",
+                  ),
+                  @rui.navigation_menu_link(href="/products/two", "Product two"),
+                ]),
+              ])
+            }),
+          ]),
+          @rui.navigation_menu_viewport(
+            scope, "Viewport-compatible custom content",
+          ),
+        ])
+      },
+    )
+  })
+  assert_contains(html, "<nav")
+  assert_contains(html, "data-slot=\"navigation-menu\"")
+  assert_contains(html, "data-value=\"products\"")
+  assert_contains(html, "aria-label=\"Main navigation\"")
+  assert_contains(html, "data-slot=\"navigation-menu-list\"")
+  assert_contains(html, "data-slot=\"navigation-menu-item\"")
+  assert_contains(html, "data-slot=\"navigation-menu-trigger\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "data-slot=\"navigation-menu-content\"")
+  assert_contains(html, "role=\"region\"")
+  assert_contains(html, "data-slot=\"navigation-menu-viewport\"")
+  assert_not_contains(html, "popover=\"auto\"")
+  assert_contains(html, "data-slot=\"navigation-menu-link\"")
+  assert_contains(html, "href=\"/products/one\"")
+  assert_contains(html, "aria-current=\"page\"")
+  assert_contains(html, "data-slot=\"navigation-menu-indicator\"")
+  assert_contains(
+    html, "top:100%;inset-inline:0;z-index:1;display:flex;height:0.375rem",
+  )
+  assert_contains(
+    html, "align-items:flex-end;justify-content:center;overflow:hidden",
+  )
+  assert_contains(
+    html, "top:60%;width:0.5rem;height:0.5rem;flex:none;transform:rotate(45deg)",
+  )
+  assert_contains(
+    html, "background:var(--rui-border,oklch(0.922 0 0));box-shadow:",
+  )
+  assert_not_contains(html, "bottom:-0.375rem;left:50%;z-index:51")
+  assert_contains(html, "data-icon=\"chevron-down\"")
+  assert_not_contains(html, "\u2304")
+  assert_contains(html, "position-anchor:")
+  assert_contains(html, "position:fixed;inset:auto")
+  assert_contains(html, "top:calc(anchor(bottom) + 0.375rem)")
+  assert_contains(
+    html, "left:clamp(calc(var(--rui-navigation-viewport-half) + 0.5rem),anchor(center),calc(100vw - var(--rui-navigation-viewport-half) - 0.5rem))",
+  )
+  assert_contains(
+    html, "--rui-navigation-viewport-half:min(16rem,calc(50vw - 0.5rem))",
+  )
+  assert_contains(html, "position-try-fallbacks:flip-block")
+  assert_contains(html, "max-height:calc(100dvh - 1rem)")
+  assert_contains(html, "max-width:100%")
+  assert_contains(html, "max-width:60rem")
+  assert_element_tag_contains(
+    html, "data-navigation-value=\"overview\"", "tabindex=\"-1\"",
+  )
+  assert_element_tag_contains(
+    html, "data-navigation-value=\"products\"", "tabindex=\"0\"",
+  )
+  assert_contains(
+    html, "background:var(--rui-nav-bg,var(--rui-nav-base-bg,var(--rui-background",
+  )
+  assert_contains(
+    html, "color:var(--rui-nav-fg,var(--rui-nav-base-fg,var(--rui-foreground",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-nav-shadow,var(--rui-nav-base-shadow,none))",
+  )
+  assert_element_tag_contains(
+    html, "data-navigation-value=\"products\"", "--rui-nav-base-bg:color-mix(in oklab,var(--rui-accent",
+  )
+  assert_element_tag_contains(
+    html, "href=\"/products/one\"", "--rui-nav-base-bg:color-mix(in oklab,var(--rui-accent",
+  )
+}
+
+///|
+test "navigation menu can opt out of the shared viewport" {
+  let html = render_incremental(() => {
+    @rui.navigation_menu(
+      id="compact-navigation",
+      default_value="docs",
+      viewport=false,
+      scope => {
+        @rui.navigation_menu_list(
+          scope,
+          @rui.navigation_menu_item(scope, value="docs", item => {
+            @html.fragment([
+              @rui.navigation_menu_trigger(item, "Docs"),
+              @rui.navigation_menu_content(
+                item,
+                @rui.navigation_menu_link(href="/docs", "Docs"),
+              ),
+            ])
+          }),
+        )
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"navigation-menu-content\"")
+  assert_contains(html, "popover=\"auto\"")
+  assert_not_contains(html, "data-slot=\"navigation-menu-viewport\"")
+}
+
+///|
+test "menubar roving tab stop skips an initially disabled first trigger" {
+  let html = render_incremental(() => {
+    @rui.menubar(id="disabled-first-menubar", scope => {
+      @html.fragment([
+        @rui.menubar_menu(scope, value="disabled", menu => {
+          @html.fragment([
+            @rui.menubar_trigger(
+              menu,
+              disabled=true,
+              title="disabled-menubar-trigger",
+              "Disabled",
+            ),
+            @rui.menubar_content(menu, @html.nothing),
+          ])
+        }),
+        @rui.menubar_menu(scope, value="enabled", menu => {
+          @html.fragment([
+            @rui.menubar_trigger(
+              menu,
+              title="enabled-menubar-trigger",
+              "Enabled",
+            ),
+            @rui.menubar_content(menu, @html.nothing),
+          ])
+        }),
+      ])
+    })
+  })
+  assert_element_tag_contains(
+    html, "title=\"disabled-menubar-trigger\"", "tabindex=\"-1\"",
+  )
+  assert_element_tag_contains(
+    html, "title=\"enabled-menubar-trigger\"", "tabindex=\"0\"",
+  )
+}
+
+///|
+test "navigation menu roving tab stop skips an initially disabled trigger" {
+  let html = render_incremental(() => {
+    @rui.navigation_menu(id="disabled-first-navigation", viewport=false, scope => {
+      @rui.navigation_menu_list(scope, [
+        @rui.navigation_menu_item(scope, value="disabled", item => {
+          @html.fragment([
+            @rui.navigation_menu_trigger(
+              item,
+              disabled=true,
+              title="disabled-navigation-trigger",
+              "Disabled",
+            ),
+            @rui.navigation_menu_content(item, @html.nothing),
+          ])
+        }),
+        @rui.navigation_menu_item(scope, value="enabled", item => {
+          @html.fragment([
+            @rui.navigation_menu_trigger(
+              item,
+              title="enabled-navigation-trigger",
+              "Enabled",
+            ),
+            @rui.navigation_menu_content(item, @html.nothing),
+          ])
+        }),
+      ])
+    })
+  })
+  assert_element_tag_contains(
+    html, "title=\"disabled-navigation-trigger\"", "tabindex=\"-1\"",
+  )
+  assert_element_tag_contains(
+    html, "title=\"enabled-navigation-trigger\"", "tabindex=\"0\"",
+  )
+}
+
+///|
+test "menu subtrees use internal keys when public values repeat" {
+  let html = render_incremental(() => {
+    @rui.dropdown_menu(id="duplicate-submenu-values", default_open=true, scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(scope, "Open"),
+        @rui.dropdown_menu_content(scope, [
+          @rui.dropdown_menu_sub(scope, value="share", sub => {
+            @html.fragment([
+              @rui.dropdown_menu_sub_trigger(sub, "Share one"),
+              @rui.dropdown_menu_sub_content(sub, @html.nothing),
+            ])
+          }),
+          @rui.dropdown_menu_sub(scope, value="share", sub => {
+            @html.fragment([
+              @rui.dropdown_menu_sub_trigger(sub, "Share two"),
+              @rui.dropdown_menu_sub_content(sub, @html.nothing),
+            ])
+          }),
+        ]),
+      ])
+    })
+  })
+  assert_contains(
+    html, "data-submenu-key=\"duplicate-submenu-values::share::submenu-0\"",
+  )
+  assert_contains(
+    html, "data-submenu-key=\"duplicate-submenu-values::share::submenu-1\"",
+  )
+}

--- a/rui/menubar.mbt
+++ b/rui/menubar.mbt
@@ -1,0 +1,1405 @@
+///|
+struct MenubarModel {
+  active_value : String?
+  active_index : Int
+  focus_index : Int
+  menu : MenuCoreModel
+} derive(Eq)
+
+///|
+struct MenubarScope {
+  id : String
+  model : MenubarModel
+  counter : Ref[Int]
+  focus_claimed : Ref[Bool]
+  activate : @cmd.Emit[(String, Int)]
+  toggle : @cmd.Emit[(String, Int)]
+  close_command : @cmd.Cmd
+  set_active : @cmd.Emit[Int]
+  toggle_checked : @cmd.Emit[String]
+  set_radio : @cmd.Emit[(String, String)]
+  set_submenu : @cmd.Emit[MenuSubmenuChange]
+}
+
+///|
+struct MenubarMenuScope {
+  menu : MenuScope
+  value : String
+  index : Int
+  focus_index : Int
+  focus_claimed : Ref[Bool]
+  active_value_set : Bool
+}
+
+///|
+struct MenubarRadioGroupScope {
+  menu : MenuScope
+  group : String
+}
+
+///|
+struct MenubarSubScope {
+  menu : MenuScope
+  key : String
+}
+
+///|
+#cfg(target="js")
+priv enum MenubarMsg {
+  MenubarActivate(String, Int)
+  MenubarSwitch(String, Int)
+  MenubarToggle(String, Int)
+  MenubarClose
+  MenubarNative(String, Int, Bool)
+  MenubarSetActive(Int)
+  MenubarToggleChecked(String)
+  MenubarSetRadio(String, String)
+  MenubarSetSubmenu(MenuSubmenuChange)
+  MenubarSetFocus(Int)
+}
+
+///|
+const MenubarStyle : String = "display:inline-flex;max-width:100%;min-width:0;flex-wrap:wrap;align-items:center;gap:0.125rem;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-background,oklch(1 0 0));padding:0.25rem;color:var(--rui-foreground,oklch(0.145 0 0));box-shadow:0 1px 2px rgb(0 0 0 / 0.05)"
+
+///|
+const MenubarTriggerStyle : String = "height:1.75rem;border:0;background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent));padding-inline:0.625rem;color:var(--rui-menu-item-fg,var(--rui-menu-item-base-fg,inherit));box-shadow:none"
+
+///|
+const MenubarHoverClickWindowMs : Int = 250
+
+///|
+#cfg(target="js")
+priv struct MenubarHoverSwitch {
+  value : String
+  index : Int
+  at : Double
+}
+
+///|
+#cfg(target="js")
+priv struct MenubarBinding {
+  id : String
+  root : @dom.Element
+  activate : Ref[(String, Int, Bool) -> Unit]
+  native_change : Ref[(String, Int, Bool) -> Unit]
+  close : Ref[() -> Unit]
+  set_focus : Ref[(Int) -> Unit]
+  toggle_contents : Array[@dom.Element]
+}
+
+///|
+#cfg(target="js")
+let menubar_bindings : Map[String, MenubarBinding] = Map([])
+
+///|
+#cfg(target="js")
+let menubar_hover_switches : Map[String, MenubarHoverSwitch] = Map([])
+
+///|
+#cfg(target="js")
+fn menubar_now() -> Double {
+  if ui_has_window() {
+    @dom.window().get_performance().now()
+  } else {
+    0.0
+  }
+}
+
+///|
+#cfg(target="js")
+fn menubar_triggers(binding : MenubarBinding) -> Array[@dom.Element] {
+  binding.root
+  .query_selector_all("[data-slot=\"menubar-trigger\"]")
+  .filter(ui_element_is_enabled)
+}
+
+///|
+#cfg(target="js")
+fn menubar_open_trigger(
+  binding : MenubarBinding,
+  trigger : @dom.Element,
+  focus_content : Bool,
+) -> Unit {
+  (binding.activate.val)(
+    trigger.get_attribute("data-menubar-value").unwrap_or(""),
+    ui_parse_int_or(
+      trigger.get_attribute("data-menubar-index").unwrap_or(""),
+      -1,
+    ),
+    focus_content,
+  )
+}
+
+///|
+#cfg(target="js")
+fn menubar_focus_menu_index(
+  binding : MenubarBinding,
+  index : Int,
+  last : Bool,
+  attempt : Int,
+  stable_frames : Int,
+) -> Unit {
+  guard ui_element_by_id(binding.id) is Some(live_root) else { return }
+  let content = ui_find_element(
+    live_root.query_selector_all("[data-slot=\"menubar-content\"]"),
+    node => {
+      ui_parse_int_or(
+        node.get_attribute("data-menubar-index").unwrap_or(""),
+        -1,
+      ) ==
+      index &&
+      menu_element_is_visible(node)
+    },
+  )
+  let target = if content is Some(content) {
+    let items = content
+      .query_selector_all("[data-menu-index]")
+      .filter(item => {
+        menu_element_is_visible(item) &&
+        item.closest("[role=\"menu\"]") is Some(owner) &&
+        owner.is_same_node(content.as_node())
+      })
+    if last {
+      items.get(items.length() - 1)
+    } else {
+      items.get(0)
+    }
+  } else {
+    None
+  }
+  if target is Some(target) {
+    ui_focus_element_without_scroll(target)
+    let focused = @dom.document().get_active_element() is Some(active) &&
+      active.is_same_node(target.as_node())
+    let next_stable_frames = if focused { stable_frames + 1 } else { 0 }
+    if next_stable_frames < 3 && attempt < 20 {
+      menu_request_frame(() => {
+        menubar_focus_menu_index(
+          binding,
+          index,
+          last,
+          attempt + 1,
+          next_stable_frames,
+        )
+      })
+    }
+  } else if attempt < 20 {
+    menu_request_frame(() => {
+      menubar_focus_menu_index(binding, index, last, attempt + 1, 0)
+    })
+  }
+}
+
+///|
+#cfg(target="js")
+fn menubar_handle_keydown(
+  binding : MenubarBinding,
+  event : @dom.KeyboardEvent,
+) -> Unit {
+  if event.get_default_prevented() {
+    return
+  }
+  guard event.target().to_element() is Some(target) else { return }
+  let trigger = target.closest("[data-slot=\"menubar-trigger\"]")
+  let content = target.closest("[data-slot=\"menubar-content\"]")
+  let rtl = ui_element_is_rtl(binding.root)
+  let forward_key = if rtl { "ArrowLeft" } else { "ArrowRight" }
+  let backward_key = if rtl { "ArrowRight" } else { "ArrowLeft" }
+  let key = event.key()
+  if trigger is None &&
+    content is Some(content) &&
+    (key == "ArrowRight" || key == "ArrowLeft") {
+    let menu_item = target.closest("[data-menu-index]")
+    if key == forward_key &&
+      menu_item is Some(menu_item) &&
+      menu_item.get_attribute("data-submenu-key").unwrap_or("") != "" {
+      return
+    }
+    if key == backward_key &&
+      menu_item is Some(menu_item) &&
+      menu_item.closest("[data-submenu-owner]") is Some(_) {
+      return
+    }
+    let triggers = menubar_triggers(binding)
+    if triggers.length() == 0 {
+      return
+    }
+    let index = ui_parse_int_or(
+      content.get_attribute("data-menubar-index").unwrap_or(""),
+      0,
+    )
+    let mut current = 0
+    for item_index, item in triggers {
+      if ui_parse_int_or(
+          item.get_attribute("data-menubar-index").unwrap_or(""),
+          -1,
+        ) ==
+        index {
+        current = item_index
+      }
+    }
+    let next_position = if key == forward_key {
+      (current + 1) % triggers.length()
+    } else if current == 0 {
+      triggers.length() - 1
+    } else {
+      current - 1
+    }
+    if triggers.get(next_position) is Some(next) {
+      event.prevent_default()
+      ui_focus_element_without_scroll(next)
+      menubar_open_trigger(binding, next, true)
+    }
+    return
+  }
+  guard trigger is Some(trigger) else { return }
+  menubar_hover_switches.remove(binding.id)
+  let triggers = menubar_triggers(binding)
+  if triggers.length() == 0 {
+    return
+  }
+  let mut current = 0
+  for item_index, item in triggers {
+    if item.is_same_node(trigger.as_node()) {
+      current = item_index
+    }
+  }
+  let mut next : @dom.Element? = None
+  if key == forward_key {
+    next = triggers.get((current + 1) % triggers.length())
+  } else if key == backward_key {
+    next = triggers.get(
+      if current == 0 {
+        triggers.length() - 1
+      } else {
+        current - 1
+      },
+    )
+  } else if key == "Home" {
+    next = triggers.get(0)
+  } else if key == "End" {
+    next = triggers.get(triggers.length() - 1)
+  }
+  if key == "ArrowDown" || key == "ArrowUp" {
+    event.prevent_default()
+    menubar_open_trigger(binding, trigger, false)
+    menubar_focus_menu_index(
+      binding,
+      ui_parse_int_or(
+        trigger.get_attribute("data-menubar-index").unwrap_or(""),
+        -1,
+      ),
+      key == "ArrowUp",
+      0,
+      0,
+    )
+    return
+  }
+  if key == "Escape" {
+    event.prevent_default()
+    (binding.close.val)()
+    ui_focus_element(trigger)
+    return
+  }
+  if next is Some(next) {
+    event.prevent_default()
+    ui_focus_element(next)
+    if binding.root.get_attribute("data-state").unwrap_or("") == "open" {
+      menubar_open_trigger(binding, next, false)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn menubar_bind_content_toggles(binding : MenubarBinding) -> Unit {
+  for
+    content in binding.root.query_selector_all(
+      "[data-slot=\"menubar-content\"]",
+    ) {
+    let mut already_bound = false
+    for current in binding.toggle_contents {
+      if current.is_same_node(content.as_node()) {
+        already_bound = true
+      }
+    }
+    if !already_bound {
+      binding.toggle_contents.push(content)
+      content.add_event_listener("toggle", _ => {
+        (binding.native_change.val)(
+          content.get_attribute("data-menubar-value").unwrap_or(""),
+          ui_parse_int_or(
+            content.get_attribute("data-menubar-index").unwrap_or(""),
+            -1,
+          ),
+          content.matches(":popover-open"),
+        )
+      })
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn bind_menubar(
+  id : String,
+  activate : (String, Int, Bool) -> Unit,
+  native_change : (String, Int, Bool) -> Unit,
+  close : () -> Unit,
+  set_focus : (Int) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  if menubar_bindings.get(id) is Some(existing) &&
+    existing.root.is_same_node(root.as_node()) {
+    existing.activate.val = activate
+    existing.native_change.val = native_change
+    existing.close.val = close
+    existing.set_focus.val = set_focus
+    menubar_bind_content_toggles(existing)
+    return
+  }
+  let binding : MenubarBinding = {
+    id,
+    root,
+    activate: Ref(activate),
+    native_change: Ref(native_change),
+    close: Ref(close),
+    set_focus: Ref(set_focus),
+    toggle_contents: [],
+  }
+  menubar_bindings[id] = binding
+  menubar_bind_content_toggles(binding)
+  root.add_event_listener("focusin", event => {
+    guard event.target().to_element() is Some(target) else { return }
+    guard target.closest("[data-slot=\"menubar-trigger\"]") is Some(trigger) &&
+      ui_element_is_enabled(trigger) else {
+      return
+    }
+    let index = ui_parse_int_or(
+      trigger.get_attribute("data-menubar-index").unwrap_or(""),
+      -1,
+    )
+    for item in menubar_triggers(binding) {
+      ui_set_element_tab_index(
+        item,
+        if item.is_same_node(trigger.as_node()) {
+          0
+        } else {
+          -1
+        },
+      )
+    }
+    if index >= 0 {
+      (binding.set_focus.val)(index)
+    }
+  })
+  root.add_event_listener("pointermove", event => {
+    if binding.root.get_attribute("data-state").unwrap_or("") != "open" {
+      return
+    }
+    guard event.target().to_element() is Some(target) else { return }
+    guard target.closest("[data-slot=\"menubar-trigger\"]") is Some(trigger) &&
+      ui_element_is_enabled(trigger) else {
+      return
+    }
+    if trigger.get_attribute("data-state").unwrap_or("") != "open" {
+      menubar_hover_switches[id] = {
+        value: trigger.get_attribute("data-menubar-value").unwrap_or(""),
+        index: ui_parse_int_or(
+          trigger.get_attribute("data-menubar-index").unwrap_or(""),
+          -1,
+        ),
+        at: if event.get_time_stamp() > 0.0 {
+          event.get_time_stamp()
+        } else {
+          menubar_now()
+        },
+      }
+    }
+    let needs_focus = @dom.document().get_active_element() is None ||
+      !@dom.document()
+      .get_active_element()
+      .unwrap()
+      .is_same_node(trigger.as_node())
+    if needs_focus {
+      ui_focus_element_without_scroll(trigger)
+    }
+    menubar_open_trigger(binding, trigger, false)
+  })
+  root.add_event_listener("keydown", event => {
+    if event.to_keyboard_event() is Some(keyboard_event) {
+      menubar_handle_keydown(binding, keyboard_event)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn consume_menubar_hover_switch(
+  id : String,
+  value : String,
+  index : Int,
+  max_age_ms : Int,
+) -> Bool {
+  let switched = menubar_hover_switches.get(id)
+  menubar_hover_switches.remove(id)
+  guard switched is Some(switched) else { return false }
+  let age = menubar_now() - switched.at
+  switched.value == value &&
+  switched.index == index &&
+  age >= 0.0 &&
+  age <= max_age_ms.to_double()
+}
+
+///|
+#cfg(target="js")
+fn menubar_should_toggle(
+  id : String,
+  active_value : String?,
+  value : String,
+  index : Int,
+) -> Bool {
+  let hover_switched = consume_menubar_hover_switch(
+    id,
+    value,
+    index,
+    MenubarHoverClickWindowMs,
+  )
+  active_value != Some(value) || !hover_switched
+}
+
+///|
+#cfg(target="js")
+fn focus_menubar_content(id : String, index : Int) -> Bool {
+  guard ui_element_by_id(id) is Some(root) else { return false }
+  guard ui_find_element(
+      root.query_selector_all("[data-slot=\"menubar-content\"]"),
+      node => {
+        ui_parse_int_or(
+          node.get_attribute("data-menubar-index").unwrap_or(""),
+          -1,
+        ) ==
+        index &&
+        menu_element_is_visible(node)
+      },
+    )
+    is Some(content) &&
+    content.get_attribute("data-state").unwrap_or("") == "open" else {
+    return false
+  }
+  let target = ui_find_element(
+    content.query_selector_all("[data-menu-index]"),
+    node => {
+      if !menu_element_is_visible(node) {
+        false
+      } else if node.closest("[role=\"menu\"]") is Some(owner) {
+        owner.is_same_node(content.as_node())
+      } else {
+        false
+      }
+    },
+  )
+  guard target is Some(target) else { return false }
+  let document = @dom.document()
+  if document.get_active_element() is None ||
+    !document.get_active_element().unwrap().is_same_node(target.as_node()) {
+    ui_focus_element_without_scroll(target)
+  }
+  document.get_active_element() is Some(active) &&
+  active.is_same_node(target.as_node())
+}
+
+///|
+#cfg(target="js")
+fn menubar_focus_content_cmd(id : String, index : Int) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    ui_after_ready("menubar-focus-content:" + id, () => {
+      focus_menubar_content(id, index)
+    })
+  })
+}
+
+///|
+#cfg(target="js")
+fn menubar_bind_cmd(
+  id : String,
+  activate : @cmd.Emit[(String, Int)],
+  switch_activate : @cmd.Emit[(String, Int)],
+  native_change : @cmd.Emit[(String, Int, Bool)],
+  close_command : @cmd.Cmd,
+  set_focus : @cmd.Emit[Int],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        bind_menubar(
+          id,
+          (value, index, focus_content) => {
+            scheduler.add(
+              if focus_content {
+                switch_activate((value, index))
+              } else {
+                activate((value, index))
+              },
+            )
+          },
+          (value, index, open) => {
+            scheduler.add(native_change((value, index, open)))
+          },
+          () => scheduler.add(close_command),
+          index => scheduler.add(set_focus(index)),
+        )
+      },
+      purpose="menubar-bind",
+    )
+  })
+}
+
+///|
+fn menubar_content_id(id : String, index : Int) -> String {
+  id + "-content-\{index}"
+}
+
+///|
+fn menubar_trigger_id(id : String, index : Int) -> String {
+  id + "-trigger-\{index}"
+}
+
+///|
+fn menubar_scope(
+  id : String,
+  model : MenubarModel,
+  activate : @cmd.Emit[(String, Int)],
+  toggle : @cmd.Emit[(String, Int)],
+  close_command : @cmd.Cmd,
+  set_active : @cmd.Emit[Int],
+  toggle_checked : @cmd.Emit[String],
+  set_radio : @cmd.Emit[(String, String)],
+  set_submenu : @cmd.Emit[MenuSubmenuChange],
+) -> MenubarScope {
+  {
+    id,
+    model,
+    counter: Ref(0),
+    focus_claimed: Ref(false),
+    activate,
+    toggle,
+    close_command,
+    set_active,
+    toggle_checked,
+    set_radio,
+    set_submenu,
+  }
+}
+
+///|
+fn menubar_change_command(
+  id : String,
+  current : MenubarModel,
+  value : String?,
+  index : Int,
+) -> @cmd.Cmd {
+  let hide_previous = if current.active_index >= 0 &&
+    current.active_value != value {
+    floating_set_open_cmd(menubar_content_id(id, current.active_index), false)
+  } else {
+    @cmd.none
+  }
+  @cmd.batch([
+    hide_previous,
+    if value is Some(_) {
+      floating_set_open_cmd(menubar_content_id(id, index), true)
+    } else {
+      @cmd.none
+    },
+    menu_position_submenus_cmd(id + "-root"),
+  ])
+}
+
+///|
+#cfg(target="js")
+pub fn menubar(
+  id~ : String,
+  default_value? : String,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_value_change? : @cmd.Emit[String?],
+  aria_label? : String = "Application menu",
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MenubarScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let initial : MenubarModel = {
+    active_value: default_value,
+    active_index: if default_value is Some(_) {
+      0
+    } else {
+      -1
+    },
+    focus_index: -1,
+    menu: menu_core_model(
+      default_value is Some(_),
+      default_checked_values,
+      default_radio_values,
+    ),
+  }
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      let set_active = emit.map(index => MenubarSetActive(index))
+      let set_submenu = emit.map(value => MenubarSetSubmenu(value))
+      (
+        initial,
+        @cmd.batch([
+          menubar_bind_cmd(
+            id + "-root",
+            emit.map(pair => MenubarActivate(pair.0, pair.1)),
+            emit.map(pair => MenubarSwitch(pair.0, pair.1)),
+            emit.map(tuple => MenubarNative(tuple.0, tuple.1, tuple.2)),
+            emit(MenubarClose),
+            emit.map(index => MenubarSetFocus(index)),
+          ),
+          menu_bind_surface_cmd(
+            id + "-root",
+            set_active,
+            emit(MenubarClose),
+            set_submenu,
+          ),
+          match default_value {
+            Some(value) =>
+              menu_open_marked_cmd(
+                id + "-root",
+                "menubar-content",
+                emit.map(index => MenubarNative(value, index, true)),
+              )
+            None => @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(emit, msg, current) => {
+      match msg {
+        MenubarActivate(value, index) =>
+          if current.active_value == Some(value) {
+            (current, @cmd.none)
+          } else {
+            let next = {
+              ..current,
+              active_value: Some(value),
+              active_index: index,
+              focus_index: index,
+              menu: { ..current.menu, open: true, active: -1, submenus: [] },
+            }
+            (
+              next,
+              @cmd.batch([
+                menubar_change_command(id, current, Some(value), index),
+                if on_value_change is Some(notify) {
+                  notify(Some(value))
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        MenubarSwitch(value, index) => {
+          let next = {
+            ..current,
+            active_value: Some(value),
+            active_index: index,
+            focus_index: index,
+            menu: { ..current.menu, open: true, active: -1, submenus: [] },
+          }
+          (
+            next,
+            @cmd.batch([
+              menubar_change_command(id, current, Some(value), index),
+              menubar_focus_content_cmd(id + "-root", index),
+              if on_value_change is Some(notify) {
+                notify(Some(value))
+              } else {
+                @cmd.none
+              },
+            ]),
+          )
+        }
+        MenubarToggle(value, index) =>
+          if !menubar_should_toggle(
+              id + "-root",
+              current.active_value,
+              value,
+              index,
+            ) {
+            (current, @cmd.none)
+          } else if current.active_value == Some(value) {
+            (
+              {
+                ..current,
+                active_value: None,
+                active_index: -1,
+                focus_index: index,
+                menu: { ..current.menu, open: false, submenus: [] },
+              },
+              @cmd.batch([
+                floating_set_open_cmd(menubar_content_id(id, index), false),
+                menu_position_submenus_cmd(id + "-root"),
+                if on_value_change is Some(notify) {
+                  notify(None)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            let next = {
+              ..current,
+              active_value: Some(value),
+              active_index: index,
+              focus_index: index,
+              menu: { ..current.menu, open: true, active: -1, submenus: [] },
+            }
+            (
+              next,
+              @cmd.batch([
+                menubar_change_command(id, current, Some(value), index),
+                menu_focus_first_cmd(
+                  id + "-root",
+                  emit.map(active => MenubarSetActive(active)),
+                ),
+                if on_value_change is Some(notify) {
+                  notify(Some(value))
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        MenubarClose =>
+          if current.active_value is Some(_) {
+            (
+              {
+                ..current,
+                active_value: None,
+                active_index: -1,
+                focus_index: current.active_index,
+                menu: { ..current.menu, open: false, submenus: [] },
+              },
+              @cmd.batch([
+                floating_set_open_cmd(
+                  menubar_content_id(id, current.active_index),
+                  false,
+                ),
+                menu_position_submenus_cmd(id + "-root"),
+                ui_focus_id(menubar_trigger_id(id, current.active_index)),
+                if on_value_change is Some(notify) {
+                  notify(None)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        MenubarNative(value, index, open) =>
+          if open {
+            if current.active_value == Some(value) &&
+              current.active_index == index {
+              (current, @cmd.none)
+            } else {
+              (
+                {
+                  ..current,
+                  active_value: Some(value),
+                  active_index: index,
+                  focus_index: index,
+                  menu: { ..current.menu, open: true },
+                },
+                @cmd.none,
+              )
+            }
+          } else if current.active_value == Some(value) {
+            (
+              {
+                ..current,
+                active_value: None,
+                active_index: -1,
+                focus_index: index,
+                menu: { ..current.menu, open: false, submenus: [] },
+              },
+              @cmd.batch([
+                menu_position_submenus_cmd(id + "-root"),
+                if on_value_change is Some(notify) {
+                  notify(None)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        MenubarSetActive(index) =>
+          if current.menu.active == index {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, menu: { ..current.menu, active: index } },
+              menu_focus_item_cmd(
+                id + "-root",
+                index,
+                content_id=menubar_content_id(id, current.active_index),
+              ),
+            )
+          }
+        MenubarToggleChecked(value) =>
+          (
+            {
+              ..current,
+              menu: {
+                ..current.menu,
+                checked: menu_toggle_value(current.menu.checked, value),
+              },
+            },
+            @cmd.none,
+          )
+        MenubarSetRadio(group, value) =>
+          (
+            {
+              ..current,
+              menu: {
+                ..current.menu,
+                radios: menu_set_radio_value(current.menu.radios, group, value),
+              },
+            },
+            @cmd.none,
+          )
+        MenubarSetSubmenu(change) => {
+          let submenus = menu_update_submenus(current.menu.submenus, change)
+          if submenus == current.menu.submenus {
+            (current, @cmd.none)
+          } else {
+            (
+              { ..current, menu: { ..current.menu, submenus, } },
+              menu_position_submenus_cmd(id + "-root"),
+            )
+          }
+        }
+        MenubarSetFocus(index) => ({ ..current, focus_index: index }, @cmd.none)
+      }
+    },
+  )
+  model.view(model => {
+    let scope = menubar_scope(
+      id,
+      model,
+      emit.map(pair => MenubarActivate(pair.0, pair.1)),
+      emit.map(pair => MenubarToggle(pair.0, pair.1)),
+      emit(MenubarClose),
+      emit.map(index => MenubarSetActive(index)),
+      emit.map(value => MenubarToggleChecked(value)),
+      emit.map(pair => MenubarSetRadio(pair.0, pair.1)),
+      emit.map(value => MenubarSetSubmenu(value)),
+    )
+    let element_attrs = menu_state_attrs(
+        attrs,
+        "menubar",
+        model.active_value is Some(_),
+      )
+      .role("menubar")
+      .aria_orientation("horizontal")
+    ignore(element_attrs.aria_label(aria_label))
+    if model.active_value is Some(value) {
+      ignore(element_attrs.data_set("value", value))
+    }
+    @html.div(
+      style=ui_styles(
+        [UiBoxSizing, UiFontSans, UiTextRendering, MenubarStyle],
+        style,
+      ),
+      id=id + "-root",
+      class?,
+      title?,
+      attrs=element_attrs,
+      children(scope),
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn menubar(
+  id~ : String,
+  default_value? : String,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_value_change? : @cmd.Emit[String?],
+  aria_label? : String = "Application menu",
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MenubarScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_value_change)
+  let model : MenubarModel = {
+    active_value: default_value,
+    active_index: if default_value is Some(_) {
+      0
+    } else {
+      -1
+    },
+    focus_index: -1,
+    menu: menu_core_model(
+      default_value is Some(_),
+      default_checked_values,
+      default_radio_values,
+    ),
+  }
+  let scope = menubar_scope(
+    id,
+    model,
+    menu_noop_emit(),
+    menu_noop_emit(),
+    @cmd.none,
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+    menu_noop_emit(),
+  )
+  let element_attrs = menu_state_attrs(
+      attrs,
+      "menubar",
+      default_value is Some(_),
+    )
+    .role("menubar")
+    .aria_orientation("horizontal")
+  ignore(element_attrs.aria_label(aria_label))
+  @rabbita.Val::constant(
+    @html.div(
+      style=ui_styles(
+        [UiBoxSizing, UiFontSans, UiTextRendering, MenubarStyle],
+        style,
+      ),
+      id=id + "-root",
+      class?,
+      title?,
+      attrs=element_attrs,
+      children(scope),
+    ),
+  )
+}
+
+///|
+/// Explicit Root spelling matching the compound-component API.
+pub fn menubar_root(
+  id~ : String,
+  default_value? : String,
+  default_checked_values? : Array[String] = [],
+  default_radio_values? : Array[(String, String)] = [],
+  on_value_change? : @cmd.Emit[String?],
+  aria_label? : String = "Application menu",
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MenubarScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  menubar(
+    id~,
+    default_value?,
+    default_checked_values~,
+    default_radio_values~,
+    on_value_change?,
+    aria_label~,
+    class?,
+    title?,
+    attrs?,
+    style~,
+    children,
+  )
+}
+
+///|
+/// Zero-DOM Portal adapter for shadcn-compatible compound composition.
+/// Menubar Content is promoted by native Popover, so children remain directly
+/// composable without an extra element or a portal registration phase.
+pub fn menubar_portal(children : Array[@html.Html]) -> @html.Html {
+  @html.fragment(children)
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_menu(
+  scope : MenubarScope,
+  value~ : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MenubarMenuScope) -> C,
+) -> @html.Html {
+  let index = scope.counter.val
+  scope.counter.val += 1
+  let open = scope.model.active_value == Some(value)
+  let menu_model = { ..scope.model.menu, open, }
+  let menu : MenuScope = {
+    id: scope.id,
+    content_id: menubar_content_id(scope.id, index),
+    trigger_id: menubar_trigger_id(scope.id, index),
+    model: menu_model,
+    counter: Ref(0),
+    open_command: (scope.activate)((value, index)),
+    close_command: scope.close_command,
+    toggle_command: (scope.toggle)((value, index)),
+    set_active: scope.set_active,
+    toggle_checked: scope.toggle_checked,
+    set_radio: scope.set_radio,
+    set_submenu: scope.set_submenu,
+  }
+  @html.div(
+    style=ui_styles([UiBoxSizing, "display:contents"], style),
+    attrs=menu_state_attrs(attrs, "menubar-menu", open)
+      .data_set("value", value)
+      .data_set("menubar-index", "\{index}"),
+    children({
+      menu,
+      value,
+      index,
+      focus_index: scope.model.focus_index,
+      focus_claimed: scope.focus_claimed,
+      active_value_set: scope.model.active_value is Some(_),
+    }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_trigger(
+  scope : MenubarMenuScope,
+  disabled? : Bool = false,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let preferred = if scope.active_value_set {
+    scope.menu.model.open
+  } else if scope.focus_index >= 0 {
+    scope.focus_index == scope.index
+  } else {
+    !scope.focus_claimed.val
+  }
+  let tab_stop = !disabled && preferred
+  if tab_stop {
+    scope.focus_claimed.val = true
+  }
+  let trigger_attrs = ui_attrs(attrs)
+    .data_set("menubar-value", scope.value)
+    .data_set("menubar-index", "\{scope.index}")
+    .role("menuitem")
+    .tabindex(if tab_stop { 0 } else { -1 })
+  menu_trigger_button(
+    "menubar-trigger",
+    scope.menu,
+    Ghost,
+    Sm,
+    disabled,
+    aria_label,
+    on_click,
+    class,
+    title,
+    Some(trigger_attrs),
+    [
+      MenubarTriggerStyle,
+      if scope.menu.model.open {
+        "--rui-menu-item-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-menu-item-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+      } else {
+        ""
+      },
+    ] +
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_content(
+  scope : MenubarMenuScope,
+  side_offset? : Int = 8,
+  align_offset? : Int = 0,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let content_attrs = ui_attrs(attrs)
+    .data_set("menubar-value", scope.value)
+    .data_set("menubar-index", "\{scope.index}")
+    .data_set("restore-focus", "false")
+  menu_content_surface(
+    "menubar-content",
+    scope.menu,
+    Bottom,
+    Start,
+    side_offset,
+    align_offset,
+    aria_label,
+    class,
+    title,
+    Some(content_attrs),
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_group(
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_group_surface(
+    "menubar-group", aria_label, class, title, attrs, style, children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_item(
+  scope : MenubarMenuScope,
+  disabled? : Bool = false,
+  inset? : Bool = false,
+  destructive? : Bool = false,
+  close_on_select? : Bool = true,
+  on_select? : @cmd.Cmd,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_item_surface(
+    "menubar-item",
+    scope.menu,
+    "menuitem",
+    None,
+    MenuIndicatorInlineStart,
+    disabled,
+    inset,
+    destructive,
+    None,
+    close_on_select,
+    None,
+    on_select,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_checkbox_item(
+  scope : MenubarMenuScope,
+  value~ : String,
+  disabled? : Bool = false,
+  close_on_select? : Bool = false,
+  on_checked_change? : @cmd.Emit[Bool],
+  on_select? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let checked = menu_contains(scope.menu.model.checked, value)
+  let notify = if on_checked_change is Some(notify) {
+    notify(!checked)
+  } else {
+    @cmd.none
+  }
+  menu_item_surface(
+    "menubar-checkbox-item",
+    scope.menu,
+    "menuitemcheckbox",
+    Some(checked),
+    MenuIndicatorInlineEnd,
+    disabled,
+    false,
+    false,
+    None,
+    close_on_select,
+    Some(@cmd.batch([notify, (scope.menu.toggle_checked)(value)])),
+    on_select,
+    None,
+    None,
+    None,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_radio_group(
+  scope : MenubarMenuScope,
+  value~ : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MenubarRadioGroupScope) -> C,
+) -> @html.Html {
+  menu_group_surface(
+    "menubar-radio-group",
+    aria_label,
+    None,
+    None,
+    attrs,
+    style,
+    children({ menu: scope.menu, group: value }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_radio_item(
+  scope : MenubarRadioGroupScope,
+  value~ : String,
+  disabled? : Bool = false,
+  close_on_select? : Bool = false,
+  on_value_change? : @cmd.Emit[String],
+  on_select? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let checked = menu_radio_value(scope.menu.model.radios, scope.group) ==
+    Some(value)
+  let notify = if on_value_change is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+  menu_item_surface(
+    "menubar-radio-item",
+    scope.menu,
+    "menuitemradio",
+    Some(checked),
+    MenuIndicatorInlineEnd,
+    disabled,
+    false,
+    false,
+    None,
+    close_on_select,
+    Some(@cmd.batch([notify, (scope.menu.set_radio)((scope.group, value))])),
+    on_select,
+    None,
+    None,
+    None,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_label(
+  inset? : Bool = false,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_label_surface("menubar-label", inset, None, None, attrs, style, children)
+}
+
+///|
+pub fn menubar_separator(
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  menu_separator_surface("menubar-separator", None, attrs, style)
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_shortcut(
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_shortcut_surface("menubar-shortcut", None, None, attrs, style, children)
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_sub(
+  scope : MenubarMenuScope,
+  value~ : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MenubarSubScope) -> C,
+) -> @html.Html {
+  let key = menu_submenu_key(scope.menu, value)
+  let open = menu_submenu_open(scope.menu.model.submenus, key)
+  menu_sub_root_surface(
+    "menubar-sub",
+    open,
+    attrs,
+    style,
+    children({ menu: scope.menu, key }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_sub_trigger(
+  scope : MenubarSubScope,
+  disabled? : Bool = false,
+  inset? : Bool = false,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_item_surface(
+    "menubar-sub-trigger",
+    scope.menu,
+    "menuitem",
+    None,
+    MenuIndicatorInlineStart,
+    disabled,
+    inset,
+    false,
+    Some(scope.key),
+    false,
+    None,
+    None,
+    None,
+    None,
+    None,
+    attrs,
+    style,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] menubar_sub_content(
+  scope : MenubarSubScope,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  menu_sub_content_surface(
+    "menubar-sub-content",
+    scope.key,
+    menu_submenu_open(scope.menu.model.submenus, scope.key),
+    None,
+    None,
+    attrs,
+    style,
+    children,
+  )
+}

--- a/rui/message.mbt
+++ b/rui/message.mbt
@@ -1,0 +1,167 @@
+///|
+pub(all) enum ContentAlignment {
+  AlignStart
+  AlignEnd
+} derive(Debug, Eq)
+
+///|
+fn content_alignment_value(align : ContentAlignment) -> String {
+  match align {
+    AlignStart => "start"
+    AlignEnd => "end"
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] message_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-group"),
+    style=ui_styles(
+      [UiBoxSizing, "display:flex;min-width:0;flex-direction:column;gap:0.5rem"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message(
+  align? : ContentAlignment = AlignStart,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let value = content_alignment_value(align)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message").data_set("align", value),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:relative;display:flex;width:100%;min-width:0;gap:0.5rem;--rui-message-content-align:flex-start;font-size:0.875rem;line-height:1.25rem",
+        if align is AlignEnd {
+          "flex-direction:row-reverse;--rui-message-content-align:flex-end"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_avatar(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-avatar"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;width:fit-content;min-width:2rem;min-height:2rem;aspect-ratio:1;flex-shrink:0;align-items:center;justify-content:center;align-self:flex-end;overflow:hidden;border-radius:9999px;background:var(--rui-muted,oklch(0.97 0 0))",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-content"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;width:100%;min-width:0;flex-direction:column;gap:0.625rem;overflow-wrap:break-word;word-break:normal",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-header"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;max-width:100%;min-width:0;align-items:center;align-self:var(--rui-message-content-align,flex-start);padding-inline:0.75rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;font-weight:500",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-footer"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;max-width:100%;min-width:0;align-items:center;align-self:var(--rui-message-content-align,flex-start);padding-inline:0.75rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;font-weight:500",
+      ],
+      style,
+    ),
+    children,
+  )
+}

--- a/rui/message_scroller.mbt
+++ b/rui/message_scroller.mbt
@@ -1,0 +1,323 @@
+///|
+pub(all) enum MessageScrollDirection {
+  ScrollStart
+  ScrollEnd
+} derive(Debug, Eq)
+
+///|
+priv struct MessageScrollerPosition {
+  at_start : Bool
+  at_end : Bool
+} derive(Debug, Eq)
+
+///|
+priv enum MessageScrollerMsg {
+  SetScrollerPosition(Bool, Bool)
+} derive(Debug)
+
+///|
+/// Opaque render scope owned by `message_scroller`.
+struct MessageScrollerScope {
+  viewport_id : String
+  position : MessageScrollerPosition
+  emit : @cmd.Emit[MessageScrollerMsg]
+}
+
+///|
+#cfg(target="js")
+fn message_scroller_initialize_cmd(
+  viewport_id : String,
+  scroll_to_end : Bool,
+  emit : @cmd.Emit[MessageScrollerMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      viewport_id,
+      () => {
+        if @dom.document().get_element_by_id(viewport_id).to_option()
+          is Some(element) {
+          if scroll_to_end {
+            element.set_scroll_top(element.get_scroll_height())
+          }
+          let top = element.get_scroll_top()
+          let height = element.get_bounding_client_rect().get_height()
+          let total = element.get_scroll_height()
+          scheduler.add(
+            emit(SetScrollerPosition(top <= 1.0, top + height >= total - 1.0)),
+          )
+        }
+      },
+      purpose="message-scroller-initialize",
+    )
+  })
+}
+
+///|
+fn[C : @html.IsChildren] render_message_scroller(
+  scope : MessageScrollerScope,
+  id : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (MessageScrollerScope) -> C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-scroller"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "position:relative;display:flex;width:100%;height:100%;min-height:0;flex-direction:column;overflow:hidden",
+      ],
+      style,
+    ),
+    children(scope),
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn[C : @html.IsChildren] message_scroller(
+  id~ : String,
+  default_at_end? : Bool = true,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MessageScrollerScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let viewport_id = "\{id}-viewport"
+  let initial = { at_start: !default_at_end, at_end: default_at_end }
+  let (position, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        message_scroller_initialize_cmd(viewport_id, default_at_end, emit),
+      )
+    },
+    update=(_, msg, _) => {
+      (
+        match msg {
+          SetScrollerPosition(at_start, at_end) => { at_start, at_end }
+        },
+        @cmd.none,
+      )
+    },
+  )
+  position.view(position => {
+    render_message_scroller(
+      { viewport_id, position, emit },
+      Some(id),
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] message_scroller(
+  id~ : String,
+  default_at_end? : Bool = true,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (MessageScrollerScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let position = { at_start: !default_at_end, at_end: default_at_end }
+  let emit = @cmd.Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_message_scroller(
+      { viewport_id: "\{id}-viewport", position, emit },
+      Some(id),
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    ),
+  )
+}
+
+///|
+#cfg(target="js")
+fn message_scroller_viewport_attrs(
+  scope : MessageScrollerScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  ui_attrs(attrs).on_scroll(event => {
+    if event.current_target().to_option() is Some(target) &&
+      target.to_element() is Some(element) {
+      let top = element.get_scroll_top()
+      let height = element.get_bounding_client_rect().get_height()
+      let total = element.get_scroll_height()
+      (scope.emit)(SetScrollerPosition(top <= 1.0, top + height >= total - 1.0))
+    } else {
+      @cmd.none
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn message_scroller_viewport_attrs(
+  _ : MessageScrollerScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  ui_attrs(attrs)
+}
+
+///|
+pub fn[C : @html.IsChildren] message_scroller_viewport(
+  scope~ : MessageScrollerScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = message_scroller_viewport_attrs(scope, attrs)
+    .data_set("slot", "message-scroller-viewport")
+    .data_set("at-start", ui_bool(scope.position.at_start))
+    .data_set("at-end", ui_bool(scope.position.at_end))
+    .tabindex(0)
+  @html.div(
+    id=id.unwrap_or(scope.viewport_id),
+    class?,
+    title?,
+    attrs=element_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "width:100%;height:100%;min-width:0;min-height:0;overflow-y:auto;overscroll-behavior:contain;scrollbar-gutter:stable;scrollbar-width:thin;contain:content;outline-offset:2px",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_scroller_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "message-scroller-content"),
+    style=ui_styles(
+      [
+        "display:flex;height:max-content;min-height:100%;flex-direction:column;gap:2rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_scroller_item(
+  scroll_anchor? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "message-scroller-item")
+      .data_set("scroll-anchor", ui_bool(scroll_anchor)),
+    style=ui_styles(
+      [
+        "min-width:0;flex-shrink:0;content-visibility:auto;contain-intrinsic-size:auto 10rem",
+        if scroll_anchor {
+          "overflow-anchor:auto"
+        } else {
+          "overflow-anchor:none"
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] message_scroller_button(
+  scope~ : MessageScrollerScope,
+  direction? : MessageScrollDirection = ScrollEnd,
+  label? : String,
+  variant? : ButtonVariant = Secondary,
+  size? : ButtonSize = IconSm,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let end_ = direction is ScrollEnd
+  let active = if end_ {
+    !scope.position.at_end
+  } else {
+    !scope.position.at_start
+  }
+  let direction_value = if end_ { "end" } else { "start" }
+  let button_attrs = ui_attrs(attrs)
+    .data_set("slot", "message-scroller-button")
+    .data_set("direction", direction_value)
+    .data_set("active", ui_bool(active))
+  if label is Some(label) {
+    ignore(button_attrs.aria_label(label))
+  }
+  button(
+    variant~,
+    size~,
+    disabled=!active,
+    slot="message-scroller-button",
+    on_click=ui_scroll_id(scope.viewport_id, end_),
+    id?,
+    class?,
+    title?,
+    attrs=button_attrs,
+    style=ui_styles(
+      [
+        "position:absolute;left:50%;z-index:10;transform:translate(-50%,var(--rui-message-scroller-shift,0)) scale(var(--rui-message-scroller-scale,1));transition:transform 200ms cubic-bezier(0.23,1,0.32,1),opacity 200ms cubic-bezier(0.23,1,0.32,1);--rui-button-base-border:var(--rui-border,oklch(0.922 0 0));--rui-button-base-bg:var(--rui-background,white);--rui-button-base-fg:var(--rui-foreground,oklch(0.145 0 0))",
+        if end_ {
+          "bottom:1rem"
+        } else {
+          "top:1rem"
+        },
+        if active {
+          "--rui-message-scroller-shift:0;--rui-message-scroller-scale:1;opacity:1"
+        } else if end_ {
+          "--rui-message-scroller-shift:100%;--rui-message-scroller-scale:0.95;opacity:0;transition-duration:400ms;transition-timing-function:cubic-bezier(0.7,0,0.84,0)"
+        } else {
+          "--rui-message-scroller-shift:-100%;--rui-message-scroller-scale:0.95;opacity:0;transition-duration:400ms;transition-timing-function:cubic-bezier(0.7,0,0.84,0)"
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}

--- a/rui/moon.mod
+++ b/rui/moon.mod
@@ -1,0 +1,23 @@
+name = "Yoorkin/rui"
+
+version = "0.1.0"
+
+import {
+  "moonbit-community/rabbita@0.13.1",
+  "Yoorkin/shiki@0.1.0",
+  "moonbitlang/async@0.19.3",
+}
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/moonbit-community/rabbita"
+
+license = "MIT"
+
+keywords = [ "UI", "components", "rabbita", "shadcn", "web" ]
+
+description = "Self-contained Vega-style UI components for Rabbita"
+
+preferred_target = "js"
+
+supported_targets = "js+native"

--- a/rui/moon.pkg
+++ b/rui/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/js",
+  "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/svg",
+  "moonbitlang/core/string",
+}
+
+supported_targets = "js+native"
+
+formatter(ignore: [ "README.mbt.md" ])

--- a/rui/mount_internal.mbt
+++ b/rui/mount_internal.mbt
@@ -1,0 +1,130 @@
+///|
+// Each pending lane owns a monotonically increasing generation. A retry only
+// runs while its generation is still current, so a remount using the same id
+// can supersede stale work without storing callback state on `globalThis`.
+#cfg(target="js")
+let ui_after_mount_pending : Map[String, Map[String, Int]] = Map([])
+
+///|
+#cfg(target="js")
+let ui_after_ready_pending : Map[String, Int] = Map([])
+
+///|
+#cfg(target="js")
+let ui_after_operation_generation : Ref[Int] = Ref(0)
+
+///|
+#cfg(target="js")
+fn ui_next_after_operation_generation() -> Int {
+  ui_after_operation_generation.val = ui_after_operation_generation.val + 1
+  ui_after_operation_generation.val
+}
+
+///|
+#cfg(target="js")
+fn ui_after_request_frame(callback : () -> Unit) -> Unit {
+  if ui_has_window() {
+    ignore(@dom.window().request_animation_frame(_ => callback()))
+  } else {
+    // Non-browser JS tests may not expose a Window. Retrying synchronously
+    // preserves the bounded behavior without reaching outside @dom.
+    callback()
+  }
+}
+
+///|
+/// Run a DOM operation once an incremental view has actually mounted its
+/// element. `create_state_with_init` may enqueue an AfterRender command before
+/// the owning `Val::view` has inserted that element into the document. A newer
+/// request with the same element id and purpose supersedes an older pending
+/// retry, while distinct purposes may wait on the same element independently.
+#cfg(target="js")
+fn ui_after_mount(
+  id : String,
+  mounted : () -> Unit,
+  purpose? : String = "default",
+) -> Unit {
+  let lanes = if ui_after_mount_pending.get(id) is Some(lanes) {
+    lanes
+  } else {
+    let lanes : Map[String, Int] = Map([])
+    ui_after_mount_pending[id] = lanes
+    lanes
+  }
+  let generation = ui_next_after_operation_generation()
+  lanes[purpose] = generation
+  fn is_current() -> Bool {
+    ui_after_mount_pending.get(id) is Some(current_lanes) &&
+    current_lanes.get(purpose) == Some(generation)
+  }
+
+  fn finish() -> Unit {
+    if is_current() {
+      lanes.remove(purpose)
+      if lanes.length() == 0 {
+        ui_after_mount_pending.remove(id)
+      }
+    }
+  }
+
+  fn try_mount(attempt : Int) -> Unit {
+    if !is_current() {
+      return
+    }
+    if !ui_has_document() {
+      finish()
+    } else if @dom.document().get_element_by_id(id).to_option() is Some(_) {
+      finish()
+      mounted()
+    } else if attempt >= 60 {
+      finish()
+    } else {
+      ui_after_request_frame(() => try_mount(attempt + 1))
+    }
+  }
+
+  try_mount(0)
+}
+
+///|
+/// Retry a live-DOM operation until all of its own prerequisites are ready.
+/// The key makes a newer operation supersede an older pending retry for the
+/// same component and purpose, which prevents stale incremental instances from
+/// installing callbacks after a same-id remount.
+#cfg(target="js")
+fn ui_after_ready(key : String, ready : () -> Bool raise) -> Unit {
+  if !ui_has_document() {
+    return
+  }
+  let generation = ui_next_after_operation_generation()
+  ui_after_ready_pending[key] = generation
+  fn is_current() -> Bool {
+    ui_after_ready_pending.get(key) == Some(generation)
+  }
+
+  fn finish() -> Unit {
+    if is_current() {
+      ui_after_ready_pending.remove(key)
+    }
+  }
+
+  fn try_ready(attempt : Int) -> Unit {
+    if !is_current() {
+      return
+    }
+    let complete = try ready() catch {
+      _ => false
+    } noraise {
+      value => value
+    }
+    if complete {
+      finish()
+    } else if attempt >= 60 {
+      finish()
+    } else {
+      ui_after_request_frame(() => try_ready(attempt + 1))
+    }
+  }
+
+  try_ready(0)
+}

--- a/rui/mount_internal_wbtest.mbt
+++ b/rui/mount_internal_wbtest.mbt
@@ -1,0 +1,209 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_delayed_mount_fixture(
+  id : String,
+  missing_reads : Int,
+) -> Unit =
+  #| (id, missingReads) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiDelayedMountFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     reads: 0,
+  #|     frames: 0,
+  #|     mountedCalls: 0,
+  #|   }
+  #|   globalThis.window = globalThis
+  #|   globalThis.document = {
+  #|     getElementById(value) {
+  #|       fixture.reads += 1
+  #|       return value === id && fixture.reads > missingReads ? { id } : null
+  #|     },
+  #|   }
+  #|   globalThis.requestAnimationFrame = callback => {
+  #|     fixture.frames += 1
+  #|     callback()
+  #|     return fixture.frames
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_delayed_mount_mark_called() -> Unit =
+  #| () => { globalThis.__ruiDelayedMountFixture.mountedCalls += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_delayed_mount_calls() -> Int =
+  #| () => globalThis.__ruiDelayedMountFixture.mountedCalls
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_delayed_mount_frames() -> Int =
+  #| () => globalThis.__ruiDelayedMountFixture.frames
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_delayed_mount_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiDelayedMountFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadRequestAnimationFrame) {
+  #|     globalThis.requestAnimationFrame = fixture.requestAnimationFrame
+  #|   } else {
+  #|     delete globalThis.requestAnimationFrame
+  #|   }
+  #|   delete globalThis.__ruiDelayedMountFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_queued_mount_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiQueuedMountFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     mounted: false,
+  #|     frames: 0,
+  #|     oldCalls: 0,
+  #|     newCalls: 0,
+  #|     queue: [],
+  #|   }
+  #|   globalThis.window = globalThis
+  #|   globalThis.document = {
+  #|     getElementById(value) {
+  #|       return fixture.mounted && value === id ? { id } : null
+  #|     },
+  #|   }
+  #|   globalThis.requestAnimationFrame = callback => {
+  #|     fixture.frames += 1
+  #|     fixture.queue.push(callback)
+  #|     return fixture.frames
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_queued_mount_mark_mounted() -> Unit =
+  #| () => { globalThis.__ruiQueuedMountFixture.mounted = true }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_queued_mount_mark_old_called() -> Unit =
+  #| () => { globalThis.__ruiQueuedMountFixture.oldCalls += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_queued_mount_mark_new_called() -> Unit =
+  #| () => { globalThis.__ruiQueuedMountFixture.newCalls += 1 }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_queued_mount_flush() -> Unit =
+  #| () => {
+  #|   const queue = globalThis.__ruiQueuedMountFixture.queue
+  #|   while (queue.length > 0) queue.shift()()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_queued_mount_old_calls() -> Int =
+  #| () => globalThis.__ruiQueuedMountFixture.oldCalls
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_queued_mount_new_calls() -> Int =
+  #| () => globalThis.__ruiQueuedMountFixture.newCalls
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_queued_mount_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiQueuedMountFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadRequestAnimationFrame) {
+  #|     globalThis.requestAnimationFrame = fixture.requestAnimationFrame
+  #|   } else {
+  #|     delete globalThis.requestAnimationFrame
+  #|   }
+  #|   delete globalThis.__ruiQueuedMountFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "after-mount operation survives a delayed incremental mount" {
+  ffi_install_delayed_mount_fixture("late-root", 3)
+  ui_after_mount("late-root", ffi_delayed_mount_mark_called)
+  let calls = ffi_delayed_mount_calls()
+  let frames = ffi_delayed_mount_frames()
+  ffi_restore_delayed_mount_fixture()
+  assert_eq(calls, 1)
+  assert_eq(frames, 3)
+}
+
+///|
+#cfg(target="js")
+test "after-mount operation stops after its bounded retry window" {
+  ffi_install_delayed_mount_fixture("never-root", 100)
+  ui_after_mount("never-root", ffi_delayed_mount_mark_called)
+  let calls = ffi_delayed_mount_calls()
+  let frames = ffi_delayed_mount_frames()
+  ffi_restore_delayed_mount_fixture()
+  assert_eq(calls, 0)
+  assert_eq(frames, 60)
+}
+
+///|
+#cfg(target="js")
+test "new same-purpose mount supersedes a queued callback for the same id" {
+  ffi_install_queued_mount_fixture("reused-root")
+  ui_after_mount("reused-root", ffi_queued_mount_mark_old_called)
+  ui_after_mount("reused-root", ffi_queued_mount_mark_new_called)
+  ffi_queued_mount_mark_mounted()
+  ffi_queued_mount_flush()
+  let old_calls = ffi_queued_mount_old_calls()
+  let new_calls = ffi_queued_mount_new_calls()
+  ffi_restore_queued_mount_fixture()
+  assert_eq(old_calls, 0)
+  assert_eq(new_calls, 1)
+}
+
+///|
+#cfg(target="js")
+test "different after-mount purposes may wait on the same id" {
+  ffi_install_queued_mount_fixture("shared-root")
+  ui_after_mount(
+    "shared-root",
+    ffi_queued_mount_mark_old_called,
+    purpose="events",
+  )
+  ui_after_mount(
+    "shared-root",
+    ffi_queued_mount_mark_new_called,
+    purpose="visibility",
+  )
+  ffi_queued_mount_mark_mounted()
+  ffi_queued_mount_flush()
+  let old_calls = ffi_queued_mount_old_calls()
+  let new_calls = ffi_queued_mount_new_calls()
+  ffi_restore_queued_mount_fixture()
+  assert_eq(old_calls, 1)
+  assert_eq(new_calls, 1)
+}

--- a/rui/native_select.mbt
+++ b/rui/native_select.mbt
@@ -1,0 +1,200 @@
+///|
+pub(all) enum NativeSelectSize {
+  NativeSelectDefault
+  NativeSelectSm
+} derive(Debug, Eq)
+
+///|
+const NativeSelectWrapperStyle : String = "position:relative;display:inline-flex;width:fit-content;max-width:100%;align-items:center"
+
+///|
+const NativeSelectBaseStyle : String = "width:100%;min-width:0;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);appearance:none;-webkit-appearance:none;border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));padding-block:0.25rem;padding-inline:0.625rem 2.25rem;color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));font-size:0.875rem;line-height:1.25rem;box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));outline-offset:2px;user-select:none"
+
+///|
+const NativeSelectDefaultStyle : String = "height:2.25rem"
+
+///|
+const NativeSelectSmStyle : String = "height:2rem"
+
+///|
+const NativeSelectInvalidStyle : String = "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+const NativeSelectIconStyle : String = "position:absolute;inset-block-start:50%;inset-inline-end:0.875rem;display:inline-flex;width:1rem;height:1rem;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));opacity:0.5;pointer-events:none;transform:translateY(-50%);user-select:none"
+
+///|
+const NativeSelectOptionStyle : String = "background:Canvas;color:CanvasText"
+
+///|
+fn native_select_size_value(size : NativeSelectSize) -> String {
+  match size {
+    NativeSelectDefault => "default"
+    NativeSelectSm => "sm"
+  }
+}
+
+///|
+fn native_select_size_style(size : NativeSelectSize) -> String {
+  match size {
+    NativeSelectDefault => NativeSelectDefaultStyle
+    NativeSelectSm => NativeSelectSmStyle
+  }
+}
+
+///|
+fn native_select_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    NativeSelectInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+fn native_select_disabled_style(disabled : Bool) -> String {
+  if disabled {
+    "cursor:not-allowed;pointer-events:none"
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render the shadcn native-select recipe with a real browser `<select>`.
+///
+/// `value` is written as a DOM property for controlled browser rendering.
+/// Options can also set `selected` for meaningful standalone SSR output.
+pub fn[C : @html.IsChildren] native_select(
+  size? : NativeSelectSize = NativeSelectDefault,
+  value? : String,
+  name? : String,
+  disabled? : Bool = false,
+  required? : Bool,
+  autofocus? : Bool,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_change? : @cmd.Emit[String],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  wrapper_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let size_value = native_select_size_value(size)
+  let select_attrs = ui_attrs(attrs)
+    .data_set("slot", "native-select")
+    .data_set("size", size_value)
+  if value is Some(value) {
+    ignore(select_attrs.value_prop(value))
+  }
+  if disabled {
+    ignore(select_attrs.data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(select_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  if aria_label is Some(label) {
+    ignore(select_attrs.aria_label(label))
+  }
+  let select = @html.select(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        NativeSelectBaseStyle,
+        native_select_size_style(size),
+        native_select_invalid_style(invalid),
+        native_select_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    disabled~,
+    name?,
+    required?,
+    autofocus?,
+    on_change?,
+    attrs=select_attrs,
+    children,
+  )
+  let wrapper_attrs = @html.Attrs::build()
+    .data_set("slot", "native-select-wrapper")
+    .data_set("size", size_value)
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        NativeSelectWrapperStyle,
+        ui_disabled_visual_style(disabled),
+      ],
+      wrapper_style,
+    ),
+    class?,
+    title?,
+    attrs=wrapper_attrs,
+    [
+      select,
+      @html.span(
+        style=[UiBoxSizing, NativeSelectIconStyle],
+        attrs=@html.Attrs::build()
+          .data_set("slot", "native-select-icon")
+          .aria_hidden("true"),
+        ui_chevron_down_icon(),
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] native_select_option(
+  value? : String,
+  selected? : Bool,
+  disabled? : Bool,
+  label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.option(
+    style=ui_styles([NativeSelectOptionStyle], style),
+    id?,
+    class?,
+    title?,
+    label?,
+    disabled?,
+    value?,
+    selected?,
+    attrs=ui_attrs(attrs).data_set("slot", "native-select-option"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] native_select_optgroup(
+  label? : String,
+  disabled? : Bool,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.optgroup(
+    style=ui_styles([NativeSelectOptionStyle], style),
+    id?,
+    class?,
+    title?,
+    label?,
+    disabled?,
+    attrs=ui_attrs(attrs).data_set("slot", "native-select-optgroup"),
+    children,
+  )
+}

--- a/rui/navigation_menu.mbt
+++ b/rui/navigation_menu.mbt
@@ -1,0 +1,1244 @@
+///|
+struct NavigationMenuModel {
+  value : String?
+  index : Int
+  focus_index : Int
+} derive(Eq)
+
+///|
+struct NavigationMenuScope {
+  id : String
+  model : NavigationMenuModel
+  counter : Ref[Int]
+  focus_claimed : Ref[Bool]
+  viewport : Bool
+  contents : Ref[Array[NavigationMenuContentEntry]]
+  viewport_rendered : Ref[Bool]
+  activate : @cmd.Emit[(String, Int)]
+  toggle : @cmd.Emit[(String, Int)]
+  close_command : @cmd.Cmd
+}
+
+///|
+struct NavigationMenuItemScope {
+  id : String
+  value : String
+  index : Int
+  open : Bool
+  focus_index : Int
+  focus_claimed : Ref[Bool]
+  active_value_set : Bool
+  viewport : Bool
+  contents : Ref[Array[NavigationMenuContentEntry]]
+  activate_command : @cmd.Cmd
+  toggle_command : @cmd.Cmd
+  close_command : @cmd.Cmd
+}
+
+///|
+priv struct NavigationMenuContentEntry {
+  value : String
+  content : @html.Html
+}
+
+///|
+#cfg(target="js")
+priv enum NavigationMenuMsg {
+  NavigationActivate(String, Int)
+  NavigationToggle(String, Int)
+  NavigationClose
+  NavigationNative(String, Int, Bool)
+  NavigationSetFocus(Int)
+}
+
+///|
+const NavigationMenuRootStyle : String = "position:relative;display:flex;width:max-content;max-width:100%;min-width:0;align-items:center;justify-content:center"
+
+///|
+const NavigationMenuListStyle : String = "display:flex;max-width:100%;flex-wrap:wrap;list-style:none;align-items:center;justify-content:center;gap:0.25rem;margin:0;padding:0"
+
+///|
+const NavigationMenuItemStyle : String = "position:relative;display:flex;align-items:center"
+
+///|
+const NavigationMenuTriggerStyle : String = "display:inline-flex;height:2.25rem;max-width:100%;min-width:0;align-items:center;justify-content:center;gap:0.375rem;--rui-nav-base-bg:var(--rui-background,oklch(1 0 0));--rui-nav-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-nav-base-border:transparent;--rui-nav-base-shadow:none;border:1px solid transparent;border-color:var(--rui-nav-border,var(--rui-nav-base-border,transparent));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-nav-bg,var(--rui-nav-base-bg,var(--rui-background,oklch(1 0 0))));padding-inline:0.75rem;color:var(--rui-nav-fg,var(--rui-nav-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-nav-shadow,var(--rui-nav-base-shadow,none));font-size:0.875rem;line-height:1.25rem;font-weight:500;white-space:nowrap;outline-offset:2px"
+
+///|
+const NavigationMenuTriggerOpenStyle : String = "--rui-nav-base-bg:color-mix(in oklab,var(--rui-accent,oklch(0.97 0 0)) 50%,transparent);--rui-nav-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+
+///|
+const NavigationMenuContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:block;width:min(32rem,calc(100vw - 1rem));max-height:calc(100vh - 1rem);overflow:auto;margin:0;border:1px solid color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);border-radius:var(--rui-radius,0.625rem);background:var(--rui-popover,oklch(1 0 0));padding:1rem;color:var(--rui-popover-foreground,oklch(0.145 0 0));box-shadow:0 12px 32px rgb(0 0 0 / 0.14);outline:none;transition:opacity 150ms ease,transform 150ms ease,visibility 150ms ease"
+
+///|
+const NavigationMenuViewportContentStyle : String = "position:relative;display:block;width:min(32rem,calc(100vw - 1rem));max-height:calc(100dvh - 1rem);overflow:auto;padding:1rem;color:var(--rui-popover-foreground,var(--rui-foreground,oklch(0.145 0 0)));outline:none"
+
+///|
+const NavigationMenuViewportStyle : String = "position:fixed;inset:auto;top:0;left:50%;z-index:50;--rui-navigation-viewport-half:min(16rem,calc(50vw - 0.5rem));width:min(32rem,calc(100vw - 1rem));max-width:calc(100vw - 1rem);max-height:calc(100dvh - 1rem);overflow:hidden;transform:translateX(-50%);position-try-fallbacks:flip-block;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:var(--rui-radius,0.625rem);background:var(--rui-popover,oklch(1 0 0));box-shadow:0 12px 32px rgb(0 0 0 / 0.14);transition:opacity 150ms ease,visibility 150ms ease"
+
+///|
+const NavigationMenuLinkStyle : String = "display:block;min-width:0;--rui-nav-base-bg:transparent;--rui-nav-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-nav-base-border:transparent;--rui-nav-base-shadow:none;border:1px solid transparent;border-color:var(--rui-nav-border,var(--rui-nav-base-border,transparent));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-nav-bg,var(--rui-nav-base-bg,transparent));padding:0.625rem 0.75rem;color:var(--rui-nav-fg,var(--rui-nav-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-nav-shadow,var(--rui-nav-base-shadow,none));text-decoration:none;outline-offset:2px;overflow-wrap:anywhere"
+
+///|
+const NavigationMenuLinkActiveStyle : String = "--rui-nav-base-bg:color-mix(in oklab,var(--rui-accent,oklch(0.97 0 0)) 50%,transparent);--rui-nav-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+
+///|
+const NavigationMenuIndicatorStyle : String = "position:absolute;top:100%;inset-inline:0;z-index:1;display:flex;height:0.375rem;align-items:flex-end;justify-content:center;overflow:hidden;transition:opacity 150ms ease,visibility 150ms ease"
+
+///|
+const NavigationMenuIndicatorArrowStyle : String = "position:relative;top:60%;width:0.5rem;height:0.5rem;flex:none;transform:rotate(45deg);border-radius:2px 0 0;background:var(--rui-border,oklch(0.922 0 0));box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1),0 2px 4px -2px rgb(0 0 0 / 0.1)"
+
+///|
+const NavigationMenuChevronBoxStyle : String = "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center;transition:transform 150ms ease"
+
+///|
+const NavigationMenuChevronStyle : String = "display:block;width:0.4375rem;height:0.4375rem;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform:translateY(-0.125rem) rotate(45deg)"
+
+///|
+fn navigation_content_id(id : String, index : Int) -> String {
+  id + "-content-\{index}"
+}
+
+///|
+fn navigation_trigger_id(id : String, index : Int) -> String {
+  id + "-trigger-\{index}"
+}
+
+///|
+fn navigation_viewport_anchor_id(id : String) -> String {
+  id + "-viewport-anchor"
+}
+
+///|
+fn navigation_viewport_position_style(id : String) -> String {
+  let anchor = popup_anchor_name(navigation_viewport_anchor_id(id))
+  "position-anchor:\{anchor};top:calc(anchor(bottom) + 0.375rem);left:clamp(calc(var(--rui-navigation-viewport-half) + 0.5rem),anchor(center),calc(100vw - var(--rui-navigation-viewport-half) - 0.5rem))"
+}
+
+///|
+#cfg(target="js")
+priv struct NavigationMenuBinding {
+  id : String
+  root : @dom.Element
+  document : @dom.Document
+  activate : Ref[(String, Int) -> Unit]
+  native_change : Ref[(String, Int, Bool) -> Unit]
+  close : Ref[() -> Unit]
+  set_focus : Ref[(Int) -> Unit]
+  toggle_contents : Array[@dom.Element]
+  close_timer : Ref[Int]
+  outside_press : Ref[@dom.Listener]
+}
+
+///|
+#cfg(target="js")
+let navigation_menu_bindings : Map[String, NavigationMenuBinding] = Map([])
+
+///|
+#cfg(target="js")
+fn navigation_menu_all_triggers(
+  binding : NavigationMenuBinding,
+) -> Array[@dom.Element] {
+  binding.root.query_selector_all("[data-slot=\"navigation-menu-trigger\"]")
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_triggers(
+  binding : NavigationMenuBinding,
+) -> Array[@dom.Element] {
+  navigation_menu_all_triggers(binding).filter(ui_element_is_enabled)
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_normalize_tab_stop(binding : NavigationMenuBinding) -> Unit {
+  let all = navigation_menu_all_triggers(binding)
+  let enabled = all.filter(ui_element_is_enabled)
+  let mut target = ui_find_element(enabled, item => {
+    item.get_attribute("aria-expanded").unwrap_or("") == "true"
+  })
+  if target is None {
+    target = ui_find_element(enabled, item => {
+      item.to_html_element() is Some(html) && html.get_tab_index() == 0
+    })
+  }
+  if target is None {
+    target = enabled.get(0)
+  }
+  for item in all {
+    ui_set_element_tab_index(
+      item,
+      if target is Some(target) && item.is_same_node(target.as_node()) {
+        0
+      } else {
+        -1
+      },
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_open_trigger(
+  binding : NavigationMenuBinding,
+  trigger : @dom.Element,
+) -> Unit {
+  (binding.activate.val)(
+    trigger.get_attribute("data-navigation-value").unwrap_or(""),
+    ui_parse_int_or(
+      trigger.get_attribute("data-navigation-index").unwrap_or(""),
+      -1,
+    ),
+  )
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_content_for_index(
+  root : @dom.Element,
+  index : Int,
+) -> @dom.Element? {
+  ui_find_element(
+    root.query_selector_all("[data-slot=\"navigation-menu-content\"]"),
+    content => {
+      ui_parse_int_or(
+        content.get_attribute("data-navigation-index").unwrap_or(""),
+        -1,
+      ) ==
+      index &&
+      menu_element_is_visible(content)
+    },
+  )
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_focus_content(
+  binding : NavigationMenuBinding,
+  index : Int,
+  attempt : Int,
+) -> Unit {
+  menu_request_frame(() => {
+    guard ui_element_by_id(binding.id) is Some(root) && root.get_is_connected() else {
+      return
+    }
+    if navigation_menu_content_for_index(root, index) is Some(content) {
+      let selector = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex=\"-1\"])"
+      let target = ui_find_element(
+        content.query_selector_all(selector),
+        menu_element_is_visible,
+      ).unwrap_or(content)
+      ui_focus_element(target)
+    } else if attempt < 3 {
+      navigation_menu_focus_content(binding, index, attempt + 1)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_clear_close_timer(binding : NavigationMenuBinding) -> Unit {
+  if binding.close_timer.val != 0 {
+    if ui_has_window() {
+      @dom.window().clear_timeout(binding.close_timer.val)
+    }
+    binding.close_timer.val = 0
+  }
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_schedule_close(binding : NavigationMenuBinding) -> Unit {
+  navigation_menu_clear_close_timer(binding)
+  let finish = () => {
+    binding.close_timer.val = 0
+    if binding.root.get_is_connected() && !binding.root.matches(":focus-within") {
+      (binding.close.val)()
+    }
+  }
+  if ui_has_window() {
+    binding.close_timer.val = @dom.window().set_timeout(finish, 100)
+  } else {
+    finish()
+  }
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_bind_content_toggles(
+  binding : NavigationMenuBinding,
+) -> Unit {
+  for
+    content in binding.root.query_selector_all(
+      "[data-slot=\"navigation-menu-content\"]",
+    ) {
+    let mut already_bound = false
+    for current in binding.toggle_contents {
+      if current.is_same_node(content.as_node()) {
+        already_bound = true
+      }
+    }
+    if !already_bound {
+      binding.toggle_contents.push(content)
+      content.add_event_listener("toggle", _ => {
+        (binding.native_change.val)(
+          content.get_attribute("data-navigation-value").unwrap_or(""),
+          ui_parse_int_or(
+            content.get_attribute("data-navigation-index").unwrap_or(""),
+            -1,
+          ),
+          content.matches(":popover-open"),
+        )
+      })
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn navigation_menu_handle_keydown(
+  binding : NavigationMenuBinding,
+  event : @dom.KeyboardEvent,
+) -> Unit {
+  if event.get_default_prevented() {
+    return
+  }
+  guard event.target().to_element() is Some(target) else { return }
+  let trigger = target.closest("[data-slot=\"navigation-menu-trigger\"]")
+  let content = target.closest("[data-slot=\"navigation-menu-content\"]")
+  let key = event.key()
+  if trigger is None && content is Some(content) && key == "Escape" {
+    event.prevent_default()
+    let index = ui_parse_int_or(
+      content.get_attribute("data-navigation-index").unwrap_or(""),
+      -1,
+    )
+    (binding.close.val)()
+    let destination = ui_find_element(navigation_menu_all_triggers(binding), item => {
+      ui_parse_int_or(
+        item.get_attribute("data-navigation-index").unwrap_or(""),
+        -1,
+      ) ==
+      index
+    })
+    if destination is Some(destination) {
+      ui_focus_element(destination)
+    }
+    return
+  }
+  guard trigger is Some(trigger) else { return }
+  let items = navigation_menu_triggers(binding)
+  if items.length() == 0 {
+    return
+  }
+  let mut current = 0
+  for item_index, item in items {
+    if item.is_same_node(trigger.as_node()) {
+      current = item_index
+    }
+  }
+  let rtl = ui_element_is_rtl(binding.root)
+  let forward_key = if rtl { "ArrowLeft" } else { "ArrowRight" }
+  let backward_key = if rtl { "ArrowRight" } else { "ArrowLeft" }
+  let mut next : @dom.Element? = None
+  if key == forward_key {
+    next = items.get((current + 1) % items.length())
+  } else if key == backward_key {
+    next = items.get(
+      if current == 0 {
+        items.length() - 1
+      } else {
+        current - 1
+      },
+    )
+  } else if key == "Home" {
+    next = items.get(0)
+  } else if key == "End" {
+    next = items.get(items.length() - 1)
+  }
+  if key == "ArrowDown" {
+    event.prevent_default()
+    navigation_menu_open_trigger(binding, trigger)
+    navigation_menu_focus_content(
+      binding,
+      ui_parse_int_or(
+        trigger.get_attribute("data-navigation-index").unwrap_or(""),
+        -1,
+      ),
+      0,
+    )
+    return
+  }
+  if key == "Escape" {
+    event.prevent_default()
+    (binding.close.val)()
+    ui_focus_element(trigger)
+    return
+  }
+  if next is Some(next) {
+    event.prevent_default()
+    ui_focus_element(next)
+    if binding.root.get_attribute("data-state").unwrap_or("") == "open" {
+      navigation_menu_open_trigger(binding, next)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn bind_navigation_menu(
+  id : String,
+  activate : (String, Int) -> Unit,
+  native_change : (String, Int, Bool) -> Unit,
+  close : () -> Unit,
+  set_focus : (Int) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  let document = @dom.document()
+  if navigation_menu_bindings.get(id) is Some(existing) {
+    if existing.root.is_same_node(root.as_node()) {
+      existing.activate.val = activate
+      existing.native_change.val = native_change
+      existing.close.val = close
+      existing.set_focus.val = set_focus
+      navigation_menu_bind_content_toggles(existing)
+      navigation_menu_normalize_tab_stop(existing)
+      return
+    }
+    navigation_menu_clear_close_timer(existing)
+    existing.document.remove_event_listener_with_options(
+      "pointerdown",
+      existing.outside_press.val,
+      capture=true,
+    )
+  }
+  let binding : NavigationMenuBinding = {
+    id,
+    root,
+    document,
+    activate: Ref(activate),
+    native_change: Ref(native_change),
+    close: Ref(close),
+    set_focus: Ref(set_focus),
+    toggle_contents: [],
+    close_timer: Ref(0),
+    outside_press: Ref(_ => ()),
+  }
+  navigation_menu_bindings[id] = binding
+  navigation_menu_bind_content_toggles(binding)
+  navigation_menu_normalize_tab_stop(binding)
+  root.add_event_listener("focusin", event => {
+    guard event.target().to_element() is Some(target) else { return }
+    guard target.closest("[data-slot=\"navigation-menu-trigger\"]")
+      is Some(trigger) &&
+      ui_element_is_enabled(trigger) else {
+      return
+    }
+    let index = ui_parse_int_or(
+      trigger.get_attribute("data-navigation-index").unwrap_or(""),
+      -1,
+    )
+    for item in navigation_menu_all_triggers(binding) {
+      ui_set_element_tab_index(
+        item,
+        if item.is_same_node(trigger.as_node()) {
+          0
+        } else {
+          -1
+        },
+      )
+    }
+    if index >= 0 {
+      (binding.set_focus.val)(index)
+    }
+  })
+  root.add_event_listener("focusout", _ => {
+    let finish = () => {
+      let active_inside = binding.document.get_active_element() is Some(active) &&
+        binding.root.contains(active.as_node())
+      if binding.root.get_attribute("data-state").unwrap_or("") == "open" &&
+        !active_inside {
+        (binding.close.val)()
+      }
+    }
+    if ui_has_window() {
+      @dom.window().queue_microtask(finish)
+    } else {
+      finish()
+    }
+  })
+  root.add_event_listener("click", event => {
+    guard event.target().to_element() is Some(target) else { return }
+    if target.closest("[data-slot=\"navigation-menu-link\"]") is Some(link) &&
+      binding.root.contains(link.as_node()) &&
+      ui_element_is_enabled(link) {
+      (binding.close.val)()
+    }
+  })
+  let outside_press : @dom.Listener = event => {
+    if !binding.root.get_is_connected() {
+      binding.document.remove_event_listener_with_options(
+        "pointerdown",
+        binding.outside_press.val,
+        capture=true,
+      )
+      return
+    }
+    let inside = event.target().to_element() is Some(target) &&
+      binding.root.contains(target.as_node())
+    if binding.root.get_attribute("data-state").unwrap_or("") == "open" &&
+      !inside {
+      (binding.close.val)()
+    }
+  }
+  binding.outside_press.val = outside_press
+  document.add_event_listener_with_options(
+    "pointerdown",
+    outside_press,
+    capture=true,
+  )
+  root.add_event_listener_with_options(
+    "pointerenter",
+    event => {
+      navigation_menu_clear_close_timer(binding)
+      guard event.target().to_element() is Some(target) else { return }
+      if target.closest("[data-slot=\"navigation-menu-trigger\"]")
+        is Some(trigger) &&
+        ui_element_is_enabled(trigger) {
+        navigation_menu_open_trigger(binding, trigger)
+      }
+    },
+    capture=true,
+  )
+  root.add_event_listener("pointerleave", _ => {
+    navigation_menu_schedule_close(binding)
+  })
+  root.add_event_listener("keydown", event => {
+    if event.to_keyboard_event() is Some(keyboard_event) {
+      navigation_menu_handle_keydown(binding, keyboard_event)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn navigation_bind_cmd(
+  id : String,
+  activate : @cmd.Emit[(String, Int)],
+  native_change : @cmd.Emit[(String, Int, Bool)],
+  close_command : @cmd.Cmd,
+  set_focus : @cmd.Emit[Int],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        bind_navigation_menu(
+          id,
+          (value, index) => scheduler.add(activate((value, index))),
+          (value, index, open) => {
+            scheduler.add(native_change((value, index, open)))
+          },
+          () => scheduler.add(close_command),
+          index => scheduler.add(set_focus(index)),
+        )
+      },
+      purpose="navigation-menu-bind",
+    )
+  })
+}
+
+///|
+fn navigation_change_cmd(
+  id : String,
+  current : NavigationMenuModel,
+  value : String?,
+  index : Int,
+  viewport : Bool,
+) -> @cmd.Cmd {
+  @cmd.batch([
+    if !viewport && current.index >= 0 && current.value != value {
+      floating_set_open_cmd(navigation_content_id(id, current.index), false)
+    } else {
+      @cmd.none
+    },
+    if !viewport && value is Some(_) {
+      floating_set_open_cmd(navigation_content_id(id, index), true)
+    } else {
+      @cmd.none
+    },
+  ])
+}
+
+///|
+#cfg(target="js")
+pub fn navigation_menu(
+  id~ : String,
+  default_value? : String,
+  viewport? : Bool = true,
+  on_value_change? : @cmd.Emit[String?],
+  aria_label? : String = "Main navigation",
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (NavigationMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let initial : NavigationMenuModel = {
+    value: default_value,
+    index: if default_value is Some(_) {
+      0
+    } else {
+      -1
+    },
+    focus_index: -1,
+  }
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        @cmd.batch([
+          navigation_bind_cmd(
+            id + "-root",
+            emit.map(pair => NavigationActivate(pair.0, pair.1)),
+            emit.map(tuple => NavigationNative(tuple.0, tuple.1, tuple.2)),
+            emit(NavigationClose),
+            emit.map(index => NavigationSetFocus(index)),
+          ),
+          if viewport {
+            @cmd.none
+          } else {
+            match default_value {
+              Some(value) =>
+                menu_open_marked_cmd(
+                  id + "-root",
+                  "navigation-menu-content",
+                  emit.map(index => NavigationNative(value, index, true)),
+                )
+              None => @cmd.none
+            }
+          },
+        ]),
+      )
+    },
+    update=(_, msg, current) => {
+      match msg {
+        NavigationActivate(value, index) =>
+          if current.value == Some(value) {
+            (current, @cmd.none)
+          } else {
+            let next : NavigationMenuModel = {
+              value: Some(value),
+              index,
+              focus_index: index,
+            }
+            (
+              next,
+              @cmd.batch([
+                navigation_change_cmd(id, current, Some(value), index, viewport),
+                if on_value_change is Some(notify) {
+                  notify(Some(value))
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        NavigationToggle(value, index) =>
+          if current.value == Some(value) {
+            (
+              { value: None, index: -1, focus_index: index },
+              @cmd.batch([
+                if viewport {
+                  @cmd.none
+                } else {
+                  floating_set_open_cmd(navigation_content_id(id, index), false)
+                },
+                if on_value_change is Some(notify) {
+                  notify(None)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (
+              { value: Some(value), index, focus_index: index },
+              @cmd.batch([
+                navigation_change_cmd(id, current, Some(value), index, viewport),
+                if on_value_change is Some(notify) {
+                  notify(Some(value))
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        NavigationClose =>
+          if current.value is Some(_) {
+            (
+              { value: None, index: -1, focus_index: current.index },
+              @cmd.batch([
+                if viewport {
+                  @cmd.none
+                } else {
+                  floating_set_open_cmd(
+                    navigation_content_id(id, current.index),
+                    false,
+                  )
+                },
+                if on_value_change is Some(notify) {
+                  notify(None)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        NavigationNative(value, index, open) =>
+          if open {
+            ({ value: Some(value), index, focus_index: index }, @cmd.none)
+          } else if current.value == Some(value) {
+            (
+              { value: None, index: -1, focus_index: index },
+              if on_value_change is Some(notify) {
+                notify(None)
+              } else {
+                @cmd.none
+              },
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        NavigationSetFocus(index) =>
+          ({ ..current, focus_index: index }, @cmd.none)
+      }
+    },
+  )
+  model.view(model => {
+    let scope : NavigationMenuScope = {
+      id,
+      model,
+      counter: Ref(0),
+      focus_claimed: Ref(false),
+      viewport,
+      contents: Ref([]),
+      viewport_rendered: Ref(false),
+      activate: emit.map(pair => NavigationActivate(pair.0, pair.1)),
+      toggle: emit.map(pair => NavigationToggle(pair.0, pair.1)),
+      close_command: emit(NavigationClose),
+    }
+    let element_attrs = menu_state_attrs(
+      attrs,
+      "navigation-menu",
+      model.value is Some(_),
+    )
+    ignore(element_attrs.aria_label(aria_label))
+    if model.value is Some(value) {
+      ignore(element_attrs.data_set("value", value))
+    }
+    let rendered_children = children(scope)
+    let automatic_viewport = if viewport && !scope.viewport_rendered.val {
+      render_navigation_menu_viewport(
+        scope,
+        None,
+        None,
+        None,
+        [],
+        @html.nothing,
+      )
+    } else {
+      @html.nothing
+    }
+    @html.nav(
+      style=ui_styles(
+        [UiBoxSizing, UiFontSans, UiTextRendering, NavigationMenuRootStyle],
+        style,
+      ),
+      id=id + "-root",
+      class?,
+      title?,
+      attrs=element_attrs,
+      [rendered_children, automatic_viewport],
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn navigation_menu(
+  id~ : String,
+  default_value? : String,
+  viewport? : Bool = true,
+  on_value_change? : @cmd.Emit[String?],
+  aria_label? : String = "Main navigation",
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (NavigationMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_value_change)
+  let model : NavigationMenuModel = {
+    value: default_value,
+    index: if default_value is Some(_) {
+      0
+    } else {
+      -1
+    },
+    focus_index: -1,
+  }
+  let scope : NavigationMenuScope = {
+    id,
+    model,
+    counter: Ref(0),
+    focus_claimed: Ref(false),
+    viewport,
+    contents: Ref([]),
+    viewport_rendered: Ref(false),
+    activate: menu_noop_emit(),
+    toggle: menu_noop_emit(),
+    close_command: @cmd.none,
+  }
+  let element_attrs = menu_state_attrs(
+    attrs,
+    "navigation-menu",
+    default_value is Some(_),
+  )
+  ignore(element_attrs.aria_label(aria_label))
+  if default_value is Some(value) {
+    ignore(element_attrs.data_set("value", value))
+  }
+  let rendered_children = children(scope)
+  let automatic_viewport = if viewport && !scope.viewport_rendered.val {
+    render_navigation_menu_viewport(scope, None, None, None, [], @html.nothing)
+  } else {
+    @html.nothing
+  }
+  @rabbita.Val::constant(
+    @html.nav(
+      style=ui_styles(
+        [UiBoxSizing, UiFontSans, UiTextRendering, NavigationMenuRootStyle],
+        style,
+      ),
+      id=id + "-root",
+      class?,
+      title?,
+      attrs=element_attrs,
+      [rendered_children, automatic_viewport],
+    ),
+  )
+}
+
+///|
+/// Explicit Root spelling matching the compound-component API.
+pub fn navigation_menu_root(
+  id~ : String,
+  default_value? : String,
+  viewport? : Bool = true,
+  on_value_change? : @cmd.Emit[String?],
+  aria_label? : String = "Main navigation",
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (NavigationMenuScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  navigation_menu(
+    id~,
+    default_value?,
+    viewport~,
+    on_value_change?,
+    aria_label~,
+    class?,
+    title?,
+    attrs?,
+    style~,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] navigation_menu_list(
+  scope : NavigationMenuScope,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  ignore(scope)
+  @html.ul(
+    style=ui_styles([UiBoxSizing, NavigationMenuListStyle], style),
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "navigation-menu-list"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] navigation_menu_item(
+  scope : NavigationMenuScope,
+  value~ : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (NavigationMenuItemScope) -> C,
+) -> @html.Html {
+  let index = scope.counter.val
+  scope.counter.val += 1
+  let open = scope.model.value == Some(value)
+  let item_scope : NavigationMenuItemScope = {
+    id: scope.id,
+    value,
+    index,
+    open,
+    focus_index: scope.model.focus_index,
+    focus_claimed: scope.focus_claimed,
+    active_value_set: scope.model.value is Some(_),
+    viewport: scope.viewport,
+    contents: scope.contents,
+    activate_command: (scope.activate)((value, index)),
+    toggle_command: (scope.toggle)((value, index)),
+    close_command: scope.close_command,
+  }
+  @html.li(
+    style=ui_styles([UiBoxSizing, NavigationMenuItemStyle], style),
+    class?,
+    title?,
+    attrs=menu_state_attrs(attrs, "navigation-menu-item", open)
+      .data_set("value", value)
+      .data_set("navigation-index", "\{index}"),
+    children(item_scope),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] navigation_menu_trigger(
+  scope : NavigationMenuItemScope,
+  disabled? : Bool = false,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let preferred = if scope.active_value_set {
+    scope.open
+  } else if scope.focus_index >= 0 {
+    scope.focus_index == scope.index
+  } else {
+    !scope.focus_claimed.val
+  }
+  let tab_stop = !disabled && preferred
+  let element_attrs = menu_state_attrs(
+      attrs,
+      "navigation-menu-trigger",
+      scope.open,
+    )
+    .data_set("navigation-value", scope.value)
+    .data_set("navigation-index", "\{scope.index}")
+    .aria_expanded(ui_bool(scope.open))
+    .aria_controls(navigation_content_id(scope.id, scope.index))
+  ignore(element_attrs.tabindex(if tab_stop { 0 } else { -1 }))
+  if tab_stop {
+    scope.focus_claimed.val = true
+  }
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  } else {
+    if on_click is Some(on_click) {
+      ignore(element_attrs.on_click(_ => on_click))
+    }
+    ignore(element_attrs.on_click(_ => scope.toggle_command))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        NavigationMenuTriggerStyle,
+        if scope.viewport {
+          if scope.open {
+            popup_anchor_style(navigation_viewport_anchor_id(scope.id))
+          } else {
+            ""
+          }
+        } else {
+          popup_anchor_style(navigation_trigger_id(scope.id, scope.index))
+        },
+        if scope.open {
+          NavigationMenuTriggerOpenStyle
+        } else {
+          ""
+        },
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id=navigation_trigger_id(scope.id, scope.index),
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    [
+      @html.span(style=[UiBoxSizing, "display:contents"], children),
+      @html.span(
+        style=[
+          UiBoxSizing,
+          NavigationMenuChevronBoxStyle,
+          if scope.open {
+            "transform:rotate(180deg)"
+          } else {
+            ""
+          },
+        ],
+        attrs=@html.Attrs::build()
+          .aria_hidden("true")
+          .data_set("icon", "chevron-down"),
+        @html.span(
+          style=[UiBoxSizing, NavigationMenuChevronStyle],
+          @html.nothing,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] navigation_menu_content(
+  scope : NavigationMenuItemScope,
+  side_offset? : Int = 8,
+  align_offset? : Int = 0,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let trigger_id = navigation_trigger_id(scope.id, scope.index)
+  let element_attrs = menu_state_attrs(
+      attrs,
+      "navigation-menu-content",
+      scope.open,
+    )
+    .role("region")
+    .tabindex(-1)
+    .aria_labelledby(trigger_id)
+    .data_set("trigger-id", trigger_id)
+    .data_set("requested-side", "bottom")
+    .data_set("requested-align", "center")
+    .data_set("side", "bottom")
+    .data_set("align", "center")
+    .data_set("side-offset", "\{side_offset}")
+    .data_set("align-offset", "\{align_offset}")
+    .data_set("navigation-value", scope.value)
+    .data_set("navigation-index", "\{scope.index}")
+  if !scope.viewport {
+    ignore(element_attrs.popover("auto"))
+  }
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  let content = @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        if scope.viewport {
+          NavigationMenuViewportContentStyle
+        } else {
+          NavigationMenuContentStyle
+        },
+        if scope.viewport {
+          ""
+        } else {
+          PopupTransition150Style
+        },
+        if scope.viewport {
+          ""
+        } else {
+          popup_floating_anchor_style(
+            trigger_id,
+            Bottom,
+            Center,
+            side_offset,
+            align_offset,
+          )
+        },
+        if scope.viewport {
+          ""
+        } else {
+          popup_state_style(scope.open)
+        },
+      ],
+      style,
+    ),
+    id=navigation_content_id(scope.id, scope.index),
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+  if scope.viewport {
+    scope.contents.val.push({ value: scope.value, content })
+    @html.nothing
+  } else {
+    content
+  }
+}
+
+///|
+fn render_navigation_menu_viewport(
+  scope : NavigationMenuScope,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  custom : @html.Html,
+) -> @html.Html {
+  let viewport_children : Array[@html.Html] = []
+  let open = scope.model.value is Some(_)
+  for entry in scope.contents.val {
+    if scope.model.value == Some(entry.value) {
+      viewport_children.push(entry.content)
+    }
+  }
+  viewport_children.push(custom)
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        NavigationMenuViewportStyle,
+        navigation_viewport_position_style(scope.id),
+        if scope.model.value is Some(_) {
+          "visibility:visible;opacity:1;pointer-events:auto"
+        } else {
+          "visibility:hidden;opacity:0;pointer-events:none"
+        },
+      ],
+      style,
+    ),
+    class?,
+    title?,
+    attrs=menu_state_attrs(attrs, "navigation-menu-viewport", open)
+      .aria_hidden(ui_bool(!open))
+      .inert(!open),
+    viewport_children,
+  )
+}
+
+///|
+/// Render the shared viewport. Content parts registered by the active menu
+/// item are mounted here; optional children are appended for custom chrome.
+pub fn[C : @html.IsChildren] navigation_menu_viewport(
+  scope : NavigationMenuScope,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  scope.viewport_rendered.val = true
+  render_navigation_menu_viewport(
+    scope,
+    class,
+    title,
+    attrs,
+    style,
+    @html.div(style=[UiBoxSizing, "display:contents"], children),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] navigation_menu_link(
+  href~ : String,
+  active? : Bool = false,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "navigation-menu-link")
+    .data_set("active", ui_bool(active))
+  if active {
+    ignore(element_attrs.aria_current("page").data_set("state", "active"))
+  }
+  @html.a(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        NavigationMenuLinkStyle,
+        if active {
+          NavigationMenuLinkActiveStyle
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    href~,
+    target~,
+    rel?,
+    download?,
+    attrs=element_attrs,
+    children,
+    escape~,
+  )
+}
+
+///|
+pub fn navigation_menu_indicator(
+  scope : NavigationMenuItemScope,
+  class? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.span(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        NavigationMenuIndicatorStyle,
+        if scope.open {
+          "visibility:visible;opacity:1;pointer-events:none"
+        } else {
+          "visibility:hidden;opacity:0;pointer-events:none"
+        },
+      ],
+      style,
+    ),
+    class?,
+    attrs=menu_state_attrs(attrs, "navigation-menu-indicator", scope.open).aria_hidden(
+      "true",
+    ),
+    @html.span(
+      style=[UiBoxSizing, NavigationMenuIndicatorArrowStyle],
+      @html.nothing,
+    ),
+  )
+}

--- a/rui/navigation_menu_wbtest.mbt
+++ b/rui/navigation_menu_wbtest.mbt
@@ -1,0 +1,260 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_navigation_menu_fixture(rtl : Bool) -> Unit =
+  #| rtl => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const listeners = {}
+  #|   const fixture = globalThis.__ruiNavigationMenuFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     queueMicrotask: globalThis.queueMicrotask,
+  #|     hadQueueMicrotask: own("queueMicrotask"),
+  #|     listeners,
+  #|     focused: -1,
+  #|     contentFocused: false,
+  #|     rafCount: 0,
+  #|     prevented: false,
+  #|   }
+  #|   globalThis.HTMLElement = function HTMLElement() {}
+  #|   globalThis.KeyboardEvent = function KeyboardEvent() {}
+  #|   const makeElement = properties => Object.assign(new globalThis.HTMLElement(), {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     tabIndex: -1,
+  #|     getAttribute: () => "",
+  #|     setAttribute: () => {},
+  #|     hasAttribute: () => false,
+  #|     closest: () => null,
+  #|     matches: () => false,
+  #|     getClientRects: () => [{}],
+  #|     querySelectorAll: () => [],
+  #|     addEventListener: () => {},
+  #|     focus() { fixture.documentValue.activeElement = this },
+  #|   }, properties)
+  #|   const root = makeElement({
+  #|     dataset: { state: "open" },
+  #|     isConnected: true,
+  #|     addEventListener: (type, callback) => { listeners[type] = callback },
+  #|     querySelectorAll: selector => selector === '[data-slot="navigation-menu-trigger"]'
+  #|       ? fixture.triggers
+  #|       : selector === '[data-slot="navigation-menu-content"]' ? [fixture.content] : [],
+  #|     querySelector: () => null,
+  #|     getAttribute: name => name === "data-state" ? "open" : "",
+  #|     contains: node => node === root || fixture.triggers.includes(node)
+  #|       || node === fixture.content || node === fixture.contentTarget,
+  #|     matches: () => false,
+  #|   })
+  #|   const makeTrigger = (index, expanded, disabled = false) => makeElement({
+  #|     disabled,
+  #|     tabIndex: index === 0 ? 0 : -1,
+  #|     dataset: {
+  #|       navigationIndex: String(index),
+  #|       navigationValue: `value-${index}`,
+  #|     },
+  #|     hasAttribute: name => name === "disabled" && disabled,
+  #|     getAttribute: name => name === "aria-disabled"
+  #|       ? disabled ? "true" : "false"
+  #|       : name === "aria-expanded" ? expanded ? "true" : "false"
+  #|       : name === "data-navigation-index" ? String(index)
+  #|       : name === "data-navigation-value" ? `value-${index}` : "",
+  #|     closest: selector => selector === '[data-slot="navigation-menu-trigger"]'
+  #|       ? fixture.triggers[index]
+  #|       : null,
+  #|     focus: () => {
+  #|       fixture.focused = index
+  #|       fixture.documentValue.activeElement = fixture.triggers[index]
+  #|     },
+  #|   })
+  #|   fixture.root = root
+  #|   fixture.triggers = [
+  #|     makeTrigger(0, false),
+  #|     makeTrigger(1, true),
+  #|     makeTrigger(2, false, true),
+  #|   ]
+  #|   fixture.contentTarget = makeElement({
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     getAttribute: () => "",
+  #|     closest: () => null,
+  #|     getClientRects: () => fixture.rafCount >= 2 ? [{}] : [],
+  #|     focus: () => {
+  #|       fixture.contentFocused = true
+  #|       fixture.documentValue.activeElement = fixture.contentTarget
+  #|     },
+  #|   })
+  #|   fixture.content = makeElement({
+  #|     dataset: { navigationIndex: "1", navigationValue: "value-1" },
+  #|     disabled: false,
+  #|     hidden: false,
+  #|     addEventListener: () => {},
+  #|     getAttribute: name => name === "data-navigation-index" ? "1"
+  #|       : name === "data-navigation-value" ? "value-1" : "",
+  #|     closest: () => null,
+  #|     getClientRects: () => fixture.rafCount >= 2 ? [{}] : [],
+  #|     matches: () => false,
+  #|     querySelectorAll: () => [fixture.contentTarget],
+  #|     focus: () => {
+  #|       fixture.contentFocused = true
+  #|       fixture.documentValue.activeElement = fixture.content
+  #|     },
+  #|   })
+  #|   fixture.documentValue = {
+  #|     activeElement: null,
+  #|     getElementById: id => id === "navigation-fixture" ? root : null,
+  #|     addEventListener: (type, callback) => { listeners[`document:${type}`] = callback },
+  #|     removeEventListener: (type, callback) => {
+  #|       if (listeners[`document:${type}`] === callback) delete listeners[`document:${type}`]
+  #|     },
+  #|   }
+  #|   globalThis.document = fixture.documentValue
+  #|   const getComputedStyle = node => ({
+  #|     getPropertyValue: name => name === "direction"
+  #|       ? node === root && rtl ? "rtl" : "ltr"
+  #|       : name === "display" ? "block"
+  #|       : name === "visibility" ? "visible" : "",
+  #|   })
+  #|   const requestAnimationFrame = callback => {
+  #|     fixture.rafCount += 1
+  #|     callback(fixture.rafCount)
+  #|     return fixture.rafCount
+  #|   }
+  #|   const windowValue = {
+  #|     document: fixture.documentValue,
+  #|     getComputedStyle,
+  #|     requestAnimationFrame,
+  #|     queueMicrotask: callback => callback(),
+  #|     setTimeout: callback => { callback(); return 1 },
+  #|     clearTimeout: () => {},
+  #|     performance: { now: () => fixture.rafCount },
+  #|   }
+  #|   globalThis.window = windowValue
+  #|   globalThis.getComputedStyle = getComputedStyle
+  #|   globalThis.requestAnimationFrame = requestAnimationFrame
+  #|   globalThis.queueMicrotask = callback => callback()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_navigation_menu_fixture_tab_index(index : Int) -> Int =
+  #| index => globalThis.__ruiNavigationMenuFixture.triggers[index].tabIndex
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_navigation_menu_key(index : Int, key : String) -> Bool =
+  #| (index, key) => {
+  #|   const fixture = globalThis.__ruiNavigationMenuFixture
+  #|   fixture.prevented = false
+  #|   const event = Object.assign(new globalThis.KeyboardEvent(), {
+  #|     target: fixture.triggers[index],
+  #|     key,
+  #|     defaultPrevented: false,
+  #|     preventDefault: () => {
+  #|       fixture.prevented = true
+  #|       event.defaultPrevented = true
+  #|     },
+  #|   })
+  #|   fixture.listeners.keydown(event)
+  #|   return fixture.prevented
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_navigation_menu_fixture_focused() -> Int =
+  #| () => globalThis.__ruiNavigationMenuFixture.focused
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_navigation_menu_fixture_content_focused() -> Bool =
+  #| () => globalThis.__ruiNavigationMenuFixture.contentFocused
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_navigation_menu_outside_press() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiNavigationMenuFixture
+  #|   fixture.listeners["document:pointerdown"]({ target: {} })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_navigation_menu_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiNavigationMenuFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadKeyboardEvent) globalThis.KeyboardEvent = fixture.KeyboardEvent
+  #|   else delete globalThis.KeyboardEvent
+  #|   if (fixture.hadGetComputedStyle) globalThis.getComputedStyle = fixture.getComputedStyle
+  #|   else delete globalThis.getComputedStyle
+  #|   if (fixture.hadRequestAnimationFrame) {
+  #|     globalThis.requestAnimationFrame = fixture.requestAnimationFrame
+  #|   } else delete globalThis.requestAnimationFrame
+  #|   if (fixture.hadQueueMicrotask) globalThis.queueMicrotask = fixture.queueMicrotask
+  #|   else delete globalThis.queueMicrotask
+  #|   delete globalThis.__ruiNavigationMenuFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "navigation menu normalizes one enabled tab stop and follows RTL arrows" {
+  ffi_install_navigation_menu_fixture(true)
+  let activated = Ref(-1)
+  let closed = Ref(0)
+  bind_navigation_menu(
+    "navigation-fixture",
+    (_, index) => activated.val = index,
+    (_, _, _) => (),
+    () => closed.val += 1,
+    _ => (),
+  )
+  let first_tab_index = ffi_navigation_menu_fixture_tab_index(0)
+  let active_tab_index = ffi_navigation_menu_fixture_tab_index(1)
+  let disabled_tab_index = ffi_navigation_menu_fixture_tab_index(2)
+  let prevented = ffi_fire_navigation_menu_key(1, "ArrowRight")
+  let focused = ffi_navigation_menu_fixture_focused()
+  ffi_fire_navigation_menu_outside_press()
+  let close_count = closed.val
+  ffi_restore_navigation_menu_fixture()
+  assert_eq(first_tab_index, -1)
+  assert_eq(active_tab_index, 0)
+  assert_eq(disabled_tab_index, -1)
+  assert_true(prevented)
+  assert_eq(focused, 0)
+  assert_eq(activated.val, 0)
+  assert_eq(close_count, 1)
+}
+
+///|
+#cfg(target="js")
+test "navigation menu retries content focus across incremental frames" {
+  ffi_install_navigation_menu_fixture(false)
+  let activated = Ref(-1)
+  bind_navigation_menu(
+    "navigation-fixture",
+    (_, index) => activated.val = index,
+    (_, _, _) => (),
+    () => (),
+    _ => (),
+  )
+  let prevented = ffi_fire_navigation_menu_key(1, "ArrowDown")
+  let focused = ffi_navigation_menu_fixture_content_focused()
+  ffi_restore_navigation_menu_fixture()
+  assert_true(prevented)
+  assert_eq(activated.val, 1)
+  assert_true(focused)
+}

--- a/rui/navigation_test.mbt
+++ b/rui/navigation_test.mbt
@@ -1,0 +1,132 @@
+///|
+test "breadcrumb is semantic and composable" {
+  let html = render(
+    @rui.breadcrumb(
+      @rui.breadcrumb_list([
+        @rui.breadcrumb_item(@rui.breadcrumb_link(href="/docs", "Docs")),
+        @rui.breadcrumb_separator(),
+        @rui.breadcrumb_item(@rui.breadcrumb_page("Components")),
+      ]),
+    ),
+  )
+  assert_contains(html, "<nav")
+  assert_contains(html, "aria-label=\"breadcrumb\"")
+  assert_contains(html, "data-slot=\"breadcrumb\"")
+  assert_contains(html, "<ol")
+  assert_contains(html, "data-slot=\"breadcrumb-list\"")
+  assert_contains(html, "<a")
+  assert_contains(html, "href=\"/docs\"")
+  assert_contains(html, "data-slot=\"breadcrumb-link\"")
+  assert_contains(
+    html, "color:var(--rui-link-fg,var(--rui-link-base-fg,inherit))",
+  )
+  assert_contains(html, "role=\"presentation\"")
+  assert_contains(html, "aria-hidden=\"true\"")
+  assert_contains(html, "width:0.875rem")
+  assert_contains(html, "aria-current=\"page\"")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "data-state=\"current\"")
+}
+
+///|
+test "breadcrumb allows custom separators and appends caller style" {
+  let html = render(
+    @rui.breadcrumb_separator(children=@html.text("/"), style=[
+      "color:rebeccapurple",
+    ]),
+  )
+  assert_contains(html, ">/</li>")
+  assert_contains(html, "color:inherit;color:rebeccapurple")
+  assert_not_contains(html, "data-icon=\"inline-end\"")
+
+  let link_html = render(
+    @rui.breadcrumb_link(
+      href="/custom",
+      style=["color:rebeccapurple"],
+      "Custom",
+    ),
+  )
+  assert_contains(
+    link_html, "color:var(--rui-link-fg,var(--rui-link-base-fg,inherit));text-decoration:none",
+  )
+  assert_contains(link_html, "color:rebeccapurple")
+}
+
+///|
+test "pagination uses native anchors and exposes active state" {
+  let html = render(
+    @rui.pagination(
+      @rui.pagination_content([
+        @rui.pagination_item(@rui.pagination_previous(href="?page=1")),
+        @rui.pagination_item(
+          @rui.pagination_link(href="?page=2", is_active=true, "2"),
+        ),
+        @rui.pagination_item(@rui.pagination_ellipsis()),
+        @rui.pagination_item(@rui.pagination_next(href="?page=3")),
+      ]),
+    ),
+  )
+  assert_contains(html, "<nav")
+  assert_contains(html, "role=\"navigation\"")
+  assert_contains(html, "aria-label=\"pagination\"")
+  assert_contains(html, "data-slot=\"pagination-content\"")
+  assert_contains(html, "flex-wrap:nowrap")
+  assert_not_contains(html, "flex-wrap:wrap")
+  assert_contains(html, "data-slot=\"pagination-item\"")
+  assert_contains(html, "href=\"?page=2\"")
+  assert_contains(html, "data-slot=\"pagination-link\"")
+  assert_contains(html, "data-active=\"true\"")
+  assert_contains(html, "data-state=\"active\"")
+  assert_contains(html, "aria-current=\"page\"")
+  assert_contains(html, "aria-label=\"Go to previous page\"")
+  assert_contains(html, "aria-label=\"Go to next page\"")
+  assert_contains(html, "data-direction=\"previous\"")
+  assert_contains(html, "data-direction=\"next\"")
+  assert_contains(html, "width:1rem")
+  assert_contains(html, ">Previous</span>")
+  assert_contains(html, ">Next</span>")
+  assert_contains(html, "data-variant=\"outline\"")
+  assert_contains(html, "data-variant=\"ghost\"")
+  assert_contains(
+    html, "background:var(--rui-button-bg,var(--rui-button-base-bg,transparent))",
+  )
+  assert_contains(
+    html, "color:var(--rui-button-fg,var(--rui-button-base-fg,currentColor))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-button-shadow,var(--rui-button-base-shadow,none))",
+  )
+}
+
+///|
+test "pagination disabled links remain semantic and non-tabbable" {
+  let html = render(
+    @rui.pagination(
+      @rui.pagination_content([
+        @rui.pagination_item(
+          @rui.pagination_previous(href="?page=1", disabled=true),
+        ),
+        @rui.pagination_item(
+          @rui.pagination_link(href="?page=2", disabled=true, "2"),
+        ),
+        @rui.pagination_item(
+          @rui.pagination_next(href="?page=3", disabled=true),
+        ),
+      ]),
+    ),
+  )
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "data-disabled=\"\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "cursor:not-allowed;pointer-events:none;opacity:0.5")
+}
+
+///|
+test "navigation components preserve caller attrs" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  ignore(@rui.pagination_link(href="/", attrs~, "1"))
+  let original = render(@html.span(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-state")
+}

--- a/rui/overlay_layout_test.mbt
+++ b/rui/overlay_layout_test.mbt
@@ -1,0 +1,639 @@
+///|
+#warnings("-alert_unstable")
+fn render_overlay_value(builder : () -> @rabbita.Val[@html.Html]) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn overlay_assert_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail(
+      "expected overlay/layout HTML to contain `\{expected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+fn overlay_assert_not_contains(
+  actual : String,
+  unexpected : String,
+) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail(
+      "expected overlay/layout HTML not to contain `\{unexpected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+test "sheet drawer and sidebar static parts render on JS" {
+  let html = render_overlay_value(() => {
+    @rabbita.Val::constant(
+      @html.div([
+        @rui.sheet_header("Sheet header"),
+        @rui.sheet_footer("Sheet footer"),
+        @rui.drawer_portal([
+          @rui.drawer_handle(direction=@rui.DrawerLeft),
+          @rui.drawer_header("Drawer header"),
+        ]),
+        @rui.sidebar_menu([
+          @rui.sidebar_menu_item(
+            @rui.sidebar_menu_button(href="/projects", "Projects"),
+          ),
+        ]),
+      ]),
+    )
+  })
+  overlay_assert_contains(html, "data-slot=\"sheet-header\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-footer\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-handle\"")
+  overlay_assert_contains(html, "data-direction=\"left\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-header\"")
+  overlay_assert_not_contains(html, "data-slot=\"drawer-portal\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-menu\"")
+  overlay_assert_contains(html, "href=\"/projects\"")
+}
+
+///|
+#cfg(target="native")
+test "sheet composes a left native-dialog surface" {
+  let html = render_overlay_value(() => {
+    @rui.sheet(id="settings-sheet", default_open=true, scope => {
+      @html.div([
+        @rui.sheet_trigger(scope, "Open settings"),
+        @rui.sheet_content(
+          scope,
+          side=@rui.SheetLeft,
+          style=["width:28rem"],
+          overlay_attrs=@html.Attrs::build().data_set("owner", "overlay"),
+          [
+            @rui.sheet_header([
+              @rui.sheet_title(scope, "Settings"),
+              @rui.sheet_description(scope, "Edit workspace settings."),
+            ]),
+            @rui.sheet_footer(@rui.sheet_close(scope, "Done")),
+          ],
+        ),
+      ])
+    })
+  })
+  overlay_assert_contains(html, "<dialog")
+  overlay_assert_contains(html, "id=\"settings-sheet\"")
+  overlay_assert_contains(html, "open")
+  overlay_assert_contains(html, "closedby=\"any\"")
+  overlay_assert_contains(html, "aria-modal=\"true\"")
+  overlay_assert_contains(html, "aria-labelledby=\"settings-sheet-title\"")
+  overlay_assert_contains(
+    html, "aria-describedby=\"settings-sheet-description\"",
+  )
+  overlay_assert_contains(html, "data-slot=\"sheet-trigger\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-overlay\"")
+  overlay_assert_contains(html, "data-owner=\"overlay\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-positioner\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-content\"")
+  overlay_assert_contains(html, "data-side=\"left\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-title\"")
+  overlay_assert_contains(html, "id=\"settings-sheet-title\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-description\"")
+  overlay_assert_contains(html, "data-slot=\"sheet-close\"")
+  overlay_assert_contains(html, "data-rui-close-icon=\"\"")
+  overlay_assert_contains(html, "data-state=\"open\"")
+  overlay_assert_contains(html, "<svg")
+  overlay_assert_not_contains(html, ">×<")
+  overlay_assert_contains(html, "animation:rui-sheet-enter 200ms ease-in-out")
+  overlay_assert_contains(html, "will-change:opacity,transform")
+  overlay_assert_contains(html, "--rui-dialog-overlay-opacity:1")
+  overlay_assert_contains(html, "--rui-sheet-opacity:1")
+  overlay_assert_contains(html, "--rui-sheet-transform:translate3d(0,0,0)")
+  overlay_assert_contains(
+    html, "opacity:var(--rui-close-opacity,var(--rui-close-base-opacity,0.7))",
+  )
+  overlay_assert_contains(
+    html, "background:var(--rui-close-bg,var(--rui-button-bg,var(--rui-button-base-bg,transparent)))",
+  )
+  overlay_assert_contains(
+    html, "box-shadow:var(--rui-close-shadow,var(--rui-button-shadow,var(--rui-button-base-shadow,none)))",
+  )
+  overlay_assert_contains(html, "pointer-events:auto")
+  overlay_assert_contains(html, "width:min(85vw,24rem);height:100%")
+  overlay_assert_contains(html, "width:28rem")
+}
+
+///|
+#cfg(target="native")
+test "drawer exposes bottom handle and deliberate close control" {
+  let html = render_overlay_value(() => {
+    @rui.drawer(id="details-drawer", default_open=true, scope => {
+      @html.div([
+        @rui.drawer_trigger(scope, "Open details"),
+        @rui.drawer_portal([
+          @rui.drawer_content(
+            scope,
+            show_close=true,
+            close_on_overlay=false,
+            overlay_attrs=@html.Attrs::build().data_set("owner", "overlay"),
+            [
+              @rui.drawer_header([
+                @rui.drawer_title(scope, "Details"),
+                @rui.drawer_description(scope, "Review this record."),
+              ]),
+              @rui.drawer_footer(@rui.drawer_close(scope, "Close details")),
+            ],
+          ),
+        ]),
+      ])
+    })
+  })
+  overlay_assert_contains(html, "id=\"details-drawer\"")
+  overlay_assert_contains(html, "closedby=\"closerequest\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-overlay\"")
+  overlay_assert_contains(html, "data-owner=\"overlay\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-positioner\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-content\"")
+  overlay_assert_contains(html, "data-direction=\"bottom\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-handle\"")
+  overlay_assert_contains(html, "aria-hidden=\"true\"")
+  overlay_assert_contains(html, "cursor:grab;touch-action:none")
+  overlay_assert_contains(html, "data-slot=\"drawer-header\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-title\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-description\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-footer\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-close\"")
+  overlay_assert_contains(html, "data-rui-close-icon=\"\"")
+  overlay_assert_contains(html, "<svg")
+  overlay_assert_not_contains(html, ">×<")
+  overlay_assert_contains(
+    html, "animation:rui-drawer-enter 200ms cubic-bezier(0.22,1,0.36,1)",
+  )
+  overlay_assert_contains(html, "will-change:opacity,transform")
+  overlay_assert_contains(html, "--rui-dialog-overlay-opacity:1")
+  overlay_assert_contains(html, "--rui-drawer-opacity:1")
+  overlay_assert_contains(html, "--rui-drawer-transform:translate3d(0,0,0)")
+  overlay_assert_contains(
+    html, "opacity:var(--rui-close-opacity,var(--rui-close-base-opacity,0.7))",
+  )
+  overlay_assert_not_contains(html, "data-slot=\"drawer-portal\"")
+}
+
+///|
+#cfg(target="native")
+test "sheet and drawer forward non-modal dialog behavior" {
+  let sheet_html = render_overlay_value(() => {
+    @rui.sheet(id="nonmodal-sheet", default_open=true, modal=false, scope => {
+      @rui.sheet_content(scope, "Inspector")
+    })
+  })
+  overlay_assert_contains(sheet_html, "closedby=\"none\"")
+  overlay_assert_contains(sheet_html, "data-modal=\"false\"")
+  overlay_assert_not_contains(sheet_html, "aria-modal")
+  overlay_assert_not_contains(sheet_html, "data-slot=\"sheet-overlay\"")
+  let drawer_html = render_overlay_value(() => {
+    @rui.drawer(id="nonmodal-drawer", default_open=true, modal=false, scope => {
+      @rui.drawer_content(scope, "Inspector")
+    })
+  })
+  overlay_assert_contains(drawer_html, "closedby=\"none\"")
+  overlay_assert_contains(drawer_html, "data-modal=\"false\"")
+  overlay_assert_not_contains(drawer_html, "aria-modal")
+  overlay_assert_not_contains(drawer_html, "data-slot=\"drawer-overlay\"")
+}
+
+///|
+#cfg(target="native")
+test "closed sheet and drawer expose edge-specific exit transforms" {
+  let sheet_html = render_overlay_value(() => {
+    @rui.sheet(id="closed-right-sheet", scope => {
+      @rui.sheet_content(scope, side=@rui.SheetRight, "Settings")
+    })
+  })
+  overlay_assert_contains(sheet_html, "data-state=\"closed\"")
+  overlay_assert_contains(sheet_html, "--rui-dialog-overlay-opacity:0")
+  overlay_assert_contains(sheet_html, "--rui-sheet-opacity:0")
+  overlay_assert_contains(
+    sheet_html, "--rui-sheet-transform:translate3d(2.5rem,0,0)",
+  )
+  overlay_assert_contains(
+    sheet_html, "animation:rui-sheet-exit 200ms ease-in-out",
+  )
+  let drawer_html = render_overlay_value(() => {
+    @rui.drawer(id="closed-left-drawer", scope => {
+      @rui.drawer_content(scope, direction=@rui.DrawerLeft, "Navigation")
+    })
+  })
+  overlay_assert_contains(drawer_html, "data-state=\"closed\"")
+  overlay_assert_contains(drawer_html, "--rui-dialog-overlay-opacity:0")
+  overlay_assert_contains(drawer_html, "--rui-drawer-opacity:0")
+  overlay_assert_contains(
+    drawer_html, "--rui-drawer-transform:translate3d(calc(-100% - 2px),0,0)",
+  )
+  overlay_assert_contains(
+    drawer_html, "animation:rui-drawer-exit 200ms cubic-bezier(0.22,1,0.36,1)",
+  )
+  let bottom_drawer_html = render_overlay_value(() => {
+    @rui.drawer(id="closed-bottom-drawer", scope => {
+      @rui.drawer_content(scope, direction=@rui.DrawerBottom, "Details")
+    })
+  })
+  overlay_assert_contains(
+    bottom_drawer_html, "--rui-drawer-transform:translate3d(0,calc(100% + 2px),0)",
+  )
+}
+
+///|
+#cfg(target="native")
+test "drawer portal is transparent and overlay is independently composable" {
+  let html = render_overlay_value(() => {
+    @rui.drawer(id="standalone-drawer-parts", default_open=true, scope => {
+      @rui.drawer_portal([
+        @rui.drawer_overlay(
+          scope,
+          close_on_overlay=false,
+          id="standalone-drawer-overlay",
+          attrs=@html.Attrs::build().data_set("owner", "drawer-overlay"),
+          style=["opacity:0.6"],
+        ),
+        @html.span(attrs=@html.Attrs::build().data_set("portal-child", ""), "D"),
+      ])
+    })
+  })
+  overlay_assert_contains(html, "id=\"standalone-drawer-overlay\"")
+  overlay_assert_contains(html, "data-slot=\"drawer-overlay\"")
+  overlay_assert_contains(html, "data-state=\"open\"")
+  overlay_assert_contains(html, "data-owner=\"drawer-overlay\"")
+  overlay_assert_contains(html, "opacity:0.6")
+  overlay_assert_contains(html, "data-portal-child=\"\"")
+  overlay_assert_not_contains(html, "data-slot=\"drawer-portal\"")
+  overlay_assert_not_contains(html, "<dialog")
+}
+
+///|
+#cfg(target="native")
+test "sidebar provider renders icon-collapse compound API" {
+  let html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_collapsed=true, scope => {
+      @html.fragment([
+        @rui.sidebar(
+          scope,
+          id="workspace-sidebar",
+          collapsible=@rui.SidebarIcon,
+          variant=@rui.SidebarFloating,
+          [
+            @rui.sidebar_header(
+              @rui.sidebar_input(
+                aria_label="Search navigation",
+                placeholder="Search",
+              ),
+            ),
+            @rui.sidebar_content(
+              @rui.sidebar_group([
+                @rui.sidebar_group_label(scope~, "Workspace"),
+                @rui.sidebar_group_action(
+                  aria_label="Workspace actions",
+                  @html.nothing,
+                ),
+                @rui.sidebar_group_content(
+                  @rui.sidebar_menu([
+                    @rui.sidebar_menu_item([
+                      @rui.sidebar_menu_button(
+                        href="/overview",
+                        is_active=true,
+                        "Overview",
+                      ),
+                      @rui.sidebar_menu_badge("3"),
+                      @rui.sidebar_menu_action(
+                        show_on_hover=true,
+                        aria_label="Overview actions",
+                        @html.nothing,
+                      ),
+                    ]),
+                    @rui.sidebar_menu_item(
+                      @rui.sidebar_menu_sub(
+                        @rui.sidebar_menu_sub_item(
+                          @rui.sidebar_menu_sub_button(
+                            href="/reports",
+                            "Reports",
+                          ),
+                        ),
+                      ),
+                    ),
+                  ]),
+                ),
+              ]),
+            ),
+            @rui.sidebar_separator(),
+            @rui.sidebar_footer("Account"),
+            @rui.sidebar_rail(scope),
+          ],
+        ),
+        @rui.sidebar_inset(
+          @rui.sidebar_trigger(scope, controls="workspace-sidebar", "Toggle"),
+        ),
+      ])
+    })
+  })
+  overlay_assert_contains(html, "data-slot=\"sidebar-wrapper\"")
+  overlay_assert_contains(html, "data-state=\"collapsed\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-shell\"")
+  overlay_assert_contains(
+    html, "width:calc(var(--rui-sidebar-width-icon,3rem) + 1rem)",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar\"")
+  overlay_assert_contains(html, "data-collapsible=\"icon\"")
+  overlay_assert_contains(html, "data-variant=\"floating\"")
+  overlay_assert_contains(html, "width:var(--rui-sidebar-width-icon,3rem)")
+  overlay_assert_contains(html, "--rui-sidebar-group-label-margin:-2rem")
+  overlay_assert_contains(html, "--rui-sidebar-group-label-opacity:0")
+  overlay_assert_contains(html, "--rui-sidebar-group-label-pointer-events:none")
+  overlay_assert_contains(html, "--rui-sidebar-group-action-display:none")
+  overlay_assert_contains(html, "--rui-sidebar-menu-action-display:none")
+  overlay_assert_contains(html, "--rui-sidebar-menu-badge-display:none")
+  overlay_assert_contains(html, "--rui-sidebar-menu-sub-display:none")
+  overlay_assert_contains(html, "--rui-sidebar-input-display:none")
+  overlay_assert_contains(html, "--rui-sidebar-content-overflow-y:hidden")
+  overlay_assert_contains(html, "--rui-sidebar-item-collapse-gap:0")
+  overlay_assert_contains(html, "--rui-sidebar-item-collapse-font-size:0")
+  overlay_assert_contains(html, "--rui-sidebar-item-collapse-width:2rem")
+  overlay_assert_contains(html, "--rui-sidebar-item-collapse-height:2rem")
+  overlay_assert_contains(html, "--rui-sidebar-item-justify-content:center")
+  overlay_assert_contains(html, "data-slot=\"sidebar-header\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-input\"")
+  overlay_assert_contains(
+    html, "--rui-control-base-shadow:0 0 #0000;background:var(--rui-background,oklch(1 0 0));font-size:0.875rem",
+  )
+  overlay_assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)))",
+  )
+  overlay_assert_not_contains(
+    html, "box-shadow:0 1px 2px rgb(0 0 0 / 0.05);height:2rem",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-content\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-group\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-group-label\"")
+  overlay_assert_contains(
+    html, "color:var(--rui-sidebar-label-fg,var(--rui-sidebar-label-base-fg,color-mix(in oklab,var(--rui-sidebar-foreground",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-group-action\"")
+  overlay_assert_contains(
+    html, "position:absolute;top:0.875rem;inset-inline-end:0.75rem",
+  )
+  overlay_assert_contains(
+    html, "background:var(--rui-sidebar-action-bg,var(--rui-button-bg,var(--rui-button-base-bg,transparent)))",
+  )
+  overlay_assert_contains(html, "data-state=\"auto\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-menu-button\"")
+  overlay_assert_contains(html, "aria-current=\"page\"")
+  overlay_assert_contains(
+    html, "background:var(--rui-sidebar-item-bg,var(--rui-sidebar-item-base-bg,transparent))",
+  )
+  overlay_assert_contains(
+    html, "--rui-sidebar-item-base-bg:var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)))",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-menu-badge\"")
+  overlay_assert_contains(
+    html, "color:var(--rui-sidebar-badge-fg,var(--rui-sidebar-badge-base-fg,inherit))",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-menu-action\"")
+  overlay_assert_contains(html, "data-show-on-hover=\"true\"")
+  overlay_assert_contains(
+    html, "opacity:var(--rui-sidebar-action-opacity,var(--rui-sidebar-action-base-opacity,1))",
+  )
+  overlay_assert_contains(html, "--rui-sidebar-action-base-opacity:0")
+  overlay_assert_contains(html, "data-slot=\"sidebar-menu-sub\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-menu-sub-button\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-separator\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-footer\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-rail\"")
+  overlay_assert_contains(html, "tabindex=\"-1\"")
+  overlay_assert_contains(html, "data-min-width=\"160\"")
+  overlay_assert_contains(html, "data-max-width=\"512\"")
+  overlay_assert_contains(html, "touch-action:none;user-select:none")
+  overlay_assert_contains(
+    html, "left:var(--rui-sidebar-rail-left,auto);right:var(--rui-sidebar-rail-right,-0.5rem)",
+  )
+  overlay_assert_contains(
+    html, "--rui-sidebar-rail-left:auto;--rui-sidebar-rail-right:-0.5rem",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-rail-line\"")
+  overlay_assert_contains(
+    html, "background:var(--rui-sidebar-rail-line-bg,transparent)",
+  )
+  overlay_assert_contains(
+    html, "pointer-events:none;transform:translateX(-50%)",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-trigger\"")
+  overlay_assert_contains(html, "aria-controls=\"workspace-sidebar\"")
+  overlay_assert_contains(html, "width:1.75rem;height:1.75rem")
+  overlay_assert_contains(
+    html, "width:1.25rem;height:1.25rem;--rui-button-icon-size:1rem",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-inset\"")
+  overlay_assert_contains(html, "role=\"main\"")
+}
+
+///|
+#cfg(target="native")
+test "fixed sidebar keeps group labels visible when provider is collapsed" {
+  let html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_collapsed=true, scope => {
+      @rui.sidebar(
+        scope,
+        collapsible=@rui.SidebarFixed,
+        @rui.sidebar_group_label(scope~, "Always visible"),
+      )
+    })
+  })
+  overlay_assert_contains(html, "data-collapsible=\"none\"")
+  overlay_assert_contains(html, "data-state=\"expanded\"")
+  overlay_assert_contains(html, "data-slot=\"sidebar-shell\"")
+  overlay_assert_contains(
+    html, "width:var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  )
+  overlay_assert_contains(html, "data-slot=\"sidebar-group-label\"")
+  overlay_assert_not_contains(html, "--rui-sidebar-group-label-margin:-2rem")
+  overlay_assert_not_contains(html, "--rui-sidebar-group-label-opacity:0")
+}
+
+///|
+#cfg(target="native")
+test "mobile sidebar transitions a dismissible backdrop and inert surface" {
+  let open_html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_mobile_open=true, scope => {
+      @rui.sidebar(scope, mobile=true, "Mobile navigation")
+    })
+  })
+  overlay_assert_contains(open_html, "data-slot=\"sidebar-overlay\"")
+  overlay_assert_contains(open_html, "data-slot=\"sidebar-mobile-layer\"")
+  overlay_assert_contains(open_html, "popover=\"manual\"")
+  overlay_assert_contains(open_html, "transition:display 200ms,overlay 200ms")
+  overlay_assert_contains(open_html, "data-mobile=\"true\"")
+  overlay_assert_contains(open_html, "role=\"dialog\"")
+  overlay_assert_contains(open_html, "aria-modal=\"true\"")
+  overlay_assert_contains(open_html, "autofocus")
+  overlay_assert_contains(open_html, "tabindex=\"-1\"")
+  overlay_assert_contains(open_html, "data-mobile-state=\"open\"")
+  overlay_assert_contains(open_html, "transform:translateX(0)")
+  overlay_assert_contains(
+    open_html, "pointer-events:auto;outline:none;box-shadow",
+  )
+  overlay_assert_contains(open_html, "--rui-sidebar-overlay-opacity:1")
+  let closed_html = render_overlay_value(() => {
+    @rui.sidebar_provider(scope => {
+      @rui.sidebar(scope, mobile=true, "Mobile navigation")
+    })
+  })
+  overlay_assert_contains(closed_html, "data-state=\"closed\"")
+  overlay_assert_contains(closed_html, "data-mobile-state=\"closed\"")
+  overlay_assert_contains(closed_html, "aria-hidden=\"true\"")
+  overlay_assert_contains(closed_html, "inert")
+  overlay_assert_contains(closed_html, "transform:translateX(-100%)")
+  overlay_assert_contains(closed_html, "--rui-sidebar-overlay-opacity:0")
+  overlay_assert_not_contains(closed_html, "display:none")
+}
+
+///|
+#cfg(target="native")
+test "sidebar resets desktop collapse on mobile and mirrors right inset spacing" {
+  let mobile_html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_collapsed=true, default_mobile_open=true, scope => {
+      @rui.sidebar(
+        scope,
+        mobile=true,
+        @rui.sidebar_group_label(scope~, "Workspace"),
+      )
+    })
+  })
+  overlay_assert_contains(mobile_html, "data-mobile=\"true\"")
+  overlay_assert_contains(mobile_html, "data-state=\"expanded\"")
+  overlay_assert_contains(
+    mobile_html, "width:min(var(--rui-sidebar-width-mobile,18rem),calc(100vw - 2rem))",
+  )
+  overlay_assert_contains(mobile_html, "--rui-sidebar-group-label-margin:0")
+  overlay_assert_contains(mobile_html, "--rui-sidebar-group-label-opacity:1")
+  overlay_assert_contains(
+    mobile_html, "--rui-sidebar-group-label-pointer-events:auto",
+  )
+  overlay_assert_contains(mobile_html, "--rui-sidebar-item-collapse-gap:0.5rem")
+  overlay_assert_contains(
+    mobile_html, "--rui-sidebar-item-collapse-font-size:var(--rui-sidebar-item-base-font-size,0.875rem)",
+  )
+
+  let right_html = render_overlay_value(() => {
+    @rui.sidebar_provider(scope => {
+      @rui.sidebar(
+        scope,
+        side=@rui.SidebarRight,
+        variant=@rui.SidebarInset,
+        "Right navigation",
+      )
+    })
+  })
+  overlay_assert_contains(right_html, "data-slot=\"sidebar-shell\"")
+  overlay_assert_contains(right_html, "data-side=\"right\"")
+  overlay_assert_contains(right_html, "data-variant=\"inset\"")
+  overlay_assert_contains(right_html, "order:1")
+  overlay_assert_contains(
+    right_html, "width:var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  )
+  overlay_assert_contains(
+    right_html, "width:calc(var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem)) - 1rem)",
+  )
+  overlay_assert_contains(right_html, "top:0.5rem;bottom:0.5rem;right:0.5rem")
+  overlay_assert_contains(
+    right_html, "border:0;border-radius:0;box-shadow:none",
+  )
+}
+
+///|
+#cfg(target="native")
+test "offcanvas collapse slides the surface while its shell releases layout width" {
+  let collapsed_html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_collapsed=true, scope => {
+      @rui.sidebar(
+        scope,
+        collapsible=@rui.SidebarOffcanvas,
+        variant=@rui.SidebarFloating,
+        "Navigation",
+      )
+    })
+  })
+  overlay_assert_contains(collapsed_html, "data-slot=\"sidebar-shell\"")
+  overlay_assert_contains(collapsed_html, "data-state=\"collapsed\"")
+  overlay_assert_contains(collapsed_html, "width:0px")
+  overlay_assert_contains(
+    collapsed_html, "width:calc(var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem)) - 1rem)",
+  )
+  overlay_assert_contains(
+    collapsed_html, "transform:translateX(calc(-100% - 0.5rem))",
+  )
+  overlay_assert_contains(
+    collapsed_html, "--rui-sidebar-rail-left:auto;--rui-sidebar-rail-right:-1rem;--rui-sidebar-rail-line-left:0%",
+  )
+  overlay_assert_contains(
+    collapsed_html, "border-radius:var(--rui-radius,0.625rem);box-shadow:0 1px 3px rgb(0 0 0 / 0.08)",
+  )
+  overlay_assert_not_contains(
+    collapsed_html, "width:0;min-width:0;margin:0;border:0;padding:0;box-shadow:none;overflow:hidden",
+  )
+
+  let right_html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_collapsed=true, scope => {
+      @rui.sidebar(
+        scope,
+        side=@rui.SidebarRight,
+        collapsible=@rui.SidebarOffcanvas,
+        [@html.span("Right navigation"), @rui.sidebar_rail(scope)],
+      )
+    })
+  })
+  overlay_assert_contains(right_html, "data-side=\"right\"")
+  overlay_assert_contains(right_html, "order:1")
+  overlay_assert_contains(right_html, "width:0px")
+  overlay_assert_contains(right_html, "transform:translateX(100%)")
+  overlay_assert_contains(
+    right_html, "--rui-sidebar-rail-left:-0.5rem;--rui-sidebar-rail-right:auto",
+  )
+  overlay_assert_contains(
+    right_html, "--rui-sidebar-rail-left:-1rem;--rui-sidebar-rail-right:auto;--rui-sidebar-rail-line-left:100%",
+  )
+  overlay_assert_contains(
+    right_html, "pointer-events:none;transform:translateX(-50%)",
+  )
+
+  let hidden_mobile_html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_mobile_open=true, scope => {
+      @rui.sidebar(scope, mobile=true, hidden=true, "Navigation")
+    })
+  })
+  overlay_assert_contains(hidden_mobile_html, "data-mobile-state=\"closed\"")
+  overlay_assert_contains(hidden_mobile_html, "aria-hidden=\"true\"")
+  overlay_assert_contains(hidden_mobile_html, "--rui-sidebar-overlay-opacity:0")
+  overlay_assert_contains(hidden_mobile_html, " hidden>")
+}
+
+///|
+#cfg(target="native")
+test "sidebar black-box defaults render desktop and mobile state" {
+  let html = render_overlay_value(() => {
+    @rui.sidebar_provider(default_collapsed=true, default_mobile_open=false, scope => {
+      @html.fragment([
+        @rui.sidebar(
+          scope,
+          id="default-sidebar",
+          collapsible=@rui.SidebarIcon,
+          "Navigation",
+        ),
+        @rui.sidebar_trigger(
+          scope,
+          controls="default-sidebar",
+          "Toggle navigation",
+        ),
+      ])
+    })
+  })
+  overlay_assert_contains(html, "data-slot=\"sidebar-wrapper\"")
+  overlay_assert_contains(html, "data-state=\"collapsed\"")
+  overlay_assert_contains(html, "data-mobile=\"closed\"")
+  overlay_assert_contains(html, "aria-expanded=\"false\"")
+  overlay_assert_contains(html, "aria-controls=\"default-sidebar\"")
+}

--- a/rui/pagination.mbt
+++ b/rui/pagination.mbt
@@ -1,0 +1,339 @@
+///|
+const PaginationRootStyle : String = "display:flex;width:100%;min-width:0;justify-content:center;margin-inline:auto"
+
+///|
+const PaginationContentStyle : String = "display:flex;max-width:100%;flex-wrap:nowrap;align-items:center;justify-content:center;gap:0.25rem;margin:0;padding:0;list-style:none"
+
+///|
+const PaginationItemStyle : String = "display:block"
+
+///|
+const PaginationLinkResetStyle : String = "text-decoration:none"
+
+///|
+const PaginationPreviousStyle : String = "padding-inline-start:0.5rem"
+
+///|
+const PaginationNextStyle : String = "padding-inline-end:0.5rem"
+
+///|
+const PaginationChevronBoxStyle : String = "display:inline-flex;width:1rem;height:1rem;flex-shrink:0;align-items:center;justify-content:center"
+
+///|
+const PaginationChevronStyle : String = "display:block;width:0.4375rem;height:0.4375rem;border-right:1.5px solid currentColor;border-bottom:1.5px solid currentColor;transform-origin:center"
+
+///|
+const PaginationChevronPreviousStyle : String = "transform:rotate(135deg)"
+
+///|
+const PaginationChevronNextStyle : String = "transform:rotate(-45deg)"
+
+///|
+const PaginationEllipsisStyle : String = "display:inline-flex;width:2.25rem;height:2.25rem;align-items:center;justify-content:center;color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+
+///|
+const PaginationDotsStyle : String = "display:block;width:0.1875rem;height:0.1875rem;border-radius:9999px;background:currentColor;box-shadow:-0.3125rem 0 currentColor,0.3125rem 0 currentColor"
+
+///|
+const PaginationScreenReaderOnlyStyle : String = "position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0"
+
+///|
+fn pagination_part_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+fn pagination_state(is_active : Bool) -> String {
+  if is_active {
+    "active"
+  } else {
+    "inactive"
+  }
+}
+
+///|
+#cfg(target="js")
+fn pagination_bind_disabled(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn pagination_bind_disabled(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+/// Render the semantic navigation root for a pagination control.
+pub fn[C : @html.IsChildren] pagination(
+  aria_label? : String = "pagination",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = pagination_part_attrs(attrs, "pagination")
+    .role("navigation")
+    .aria_label(aria_label)
+  @html.nav(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, PaginationRootStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the list that contains pagination items.
+pub fn[C : @html.IsChildren] pagination_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.ul(
+    style=ui_styles([UiBoxSizing, PaginationContentStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=pagination_part_attrs(attrs, "pagination-content"),
+    children,
+  )
+}
+
+///|
+/// Render one semantic list item in a pagination control.
+pub fn[C : @html.IsChildren] pagination_item(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.li(
+    style=ui_styles([UiBoxSizing, PaginationItemStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=pagination_part_attrs(attrs, "pagination-item"),
+    children,
+  )
+}
+
+///|
+/// Render a native page anchor using the Vega button recipe.
+///
+/// Active links expose both `aria-current="page"` and stable data state.
+pub fn[C : @html.IsChildren] pagination_link(
+  href~ : String,
+  is_active? : Bool = false,
+  disabled? : Bool = false,
+  size? : ButtonSize = Icon,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let variant : ButtonVariant = if is_active { Outline } else { Ghost }
+  let element_attrs = pagination_part_attrs(attrs, "pagination-link")
+    .data_set("active", ui_bool(is_active))
+    .data_set("state", pagination_state(is_active))
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+  if is_active {
+    ignore(element_attrs.aria_current("page"))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  }
+  pagination_bind_disabled(element_attrs, disabled)
+  if aria_label is Some(aria_label) {
+    ignore(element_attrs.aria_label(aria_label))
+  }
+  @html.a(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        PaginationLinkResetStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    href~,
+    target~,
+    rel?,
+    download?,
+    attrs=element_attrs,
+    children,
+    escape~,
+  )
+}
+
+///|
+/// Render a previous-page anchor with a dependency-free CSS chevron.
+pub fn pagination_previous(
+  href~ : String,
+  disabled? : Bool = false,
+  text? : String = "Previous",
+  aria_label? : String = "Go to previous page",
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("direction", "previous")
+  pagination_link(
+    href~,
+    disabled~,
+    size=Default,
+    aria_label~,
+    target~,
+    rel?,
+    download?,
+    escape~,
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    style=ui_styles([PaginationPreviousStyle], style),
+    [
+      @html.span(
+        style=[UiBoxSizing, PaginationChevronBoxStyle],
+        attrs=@html.Attrs::build()
+          .aria_hidden("true")
+          .data_set("icon", "inline-start"),
+        @html.span(
+          style=[
+            UiBoxSizing,
+            PaginationChevronStyle,
+            PaginationChevronPreviousStyle,
+          ],
+          @html.nothing,
+        ),
+      ),
+      @html.span(text),
+    ],
+  )
+}
+
+///|
+/// Render a next-page anchor with a dependency-free CSS chevron.
+pub fn pagination_next(
+  href~ : String,
+  disabled? : Bool = false,
+  text? : String = "Next",
+  aria_label? : String = "Go to next page",
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  escape? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("direction", "next")
+  pagination_link(
+    href~,
+    disabled~,
+    size=Default,
+    aria_label~,
+    target~,
+    rel?,
+    download?,
+    escape~,
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    style=ui_styles([PaginationNextStyle], style),
+    [
+      @html.span(text),
+      @html.span(
+        style=[UiBoxSizing, PaginationChevronBoxStyle],
+        attrs=@html.Attrs::build()
+          .aria_hidden("true")
+          .data_set("icon", "inline-end"),
+        @html.span(
+          style=[
+            UiBoxSizing,
+            PaginationChevronStyle,
+            PaginationChevronNextStyle,
+          ],
+          @html.nothing,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+/// Render the collapsed-range marker used by long pagination controls.
+pub fn pagination_ellipsis(
+  label? : String = "More pages",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = pagination_part_attrs(attrs, "pagination-ellipsis")
+    .role("presentation")
+    .aria_hidden("true")
+  @html.span(
+    style=ui_styles([UiBoxSizing, PaginationEllipsisStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    [
+      @html.span(
+        style=[UiBoxSizing, PaginationDotsStyle],
+        attrs=@html.Attrs::build().data_set("icon", "ellipsis"),
+        @html.nothing,
+      ),
+      @html.span(style=[PaginationScreenReaderOnlyStyle], label),
+    ],
+  )
+}

--- a/rui/pkg.generated.mbti
+++ b/rui/pkg.generated.mbti
@@ -1,0 +1,1233 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "Yoorkin/rui"
+
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn accordion(items~ : Array[AccordionEntry], type_? : AccordionType, collapsible? : Bool, disabled? : Bool, default_value? : String, default_values? : Array[String], show_indicator? : Bool, force_mount? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], item_style? : Array[String], trigger_style? : Array[String], content_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] accordion_content(value~ : String, open? : Bool, force_mount? : Bool, labelledby? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn accordion_entry(value~ : String, label~ : String, content~ : @html.Html, disabled? : Bool) -> AccordionEntry
+
+pub fn[C : @html.IsChildren] accordion_item(value~ : String, open? : Bool, disabled? : Bool, name? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] accordion_root(type_? : AccordionType, disabled? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] accordion_trigger(value~ : String, open? : Bool, disabled? : Bool, controls? : String, show_indicator? : Bool, on_value_change? : @cmd.Emit[String], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert(variant? : AlertVariant, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_action(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn alert_dialog(id~ : String, default_open? : Bool, close_on_escape? : Bool, on_open_change? : @cmd.Emit[Bool], on_close? : @cmd.Emit[String], (AlertDialogScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] alert_dialog_action(AlertDialogScope, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_cancel(AlertDialogScope, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_content(AlertDialogScope, described? : Bool, aria_label? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], overlay_attrs? : @html.Attrs, overlay_style? : Array[String], native_attrs? : @html.Attrs, native_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_description(AlertDialogScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_media(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn alert_dialog_overlay(AlertDialogScope, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn alert_dialog_portal(Array[@html.Html]) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_title(AlertDialogScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_dialog_trigger(AlertDialogScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] alert_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] aspect_ratio(ratio? : Double, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment(state? : AttachmentState, size? : AttachmentSize, orientation? : AttachmentOrientation, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_action(variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, aria_label? : String, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_actions(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_media(variant? : AttachmentMediaVariant, error? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_trigger(disabled? : Bool, on_click? : @cmd.Cmd, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] attachment_trigger_link(href~ : String, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] avatar(size? : AvatarSize, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] avatar_badge(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] avatar_fallback(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] avatar_group(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] avatar_group_count(size? : AvatarSize, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn avatar_image(src? : String, alt? : String, width? : Int, height? : Int, srcset? : String, sizes? : String, loading? : String, decoding? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] avatar_with_fallback(id~ : String, src~ : String, alt? : String, size? : AvatarSize, on_status_change? : @cmd.Emit[AvatarImageStatus], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], image_attrs? : @html.Attrs, image_style? : Array[String], fallback_attrs? : @html.Attrs, fallback_style? : Array[String], C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] badge(variant? : BadgeVariant, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] badge_link(href~ : String, variant? : BadgeVariant, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] breadcrumb(aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn breadcrumb_ellipsis(label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] breadcrumb_item(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] breadcrumb_link(href~ : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] breadcrumb_list(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] breadcrumb_page(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn breadcrumb_separator(children? : @html.Html, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] bubble(variant? : BubbleVariant, align? : ContentAlignment, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] bubble_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] bubble_content_button(disabled? : Bool, type_? : String, aria_label? : String, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] bubble_content_link(href~ : String, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] bubble_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] bubble_reactions(side? : BubbleReactionSide, align? : ContentAlignment, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] button(variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, type_? : String, id? : String, class? : String, title? : String, name? : String, value? : String, autofocus? : Bool, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], slot? : String, C) -> @html.Html
+
+pub fn[C : @html.IsChildren] button_group(orientation? : SeparatorOrientation, id? : String, class? : String, title? : String, aria_label? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn button_group_separator(orientation? : SeparatorOrientation, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] button_group_text(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn calendar(default_month? : CalendarDate, default_selected? : CalendarDate, today? : CalendarDate, show_outside_days? : Bool, disabled? : Bool, aria_label? : String, on_select? : @cmd.Emit[CalendarDate], on_month_change? : @cmd.Emit[CalendarDate], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, previous_attrs? : @html.Attrs, next_attrs? : @html.Attrs, grid_attrs? : @html.Attrs, day_attrs? : @html.Attrs, style? : Array[String], header_style? : Array[String], caption_style? : Array[String], nav_style? : Array[String], previous_style? : Array[String], next_style? : Array[String], grid_style? : Array[String], weekday_style? : Array[String], cell_style? : Array[String], day_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn calendar_date(year~ : Int, month~ : Int, day~ : Int) -> CalendarDate
+
+pub fn calendar_day_button(date~ : CalendarDate, selected? : Bool, today? : Bool, outside? : Bool, disabled? : Bool, focused? : Bool, on_select? : @cmd.Emit[CalendarDate], on_focus_change? : @cmd.Emit[CalendarDate], on_focus_move? : @cmd.Emit[CalendarDate], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn calendar_multiple(default_month? : CalendarDate, default_selected? : Array[CalendarDate], today? : CalendarDate, show_outside_days? : Bool, disabled? : Bool, aria_label? : String, on_select? : @cmd.Emit[Array[CalendarDate]], on_month_change? : @cmd.Emit[CalendarDate], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, previous_attrs? : @html.Attrs, next_attrs? : @html.Attrs, grid_attrs? : @html.Attrs, day_attrs? : @html.Attrs, style? : Array[String], header_style? : Array[String], caption_style? : Array[String], nav_style? : Array[String], previous_style? : Array[String], next_style? : Array[String], grid_style? : Array[String], weekday_style? : Array[String], cell_style? : Array[String], day_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn calendar_range(default_month? : CalendarDate, default_selected? : DateRange, today? : CalendarDate, show_outside_days? : Bool, disabled? : Bool, aria_label? : String, on_select? : @cmd.Emit[DateRange], on_month_change? : @cmd.Emit[CalendarDate], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, previous_attrs? : @html.Attrs, next_attrs? : @html.Attrs, grid_attrs? : @html.Attrs, day_attrs? : @html.Attrs, style? : Array[String], header_style? : Array[String], caption_style? : Array[String], nav_style? : Array[String], previous_style? : Array[String], next_style? : Array[String], grid_style? : Array[String], weekday_style? : Array[String], cell_style? : Array[String], day_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] card(size? : CardSize, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] card_action(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] card_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] card_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] card_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] card_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] card_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] carousel(count~ : Int, default_index? : Int, loop_? : Bool, orientation? : CarouselOrientation, aria_label? : String, on_index_change? : @cmd.Emit[Int], id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], (CarouselScope) -> C) -> @rabbita.Val[@html.Html]
+
+pub fn carousel_active_index(CarouselScope) -> Int
+
+pub fn carousel_can_next(CarouselScope) -> Bool
+
+pub fn carousel_can_previous(CarouselScope) -> Bool
+
+pub fn[C : @html.IsChildren] carousel_content(scope~ : CarouselScope, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, track_attrs? : @html.Attrs, style? : Array[String], track_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] carousel_item(scope~ : CarouselScope, index~ : Int, aria_label? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn carousel_items(scope~ : CarouselScope, items~ : Array[@html.Html], id? : String, class? : String, title? : String, attrs? : @html.Attrs, track_attrs? : @html.Attrs, style? : Array[String], track_style? : Array[String], item_style? : Array[String]) -> @html.Html
+
+pub fn carousel_next(scope~ : CarouselScope, disabled? : Bool, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn carousel_previous(scope~ : CarouselScope, disabled? : Bool, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn carousel_slide_count(CarouselScope) -> Int
+
+pub fn[C : @html.IsChildren] chart_container(aria_label? : String, aspect? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_legend(position? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_legend_content(position? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_legend_item(color? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_style(variables? : Array[(String, String)], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_tooltip(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_tooltip_content(active? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn chart_tooltip_item(label~ : String, value~ : String, color? : String, indicator? : ChartIndicator, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] chart_tooltip_label(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn checkbox(default_checked? : Bool, default_indeterminate? : Bool, disabled? : Bool, read_only? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_checked_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn[T : @html.IsChildren, C : @html.IsChildren] collapsible(default_open? : Bool, disabled? : Bool, show_indicator? : Bool, force_mount? : Bool, id? : String, trigger_id? : String, content_id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, trigger_attrs? : @html.Attrs, content_attrs? : @html.Attrs, style? : Array[String], trigger_style? : Array[String], content_style? : Array[String], content_body_style? : Array[String], trigger~ : T, content~ : C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] collapsible_content(open? : Bool, force_mount? : Bool, labelledby? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], body_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] collapsible_root(open? : Bool, disabled? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] collapsible_trigger(open? : Bool, disabled? : Bool, controls? : String, show_indicator? : Bool, on_open_change? : @cmd.Emit[Bool], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn combobox(id~ : String, options~ : Array[ComboboxOption], default_value? : String, default_values? : Array[String], multiple? : Bool, default_open? : Bool, placeholder? : String, empty_text? : String, disabled? : Bool, invalid? : Bool, required? : Bool, name? : String, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, on_value_change? : @cmd.Emit[String], on_values_change? : @cmd.Emit[Array[String]], on_query_change? : @cmd.Emit[String], on_open_change? : @cmd.Emit[Bool], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], render? : (ComboboxScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] combobox_chip(scope~ : ComboboxScope, value~ : String, removable? : Bool, remove_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_chips(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn combobox_chips_input(scope~ : ComboboxScope, aria_label? : String, auto_complete? : @html.AutoComplete, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn combobox_clear(scope~ : ComboboxScope, label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_collection(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_content(scope~ : ComboboxScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_empty(visible? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_group(label_id? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn combobox_input(scope~ : ComboboxScope, aria_label? : String, auto_complete? : @html.AutoComplete, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_item(scope~ : ComboboxScope, value~ : String, disabled? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_label(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] combobox_list(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn combobox_option(value~ : String, label~ : String, disabled? : Bool) -> ComboboxOption
+
+pub fn combobox_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn combobox_trigger(scope~ : ComboboxScope, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn combobox_value(scope~ : ComboboxScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], prefix? : @html.Html) -> @html.Html
+
+pub fn command(id~ : String, default_query? : String, should_filter? : Bool, filter? : (String, String, Array[String]) -> Bool, on_value_select? : @cmd.Emit[String], on_query_change? : @cmd.Emit[String], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (CommandScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn command_close(CommandScope) -> @cmd.Cmd
+
+pub fn command_dialog(id~ : String, default_open? : Bool, default_query? : String, should_filter? : Bool, filter? : (String, String, Array[String]) -> Bool, close_on_select? : Bool, close_on_escape? : Bool, close_on_overlay? : Bool, aria_label? : String, on_value_select? : @cmd.Emit[String], on_query_change? : @cmd.Emit[String], on_open_change? : @cmd.Emit[Bool], on_close? : @cmd.Emit[String], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], overlay_attrs? : @html.Attrs, overlay_style? : Array[String], native_attrs? : @html.Attrs, native_style? : Array[String], trigger? : (CommandScope) -> @html.Html, (CommandScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] command_dialog_trigger(scope~ : CommandScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] command_empty(scope~ : CommandScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] command_group(scope~ : CommandScope, heading? : String, heading_id? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], heading_style? : Array[String], C) -> @html.Html
+
+pub fn command_input(scope~ : CommandScope, placeholder? : String, aria_label? : String, auto_complete? : @html.AutoComplete, disabled? : Bool, on_input? : @cmd.Emit[String], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], input_style? : Array[String]) -> @html.Html
+
+pub fn command_is_open(CommandScope) -> Bool
+
+pub fn[C : @html.IsChildren] command_item(scope~ : CommandScope, value~ : String, keywords? : Array[String], disabled? : Bool, force_mount? : Bool, on_select? : @cmd.Emit[String], on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] command_list(scope~ : CommandScope, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn command_open(CommandScope) -> @cmd.Cmd
+
+pub fn command_query(CommandScope) -> String
+
+pub fn command_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] command_shortcut(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn context_menu(id~ : String, default_open? : Bool, default_checked_values? : Array[String], default_radio_values? : Array[(String, String)], on_open_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String], (ContextMenuScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] context_menu_checkbox_item(ContextMenuScope, value~ : String, disabled? : Bool, close_on_select? : Bool, on_checked_change? : @cmd.Emit[Bool], on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_content(ContextMenuScope, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_group(aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_item(ContextMenuScope, disabled? : Bool, inset? : Bool, destructive? : Bool, close_on_select? : Bool, on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_label(inset? : Bool, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn context_menu_portal(Array[@html.Html]) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_radio_group(ContextMenuScope, value~ : String, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (ContextMenuRadioGroupScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_radio_item(ContextMenuRadioGroupScope, value~ : String, disabled? : Bool, close_on_select? : Bool, on_value_change? : @cmd.Emit[String], on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn context_menu_root(id~ : String, default_open? : Bool, default_checked_values? : Array[String], default_radio_values? : Array[(String, String)], on_open_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String], (ContextMenuScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn context_menu_separator(class? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_shortcut(class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_sub(ContextMenuScope, value~ : String, attrs? : @html.Attrs, style? : Array[String], (ContextMenuSubScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_sub_content(ContextMenuSubScope, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_sub_trigger(ContextMenuSubScope, disabled? : Bool, inset? : Bool, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] context_menu_trigger(ContextMenuScope, tabindex? : Int, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[T] data_table(id~ : String, rows~ : Array[T], columns~ : Array[DataTableColumn[T]], row_key~ : (T) -> String, page_size? : Int, searchable? : Bool, selectable? : Bool, show_columns? : Bool, search_placeholder? : String, empty_text? : String, aria_label? : String, default_sort_key? : String, default_sort_descending? : Bool, default_selected? : Array[String], default_hidden_columns? : Array[String], on_selection_change? : @cmd.Emit[Array[String]], on_query_change? : @cmd.Emit[String], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn[T] data_table_column(key~ : String, label~ : String, value~ : (T) -> String, render? : (T) -> @html.Html, sortable? : Bool, searchable? : Bool, hideable? : Bool, numeric? : Bool) -> DataTableColumn[T]
+
+pub fn date_picker(id~ : String, default_value? : CalendarDate, default_month? : CalendarDate, today? : CalendarDate, default_open? : Bool, show_outside_days? : Bool, placeholder? : String, disabled? : Bool, invalid? : Bool, aria_label? : String, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, presets? : Array[DatePickerPreset], format_value? : (CalendarDate) -> String, on_value_change? : @cmd.Emit[CalendarDate], on_open_change? : @cmd.Emit[Bool], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], trigger_attrs? : @html.Attrs, trigger_style? : Array[String], content_attrs? : @html.Attrs, content_style? : Array[String], calendar_attrs? : @html.Attrs, calendar_style? : Array[String], day_attrs? : @html.Attrs, day_style? : Array[String], preset_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn date_picker_preset(label~ : String, value~ : CalendarDate) -> DatePickerPreset
+
+pub fn date_range(start~ : CalendarDate, end? : CalendarDate) -> DateRange
+
+pub fn date_range_picker(id~ : String, default_value? : DateRange, default_month? : CalendarDate, today? : CalendarDate, default_open? : Bool, show_outside_days? : Bool, placeholder? : String, disabled? : Bool, invalid? : Bool, aria_label? : String, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, format_value? : (DateRange) -> String, on_value_change? : @cmd.Emit[DateRange], on_open_change? : @cmd.Emit[Bool], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], trigger_attrs? : @html.Attrs, trigger_style? : Array[String], content_attrs? : @html.Attrs, content_style? : Array[String], calendar_attrs? : @html.Attrs, calendar_style? : Array[String], day_attrs? : @html.Attrs, day_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn dialog(id~ : String, default_open? : Bool, modal? : Bool, close_on_escape? : Bool, on_open_change? : @cmd.Emit[Bool], on_close? : @cmd.Emit[String], (DialogScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] dialog_close(DialogScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dialog_content(DialogScope, close_on_overlay? : Bool, show_close? : Bool, close_label? : String, described? : Bool, aria_label? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], overlay_attrs? : @html.Attrs, overlay_style? : Array[String], native_attrs? : @html.Attrs, native_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dialog_description(DialogScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dialog_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dialog_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn dialog_overlay(DialogScope, close_on_overlay? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn dialog_portal(Array[@html.Html]) -> @html.Html
+
+pub fn[C : @html.IsChildren] dialog_title(DialogScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dialog_trigger(DialogScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] direction(direction? : TextDirection, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn drawer(id~ : String, default_open? : Bool, modal? : Bool, close_on_escape? : Bool, on_open_change? : @cmd.Emit[Bool], on_close? : @cmd.Emit[String], (DrawerScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] drawer_close(DrawerScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] drawer_content(DrawerScope, direction? : DrawerDirection, close_on_overlay? : Bool, show_handle? : Bool, show_close? : Bool, close_label? : String, described? : Bool, aria_label? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], overlay_attrs? : @html.Attrs, overlay_style? : Array[String], native_attrs? : @html.Attrs, native_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] drawer_description(DrawerScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] drawer_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn drawer_handle(direction? : DrawerDirection, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] drawer_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn drawer_overlay(DrawerScope, close_on_overlay? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn drawer_portal(Array[@html.Html]) -> @html.Html
+
+pub fn[C : @html.IsChildren] drawer_title(DrawerScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] drawer_trigger(DrawerScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn dropdown_menu(id~ : String, default_open? : Bool, default_checked_values? : Array[String], default_radio_values? : Array[(String, String)], on_open_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String], (DropdownMenuScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] dropdown_menu_checkbox_item(DropdownMenuScope, value~ : String, disabled? : Bool, close_on_select? : Bool, on_checked_change? : @cmd.Emit[Bool], on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_content(DropdownMenuScope, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_group(aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_item(DropdownMenuScope, disabled? : Bool, inset? : Bool, destructive? : Bool, close_on_select? : Bool, on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_label(inset? : Bool, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn dropdown_menu_portal(Array[@html.Html]) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_radio_group(DropdownMenuScope, value~ : String, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (DropdownMenuRadioGroupScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_radio_item(DropdownMenuRadioGroupScope, value~ : String, disabled? : Bool, close_on_select? : Bool, on_value_change? : @cmd.Emit[String], on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn dropdown_menu_root(id~ : String, default_open? : Bool, default_checked_values? : Array[String], default_radio_values? : Array[(String, String)], on_open_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String], (DropdownMenuScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn dropdown_menu_separator(class? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_shortcut(class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_sub(DropdownMenuScope, value~ : String, attrs? : @html.Attrs, style? : Array[String], (DropdownMenuSubScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_sub_content(DropdownMenuSubScope, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_sub_trigger(DropdownMenuSubScope, disabled? : Bool, inset? : Bool, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] dropdown_menu_trigger(DropdownMenuScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, aria_label? : String, on_click? : @cmd.Cmd, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] empty(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] empty_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] empty_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] empty_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] empty_media(variant? : EmptyMediaVariant, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] empty_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field(orientation? : FieldOrientation, disabled? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_error(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_label(for_? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_legend(variant? : FieldLegendVariant, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_set(disabled? : Bool, name? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] field_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form(action? : String, name? : String, on_submit? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form_control(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form_field(name~ : String, invalid? : Bool, required? : Bool, describedby? : String, errormessage? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form_item(invalid? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form_label(for_? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] form_message(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[T : @html.IsChildren, C : @html.IsChildren] hover_card(id~ : String, href? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, default_open? : Bool, disabled? : Bool, open_delay? : Int, close_delay? : Int, hoverable? : Bool, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, trigger_variant? : ButtonVariant, trigger_size? : ButtonSize, aria_labelledby? : String, aria_describedby? : String, on_open_change? : @cmd.Emit[Bool], on_trigger_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], trigger_attrs? : @html.Attrs, trigger_style? : Array[String], content_attrs? : @html.Attrs, content_style? : Array[String], T, C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] hover_card_content(id~ : String, trigger_id~ : String, open? : Bool, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, aria_labelledby? : String, aria_describedby? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] hover_card_trigger(content_id~ : String, href~ : String, open? : Bool, disabled? : Bool, open_delay? : Int, close_delay? : Int, variant? : ButtonVariant, size? : ButtonSize, target? : @html.Target, rel? : String, download? : String, escape? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn input(input_type? : @html.InputType, name? : String, value? : String, checked? : Bool, read_only? : Bool, multiple? : Bool, accept? : String, placeholder? : String, auto_complete? : @html.AutoComplete, max? : Int, min? : Int, step? : Int, maxlength? : Int, minlength? : Int, pattern? : String, size? : Int, width? : Int, height? : Int, id? : String, class? : String, title? : String, hidden? : Bool, disabled? : Bool, required? : Bool, autofocus? : Bool, list? : String, inputmode? : String, invalid? : Bool, on_change? : @cmd.Emit[String], on_input? : @cmd.Emit[String], attrs? : @html.Attrs, style? : Array[String], slot? : String) -> @html.Html
+
+pub fn[C : @html.IsChildren] input_group(disabled? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] input_group_addon(align? : InputGroupAddonAlign, for_? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] input_group_button(size? : InputGroupButtonSize, variant? : ButtonVariant, disabled? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn input_group_control(attrs? : @html.Attrs, style? : Array[String], (@html.Attrs, Array[String]) -> @html.Html) -> @html.Html
+
+pub fn input_group_input(input_type? : @html.InputType, name? : String, value? : String, placeholder? : String, read_only? : Bool, disabled? : Bool, required? : Bool, autofocus? : Bool, invalid? : Bool, on_change? : @cmd.Emit[String], on_input? : @cmd.Emit[String], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] input_group_text(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn input_group_textarea(name? : String, value? : String, rows? : Int, cols? : Int, placeholder? : String, read_only? : Bool, disabled? : Bool, required? : Bool, autofocus? : Bool, invalid? : Bool, on_change? : @cmd.Emit[String], on_input? : @cmd.Emit[String], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn input_otp(id~ : String, max_length? : Int, default_value? : String, separator_after? : Int, disabled? : Bool, invalid? : Bool, aria_label? : String, inputmode? : String, pattern? : String, on_value_change? : @cmd.Emit[String], on_complete? : @cmd.Emit[String], class? : String, title? : String, attrs? : @html.Attrs, input_attrs? : @html.Attrs, style? : Array[String], render? : (InputOtpScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] input_otp_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn input_otp_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn input_otp_slot(scope~ : InputOtpScope, index~ : Int, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] item(variant? : ItemVariant, size? : ItemSize, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_actions(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_link(href~ : String, variant? : ItemVariant, size? : ItemSize, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_media(variant? : ItemMediaVariant, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn item_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] item_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] kbd(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] kbd_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] label(for_? : String, disabled? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] marker(variant? : MarkerVariant, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] marker_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] marker_icon(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] marker_link(href~ : String, variant? : MarkerVariant, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn menubar(id~ : String, default_value? : String, default_checked_values? : Array[String], default_radio_values? : Array[(String, String)], on_value_change? : @cmd.Emit[String?], aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (MenubarScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] menubar_checkbox_item(MenubarMenuScope, value~ : String, disabled? : Bool, close_on_select? : Bool, on_checked_change? : @cmd.Emit[Bool], on_select? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_content(MenubarMenuScope, side_offset? : Int, align_offset? : Int, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_group(aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_item(MenubarMenuScope, disabled? : Bool, inset? : Bool, destructive? : Bool, close_on_select? : Bool, on_select? : @cmd.Cmd, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_label(inset? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_menu(MenubarScope, value~ : String, attrs? : @html.Attrs, style? : Array[String], (MenubarMenuScope) -> C) -> @html.Html
+
+pub fn menubar_portal(Array[@html.Html]) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_radio_group(MenubarMenuScope, value~ : String, aria_label? : String, attrs? : @html.Attrs, style? : Array[String], (MenubarRadioGroupScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_radio_item(MenubarRadioGroupScope, value~ : String, disabled? : Bool, close_on_select? : Bool, on_value_change? : @cmd.Emit[String], on_select? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn menubar_root(id~ : String, default_value? : String, default_checked_values? : Array[String], default_radio_values? : Array[(String, String)], on_value_change? : @cmd.Emit[String?], aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (MenubarScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn menubar_separator(attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_shortcut(attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_sub(MenubarMenuScope, value~ : String, attrs? : @html.Attrs, style? : Array[String], (MenubarSubScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_sub_content(MenubarSubScope, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_sub_trigger(MenubarSubScope, disabled? : Bool, inset? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] menubar_trigger(MenubarMenuScope, disabled? : Bool, aria_label? : String, on_click? : @cmd.Cmd, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message(align? : ContentAlignment, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_avatar(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_group(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_scroller(id~ : String, default_at_end? : Bool, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (MessageScrollerScope) -> C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] message_scroller_button(scope~ : MessageScrollerScope, direction? : MessageScrollDirection, label? : String, variant? : ButtonVariant, size? : ButtonSize, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_scroller_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_scroller_item(scroll_anchor? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] message_scroller_viewport(scope~ : MessageScrollerScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] native_select(size? : NativeSelectSize, value? : String, name? : String, disabled? : Bool, required? : Bool, autofocus? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_change? : @cmd.Emit[String], attrs? : @html.Attrs, style? : Array[String], wrapper_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] native_select_optgroup(label? : String, disabled? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] native_select_option(value? : String, selected? : Bool, disabled? : Bool, label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn navigation_menu(id~ : String, default_value? : String, viewport? : Bool, on_value_change? : @cmd.Emit[String?], aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (NavigationMenuScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] navigation_menu_content(NavigationMenuItemScope, side_offset? : Int, align_offset? : Int, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn navigation_menu_indicator(NavigationMenuItemScope, class? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] navigation_menu_item(NavigationMenuScope, value~ : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (NavigationMenuItemScope) -> C) -> @html.Html
+
+pub fn[C : @html.IsChildren] navigation_menu_link(href~ : String, active? : Bool, target? : @html.Target, rel? : String, download? : String, escape? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] navigation_menu_list(NavigationMenuScope, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn navigation_menu_root(id~ : String, default_value? : String, viewport? : Bool, on_value_change? : @cmd.Emit[String?], aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (NavigationMenuScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] navigation_menu_trigger(NavigationMenuItemScope, disabled? : Bool, aria_label? : String, on_click? : @cmd.Cmd, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] navigation_menu_viewport(NavigationMenuScope, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] pagination(aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] pagination_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn pagination_ellipsis(label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] pagination_item(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] pagination_link(href~ : String, is_active? : Bool, disabled? : Bool, size? : ButtonSize, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn pagination_next(href~ : String, disabled? : Bool, text? : String, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn pagination_previous(href~ : String, disabled? : Bool, text? : String, aria_label? : String, target? : @html.Target, rel? : String, download? : String, escape? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[T : @html.IsChildren, C : @html.IsChildren] popover(id~ : String, default_open? : Bool, disabled? : Bool, modal? : Bool, initial_focus? : Bool, initial_focus_id? : String, restore_focus? : Bool, final_focus_id? : String, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, trigger_variant? : ButtonVariant, trigger_size? : ButtonSize, title_id? : String, description_id? : String, on_open_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String], trigger_attrs? : @html.Attrs, trigger_style? : Array[String], content_attrs? : @html.Attrs, content_style? : Array[String], T, C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] popover_anchor(id~ : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn popover_close(String) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] popover_close_button(target_id~ : String, disabled? : Bool, variant? : ButtonVariant, size? : ButtonSize, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] popover_content(id~ : String, trigger_id~ : String, open? : Bool, modal? : Bool, initial_focus? : Bool, initial_focus_id? : String, restore_focus? : Bool, final_focus_id? : String, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, title_id? : String, description_id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] popover_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] popover_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn popover_open(String) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] popover_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn popover_toggle(String) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] popover_trigger(target_id~ : String, open? : Bool, disabled? : Bool, variant? : ButtonVariant, size? : ButtonSize, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn progress(value? : Int, min? : Int, max? : Int, aria_label? : String, aria_value_text? : String, labelledby? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], children? : Array[@html.Html]) -> @html.Html
+
+pub fn progress_indicator(value? : Int, min? : Int, max? : Int, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] progress_label(value? : Int, min? : Int, max? : Int, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] progress_track(value? : Int, min? : Int, max? : Int, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn progress_value(value? : Int, min? : Int, max? : Int, text? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] radio_group(default_value? : String, name? : String, disabled? : Bool, required? : Bool, invalid? : Bool, orientation? : RadioGroupOrientation, on_value_change? : @cmd.Emit[String], id? : String, class? : String, title? : String, aria_label? : String, attrs? : @html.Attrs, style? : Array[String], (RadioGroupScope) -> C) -> @rabbita.Val[@html.Html]
+
+pub fn radio_group_item(scope~ : RadioGroupScope, value~ : String, disabled? : Bool, required? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, aria_label? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] radio_group_root(orientation? : RadioGroupOrientation, id? : String, class? : String, title? : String, aria_label? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] resizable_group(id~ : String, default_sizes~ : Array[Int], min_sizes? : Array[Int], max_sizes? : Array[Int], orientation? : SeparatorOrientation, aria_label? : String, on_resize? : @cmd.Emit[Array[Int]], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (ResizableGroupScope) -> C) -> @rabbita.Val[@html.Html]
+
+pub fn resizable_group_handle(scope~ : ResizableGroupScope, between~ : Int, with_handle? : Bool, aria_label? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] resizable_group_panel(scope~ : ResizableGroupScope, index~ : Int, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn resizable_handle(scope~ : ResizableScope, with_handle? : Bool, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] resizable_panel(scope~ : ResizableScope, side~ : ResizablePanelSide, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] resizable_panel_group(id~ : String, default_size? : Int, min? : Int, max? : Int, orientation? : SeparatorOrientation, aria_label? : String, on_resize? : @cmd.Emit[Int], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (ResizableScope) -> C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] scroll_area(orientation? : SeparatorOrientation, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] scroll_area_with_scrollbar(orientation? : SeparatorOrientation, id~ : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @rabbita.Val[@html.Html]
+
+pub fn scroll_bar(orientation? : SeparatorOrientation, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn select(id~ : String, options~ : Array[SelectOption], default_value? : String, default_open? : Bool, placeholder? : String, disabled? : Bool, invalid? : Bool, required? : Bool, name? : String, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, on_value_change? : @cmd.Emit[String], on_open_change? : @cmd.Emit[Bool], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], render? : (SelectScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] select_content(scope~ : SelectScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] select_group(label_id? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] select_item(scope~ : SelectScope, value~ : String, disabled? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] select_label(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn select_option(value~ : String, label~ : String, disabled? : Bool) -> SelectOption
+
+pub fn select_scroll_down_button(scope~ : SelectScope, label? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn select_scroll_up_button(scope~ : SelectScope, label? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn select_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn select_trigger(scope~ : SelectScope, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn select_value(scope~ : SelectScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], prefix? : @html.Html) -> @html.Html
+
+pub fn separator(orientation? : SeparatorOrientation, decorative? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], slot? : String) -> @html.Html
+
+pub fn sheet(id~ : String, default_open? : Bool, modal? : Bool, close_on_escape? : Bool, on_open_change? : @cmd.Emit[Bool], on_close? : @cmd.Emit[String], (SheetScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] sheet_close(SheetScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sheet_content(SheetScope, side? : SheetSide, close_on_overlay? : Bool, show_close? : Bool, close_label? : String, described? : Bool, aria_label? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], overlay_attrs? : @html.Attrs, overlay_style? : Array[String], native_attrs? : @html.Attrs, native_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sheet_description(SheetScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sheet_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sheet_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sheet_title(SheetScope, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sheet_trigger(SheetScope, variant? : ButtonVariant, size? : ButtonSize, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar(SidebarScope, side? : SidebarSide, variant? : SidebarVariant, collapsible? : SidebarCollapsible, mobile? : Bool, aria_label? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], overlay_attrs? : @html.Attrs, overlay_style? : Array[String], C) -> @html.Html
+
+pub fn sidebar_close_mobile(SidebarScope) -> @cmd.Cmd
+
+pub fn sidebar_collapse(SidebarScope) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] sidebar_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn sidebar_expand(SidebarScope) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] sidebar_footer(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_group(id? : String, class? : String, title? : String, aria_label? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_group_action(disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_group_content(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_group_label(scope? : SidebarScope, hide_when_collapsed? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_header(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn sidebar_input(name? : String, value? : String, placeholder? : String, auto_complete? : @html.AutoComplete, id? : String, class? : String, title? : String, disabled? : Bool, aria_label? : String, on_change? : @cmd.Emit[String], on_input? : @cmd.Emit[String], attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_inset(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn sidebar_is_collapsed(SidebarScope) -> Bool
+
+pub fn sidebar_is_mobile_open(SidebarScope) -> Bool
+
+pub fn[C : @html.IsChildren] sidebar_menu(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_action(show_on_hover? : Bool, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_badge(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_button(href? : String, is_active? : Bool, variant? : SidebarMenuButtonVariant, size? : SidebarMenuButtonSize, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_button_with_tooltip(id~ : String, tooltip~ : String, href? : String, is_active? : Bool, variant? : SidebarMenuButtonVariant, size? : SidebarMenuButtonSize, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, on_click? : @cmd.Cmd, on_tooltip_open_change? : @cmd.Emit[Bool], class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], tooltip_side? : PopupSide, tooltip_align? : PopupAlign, tooltip_side_offset? : Int, tooltip_align_offset? : Int, tooltip_show_arrow? : Bool, tooltip_attrs? : @html.Attrs, tooltip_style? : Array[String], C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] sidebar_menu_item(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn sidebar_menu_skeleton(show_icon? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_sub(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_sub_button(href? : String, is_active? : Bool, disabled? : Bool, aria_label? : String, target? : @html.Target, rel? : String, download? : String, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_menu_sub_item(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn sidebar_open_mobile(SidebarScope) -> @cmd.Cmd
+
+pub fn sidebar_provider(default_collapsed? : Bool, default_mobile_open? : Bool, on_collapsed_change? : @cmd.Emit[Bool], on_mobile_open_change? : @cmd.Emit[Bool], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (SidebarScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn sidebar_rail(SidebarScope, min_width? : Int, max_width? : Int, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn sidebar_separator(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] sidebar_trigger(SidebarScope, mobile? : Bool, controls? : String, disabled? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn skeleton(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn slider(id~ : String, default_value? : Int, min? : Int, max? : Int, step? : Int, large_step? : Int, orientation? : SeparatorOrientation, disabled? : Bool, aria_label? : String, on_value_change? : @cmd.Emit[Int], on_value_commit? : @cmd.Emit[Int], class? : String, title? : String, attrs? : @html.Attrs, input_attrs? : @html.Attrs, style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn slider_values(id~ : String, default_values~ : Array[Int], min? : Int, max? : Int, step? : Int, large_step? : Int, min_steps_between_values? : Int, orientation? : SeparatorOrientation, disabled? : Bool, aria_label? : String, on_value_change? : @cmd.Emit[Array[Int]], on_value_commit? : @cmd.Emit[Array[Int]], class? : String, title? : String, attrs? : @html.Attrs, input_attrs? : @html.Attrs, style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn sonner(max_toasts? : Int, position? : String, class? : String, attrs? : @html.Attrs, style? : Array[String], (ToastScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn spinner(label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn switch(default_checked? : Bool, size? : SwitchSize, disabled? : Bool, read_only? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_checked_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn tab_entry(value~ : String, label~ : String, icon? : @html.Html, content~ : @html.Html, disabled? : Bool) -> TabEntry
+
+pub fn[C : @html.IsChildren] table(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], container_attrs? : @html.Attrs, container_style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_body(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_caption(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_cell(colspan? : Int, rowspan? : Int, headers? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_footer(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_head(scope? : @html.Scope, abbr? : String, colspan? : Int, rowspan? : Int, headers? : String, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_header(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] table_row(selected? : Bool, expanded? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn tabs(items~ : Array[TabEntry], default_value? : String, orientation? : TabsOrientation, list_variant? : TabsListVariant, aria_label? : String, force_mount? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, list_attrs? : @html.Attrs, style? : Array[String], list_style? : Array[String], trigger_style? : Array[String], content_style? : Array[String]) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] tabs_content(value~ : String, selected? : Bool, force_mount? : Bool, labelledby? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] tabs_list(orientation? : TabsOrientation, variant? : TabsListVariant, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] tabs_root(value? : String, orientation? : TabsOrientation, id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] tabs_trigger(value~ : String, selected? : Bool, disabled? : Bool, tab_stop? : Bool, controls? : String, on_value_change? : @cmd.Emit[String], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn textarea(name? : String, value? : String, rows? : Int, cols? : Int, placeholder? : String, read_only? : Bool, disabled? : Bool, maxlength? : Int, minlength? : Int, required? : Bool, autofocus? : Bool, wrap? : String, invalid? : Bool, id? : String, class? : String, title? : String, hidden? : Bool, on_change? : @cmd.Emit[String], on_input? : @cmd.Emit[String], attrs? : @html.Attrs, style? : Array[String], slot? : String) -> @html.Html
+
+pub fn[C : @html.IsChildren] theme(mode? : ColorMode, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] toast(variant? : ToastVariant, open? : Bool, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] toast_action(on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn toast_close(scope~ : ToastScope, toast_id~ : Int, label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn[C : @html.IsChildren] toast_description(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] toast_title(id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn toaster(max_toasts? : Int, position? : String, class? : String, attrs? : @html.Attrs, style? : Array[String], (ToastScope) -> @html.Html) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] toggle(default_pressed? : Bool, variant? : ToggleVariant, size? : ToggleSize, disabled? : Bool, invalid? : Bool, id? : String, class? : String, title? : String, aria_label? : String, on_pressed_change? : @cmd.Emit[Bool], attrs? : @html.Attrs, style? : Array[String], slot? : String, C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] toggle_group(default_values? : Array[String], multiple? : Bool, orientation? : SeparatorOrientation, variant? : ToggleVariant, size? : ToggleSize, spacing? : Int, aria_label? : String, on_value_change? : @cmd.Emit[Array[String]], id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], (ToggleGroupScope) -> C) -> @rabbita.Val[@html.Html]
+
+pub fn[C : @html.IsChildren] toggle_group_item(scope~ : ToggleGroupScope, value~ : String, disabled? : Bool, aria_label? : String, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[T : @html.IsChildren, C : @html.IsChildren] tooltip(id~ : String, default_open? : Bool, disabled? : Bool, delay? : Int, close_delay? : Int, close_on_click? : Bool, hoverable? : Bool, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, show_arrow? : Bool, trigger_variant? : ButtonVariant, trigger_size? : ButtonSize, on_open_change? : @cmd.Emit[Bool], on_trigger_click? : @cmd.Cmd, attrs? : @html.Attrs, style? : Array[String], trigger_attrs? : @html.Attrs, trigger_style? : Array[String], content_attrs? : @html.Attrs, content_style? : Array[String], arrow_attrs? : @html.Attrs, arrow_style? : Array[String], T, C) -> @rabbita.Val[@html.Html]
+
+pub fn tooltip_arrow(side? : PopupSide, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String]) -> @html.Html
+
+pub fn tooltip_close(String) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] tooltip_content(id~ : String, trigger_id~ : String, open? : Bool, side? : PopupSide, align? : PopupAlign, side_offset? : Int, align_offset? : Int, show_arrow? : Bool, class? : String, title? : String, attrs? : @html.Attrs, arrow_attrs? : @html.Attrs, style? : Array[String], arrow_style? : Array[String], C) -> @html.Html
+
+pub fn tooltip_open(String) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] tooltip_provider(delay? : Int, close_delay? : Int, timeout? : Int, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn tooltip_toggle(String) -> @cmd.Cmd
+
+pub fn[C : @html.IsChildren] tooltip_trigger(content_id~ : String, open? : Bool, disabled? : Bool, variant? : ButtonVariant, size? : ButtonSize, on_click? : @cmd.Cmd, id? : String, class? : String, title? : String, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_blockquote(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_h1(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_h2(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_h3(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_h4(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_inline_code(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_large(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_lead(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_list(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_muted(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_p(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+pub fn[C : @html.IsChildren] typography_small(id? : String, class? : String, title? : String, hidden? : Bool, attrs? : @html.Attrs, style? : Array[String], C) -> @html.Html
+
+// Errors
+
+// Types and methods
+type AccordionEntry
+
+pub(all) enum AccordionType {
+  Single
+  Multiple
+} derive(Eq, @debug.Debug)
+
+type AlertDialogScope
+
+pub(all) enum AlertVariant {
+  Default
+  Destructive
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AttachmentMediaVariant {
+  AttachmentIcon
+  AttachmentImage
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AttachmentOrientation {
+  AttachmentHorizontal
+  AttachmentVertical
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AttachmentSize {
+  AttachmentDefaultSize
+  AttachmentSm
+  AttachmentXs
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AttachmentState {
+  AttachmentIdle
+  AttachmentUploading
+  AttachmentProcessing
+  AttachmentError
+  AttachmentDone
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AvatarImageStatus {
+  AvatarLoading
+  AvatarLoaded
+  AvatarError
+} derive(Eq, @debug.Debug)
+
+pub(all) enum AvatarSize {
+  Default
+  Sm
+  Lg
+} derive(Eq, @debug.Debug)
+
+pub(all) enum BadgeVariant {
+  Default
+  Secondary
+  Destructive
+  Outline
+  Ghost
+  Link
+} derive(Eq, @debug.Debug)
+
+pub(all) enum BubbleReactionSide {
+  ReactionTop
+  ReactionBottom
+} derive(Eq, @debug.Debug)
+
+pub(all) enum BubbleVariant {
+  BubbleDefault
+  BubbleSecondary
+  BubbleMuted
+  BubbleTinted
+  BubbleOutline
+  BubbleGhost
+  BubbleDestructive
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ButtonSize {
+  Default
+  Xs
+  Sm
+  Lg
+  Icon
+  IconXs
+  IconSm
+  IconLg
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ButtonVariant {
+  Default
+  Outline
+  Secondary
+  Ghost
+  Destructive
+  Link
+} derive(Eq, @debug.Debug)
+
+type CalendarDate derive(Eq, @debug.Debug)
+pub fn CalendarDate::day(Self) -> Int
+pub fn CalendarDate::month(Self) -> Int
+pub fn CalendarDate::to_iso_string(Self) -> String
+pub fn CalendarDate::year(Self) -> Int
+
+pub(all) enum CardSize {
+  Default
+  Sm
+} derive(Eq, @debug.Debug)
+
+pub(all) enum CarouselOrientation {
+  CarouselHorizontal
+  CarouselVertical
+} derive(Eq, @debug.Debug)
+
+type CarouselScope
+
+pub(all) enum ChartIndicator {
+  ChartDot
+  ChartLine
+  ChartDashed
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ColorMode {
+  Light
+  Dark
+} derive(Eq, @debug.Debug)
+
+type ComboboxOption
+
+type ComboboxScope
+
+type CommandScope
+
+pub(all) enum ContentAlignment {
+  AlignStart
+  AlignEnd
+} derive(Eq, @debug.Debug)
+
+type ContextMenuRadioGroupScope
+
+type ContextMenuScope
+
+type ContextMenuSubScope
+
+type DataTableColumn[T]
+
+type DatePickerPreset derive(Eq, @debug.Debug)
+
+type DateRange derive(Eq, @debug.Debug)
+pub fn DateRange::end(Self) -> CalendarDate?
+pub fn DateRange::start(Self) -> CalendarDate
+
+type DialogScope
+
+pub(all) enum DrawerDirection {
+  DrawerTop
+  DrawerRight
+  DrawerBottom
+  DrawerLeft
+} derive(Eq, @debug.Debug)
+
+type DrawerScope
+
+type DropdownMenuRadioGroupScope
+
+type DropdownMenuScope
+
+type DropdownMenuSubScope
+
+pub(all) enum EmptyMediaVariant {
+  EmptyMediaDefault
+  EmptyMediaIcon
+} derive(Eq, @debug.Debug)
+
+pub(all) enum FieldLegendVariant {
+  FieldLegend
+  FieldLabelLegend
+} derive(Eq, @debug.Debug)
+
+pub(all) enum FieldOrientation {
+  FieldVertical
+  FieldHorizontal
+  FieldResponsive
+} derive(Eq, @debug.Debug)
+
+pub(all) enum InputGroupAddonAlign {
+  InputInlineStart
+  InputInlineEnd
+  InputBlockStart
+  InputBlockEnd
+} derive(Eq, @debug.Debug)
+
+pub(all) enum InputGroupButtonSize {
+  InputButtonXs
+  InputButtonSm
+  InputButtonIconXs
+  InputButtonIconSm
+} derive(Eq, @debug.Debug)
+
+type InputOtpScope
+
+pub(all) enum ItemMediaVariant {
+  ItemMediaDefault
+  ItemMediaIcon
+  ItemMediaImage
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ItemSize {
+  ItemDefaultSize
+  ItemSm
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ItemVariant {
+  ItemDefault
+  ItemOutline
+  ItemMuted
+} derive(Eq, @debug.Debug)
+
+pub(all) enum MarkerVariant {
+  MarkerDefault
+  MarkerSeparator
+  MarkerBorder
+} derive(Eq, @debug.Debug)
+
+type MenuCoreModel derive(Eq)
+
+type MenuIndicatorPlacement derive(Eq)
+
+type MenuScope
+
+type MenuSubmenuChange derive(Eq)
+
+type MenubarMenuScope
+
+type MenubarModel derive(Eq)
+
+type MenubarRadioGroupScope
+
+type MenubarScope
+
+type MenubarSubScope
+
+pub(all) enum MessageScrollDirection {
+  ScrollStart
+  ScrollEnd
+} derive(Eq, @debug.Debug)
+
+type MessageScrollerScope
+
+pub(all) enum NativeSelectSize {
+  NativeSelectDefault
+  NativeSelectSm
+} derive(Eq, @debug.Debug)
+
+type NavigationMenuItemScope
+
+type NavigationMenuModel derive(Eq)
+
+type NavigationMenuScope
+
+pub(all) enum PopupAlign {
+  Start
+  Center
+  End
+} derive(Eq, @debug.Debug)
+
+pub(all) enum PopupSide {
+  Top
+  Right
+  Bottom
+  Left
+} derive(Eq, @debug.Debug)
+
+pub(all) enum RadioGroupOrientation {
+  RadioVertical
+  RadioHorizontal
+} derive(Eq, @debug.Debug)
+
+type RadioGroupScope
+
+type ResizableGroupScope
+
+pub(all) enum ResizablePanelSide {
+  FirstPanel
+  SecondPanel
+} derive(Eq, @debug.Debug)
+
+type ResizableScope
+
+type SelectOption
+
+type SelectScope
+
+pub(all) enum SeparatorOrientation {
+  Horizontal
+  Vertical
+} derive(Eq, @debug.Debug)
+
+type SheetScope
+
+pub(all) enum SheetSide {
+  SheetTop
+  SheetRight
+  SheetBottom
+  SheetLeft
+} derive(Eq, @debug.Debug)
+
+pub(all) enum SidebarCollapsible {
+  SidebarOffcanvas
+  SidebarIcon
+  SidebarFixed
+} derive(Eq, @debug.Debug)
+
+pub(all) enum SidebarMenuButtonSize {
+  SidebarMenuSm
+  SidebarMenuDefault
+  SidebarMenuLg
+} derive(Eq, @debug.Debug)
+
+pub(all) enum SidebarMenuButtonVariant {
+  SidebarMenuButtonDefault
+  SidebarMenuButtonOutline
+} derive(Eq, @debug.Debug)
+
+type SidebarScope
+
+pub(all) enum SidebarSide {
+  SidebarLeft
+  SidebarRight
+} derive(Eq, @debug.Debug)
+
+pub(all) enum SidebarVariant {
+  SidebarDefault
+  SidebarFloating
+  SidebarInset
+} derive(Eq, @debug.Debug)
+
+pub(all) enum SwitchSize {
+  Default
+  Sm
+} derive(Eq, @debug.Debug)
+
+type TabEntry
+
+pub(all) enum TabsListVariant {
+  TabsDefault
+  TabsLine
+} derive(Eq, @debug.Debug)
+
+pub(all) enum TabsOrientation {
+  TabsHorizontal
+  TabsVertical
+} derive(Eq, @debug.Debug)
+
+pub(all) enum TextDirection {
+  Ltr
+  Rtl
+} derive(Eq, @debug.Debug)
+
+type ToastScope
+pub fn ToastScope::dismiss(Self, id~ : Int) -> @cmd.Cmd
+pub fn ToastScope::dismiss_all(Self) -> @cmd.Cmd
+pub fn ToastScope::show(Self, title~ : String, description? : String, variant? : ToastVariant, duration_ms? : Int) -> @cmd.Cmd
+
+pub(all) enum ToastVariant {
+  ToastDefault
+  ToastDestructive
+  ToastSuccess
+} derive(Eq, @debug.Debug)
+
+type ToggleGroupScope
+
+pub(all) enum ToggleSize {
+  Default
+  Sm
+  Lg
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ToggleVariant {
+  Default
+  Outline
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/rui/popover.mbt
+++ b/rui/popover.mbt
@@ -1,0 +1,1941 @@
+///|
+pub(all) enum PopupSide {
+  Top
+  Right
+  Bottom
+  Left
+} derive(Debug, Eq)
+
+///|
+pub(all) enum PopupAlign {
+  Start
+  Center
+  End
+} derive(Debug, Eq)
+
+///|
+const PopoverRootStyle : String = "display:contents"
+
+///|
+const PopoverAnchorStyle : String = "position:relative;display:inline-flex;max-width:100%"
+
+///|
+const PopoverContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:flex;width:18rem;max-width:calc(100vw - 1rem);transform-origin:var(--rui-floating-transform-origin,center);flex-direction:column;gap:1rem;margin:0;border:0;border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:1rem;color:var(--rui-popover-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem;box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1),0 0 0 1px color-mix(in oklab,var(--rui-foreground,oklch(0.145 0 0)) 10%,transparent);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const PopoverHeaderStyle : String = "display:flex;flex-direction:column;gap:0.25rem;font-size:0.875rem;line-height:1.25rem"
+
+///|
+const PopoverTitleStyle : String = "margin:0;font-size:0.875rem;line-height:1.25rem;font-weight:500"
+
+///|
+const PopoverDescriptionStyle : String = "margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem"
+
+///|
+const PopupOpenStyle : String = "visibility:visible;opacity:1;pointer-events:auto;transform:scale(1)"
+
+///|
+const PopupClosedStyle : String = "visibility:hidden;opacity:0;pointer-events:none;transform:scale(0.95)"
+
+///|
+/// Keep a native popover or dialog in the top layer while its visual exit
+/// finishes. `@starting-style` in the internal theme supplies the matching
+/// closed first frame for entry, so consumers do not need lifecycle scripts or
+/// an external animation stylesheet.
+const PopupTransition100Style : String = "transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease,display 100ms allow-discrete,overlay 100ms allow-discrete;transition-behavior:allow-discrete"
+
+///|
+const PopupTransition150Style : String = "transition:opacity 150ms ease,transform 150ms ease,visibility 150ms ease,display 150ms allow-discrete,overlay 150ms allow-discrete;transition-behavior:allow-discrete"
+
+///|
+fn popup_side_value(side : PopupSide) -> String {
+  match side {
+    Top => "top"
+    Right => "right"
+    Bottom => "bottom"
+    Left => "left"
+  }
+}
+
+///|
+fn popup_align_value(align : PopupAlign) -> String {
+  match align {
+    Start => "start"
+    Center => "center"
+    End => "end"
+  }
+}
+
+///|
+/// Encode an arbitrary HTML id as a valid, collision-free CSS dashed-ident.
+/// Keeping this deterministic lets both compound and standalone parts render
+/// their anchor relationship directly, without a post-render setup pass.
+fn popup_anchor_name(id : String) -> String {
+  let name = StringBuilder::new()
+  name.write_string("--rui-anchor")
+  for character in id.iter() {
+    name.write_char('_')
+    name.write_object(character.to_int())
+  }
+  name.to_string()
+}
+
+///|
+fn popup_anchor_style(id : String) -> String {
+  "anchor-name:\{popup_anchor_name(id)}"
+}
+
+///|
+fn popup_position_area(side : PopupSide, align : PopupAlign) -> String {
+  let side_value = popup_side_value(side)
+  match (side, align) {
+    (Top | Bottom, Start) => side_value + " span-x-end"
+    (Top | Bottom, Center) => side_value
+    (Top | Bottom, End) => side_value + " span-x-start"
+    (Left | Right, Start) => side_value + " span-y-end"
+    (Left | Right, Center) => side_value
+    (Left | Right, End) => side_value + " span-y-start"
+  }
+}
+
+///|
+fn popup_side_offset_style(side : PopupSide, offset : Int) -> String {
+  match side {
+    Top => "margin-bottom:\{offset}px"
+    Right => "margin-left:\{offset}px"
+    Bottom => "margin-top:\{offset}px"
+    Left => "margin-right:\{offset}px"
+  }
+}
+
+///|
+fn popup_align_offset_style(side : PopupSide, offset : Int) -> String {
+  match side {
+    Top | Bottom => "translate:\{offset}px 0"
+    Right | Left => "translate:0 \{offset}px"
+  }
+}
+
+///|
+fn popup_transform_origin(side : PopupSide, align : PopupAlign) -> String {
+  let cross_axis = match align {
+    Start => "0%"
+    Center => "50%"
+    End => "100%"
+  }
+  match side {
+    Top => cross_axis + " 100%"
+    Right => "0% " + cross_axis
+    Bottom => cross_axis + " 0%"
+    Left => "100% " + cross_axis
+  }
+}
+
+///|
+/// Native CSS Anchor Positioning is the primary path. The browser performs
+/// scroll tracking, viewport fitting, and opposite-side fallbacks during its
+/// own layout pass; the runtime positioning pass is retained only for older
+/// engines and for synchronizing a tooltip arrow with the rendered side.
+fn popup_floating_anchor_style(
+  trigger_id : String,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+) -> String {
+  let fallbacks = match side {
+    Top | Bottom => "flip-inline,flip-block,flip-inline flip-block"
+    Right | Left => "flip-block,flip-inline,flip-block flip-inline"
+  }
+  "position-anchor:\{popup_anchor_name(trigger_id)};position-area:\{popup_position_area(side, align)};position-try-fallbacks:\{fallbacks};position-visibility:always;\{popup_side_offset_style(side, side_offset)};\{popup_align_offset_style(side, align_offset)};--rui-floating-transform-origin:\{popup_transform_origin(side, align)}"
+}
+
+///|
+fn popup_state_style(open : Bool) -> String {
+  if open {
+    PopupOpenStyle
+  } else {
+    PopupClosedStyle
+  }
+}
+
+///|
+fn popup_state_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  open : Bool,
+) -> @html.Attrs {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("state", if open { "open" } else { "closed" })
+  if open {
+    ignore(element_attrs.data_set("open", ""))
+  } else {
+    ignore(element_attrs.data_set("closed", ""))
+  }
+  element_attrs
+}
+
+///|
+#cfg(target="js")
+fn floating_dialog_open(open : Bool) -> Bool? {
+  ignore(open)
+  None
+}
+
+///|
+#cfg(not(target="js"))
+fn floating_dialog_open(open : Bool) -> Bool? {
+  Some(open)
+}
+
+///|
+#cfg(target="js")
+priv struct FloatingLayerBinding {
+  id : String
+  element : @dom.Element
+  html : @dom.HTMLElement
+  sync : Ref[(Bool) -> Unit]
+  open : Ref[Bool]
+  return_focus : Ref[@dom.HTMLElement?]
+  had_nested_pointer : Ref[Bool]
+}
+
+///|
+#cfg(target="js")
+priv struct TooltipProviderClose {
+  element : @dom.Element
+  closed_at : Ref[Double]
+}
+
+///|
+#cfg(target="js")
+let floating_layers : Map[String, FloatingLayerBinding] = Map([])
+
+///|
+#cfg(target="js")
+let floating_stack : Ref[Array[String]] = Ref([])
+
+///|
+#cfg(target="js")
+let floating_request_close : Map[String, () -> Unit] = Map([])
+
+///|
+#cfg(target="js")
+let floating_stop_positioning : Map[String, () -> Unit] = Map([])
+
+///|
+#cfg(target="js")
+let floating_bound_document : Ref[@dom.Document?] = Ref(None)
+
+///|
+#cfg(target="js")
+let tooltip_provider_closes : Array[TooltipProviderClose] = []
+
+///|
+#cfg(target="js")
+fn floating_same_element(left : @dom.Element, right : @dom.Element) -> Bool {
+  left.is_same_node(right.as_node())
+}
+
+///|
+#cfg(target="js")
+fn floating_set_request_close(id : String, request : () -> Unit) -> Unit {
+  floating_request_close[id] = request
+}
+
+///|
+#cfg(target="js")
+fn floating_set_stop_positioning(id : String, stop : () -> Unit) -> Unit {
+  floating_stop_positioning[id] = stop
+}
+
+///|
+#cfg(target="js")
+fn floating_stop(id : String) -> Unit {
+  if floating_stop_positioning.get(id) is Some(stop) {
+    stop()
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_update_stack(id : String, open : Bool) -> Unit {
+  let next : Array[String] = []
+  for current in floating_stack.val {
+    if current != id {
+      next.push(current)
+    }
+  }
+  if open {
+    next.push(id)
+  }
+  floating_stack.val = next
+}
+
+///|
+#cfg(target="js")
+fn floating_live_layer(id : String) -> FloatingLayerBinding? {
+  guard floating_layers.get(id) is Some(layer) else { return None }
+  guard ui_element_by_id(id) is Some(element) else {
+    floating_update_stack(id, false)
+    return None
+  }
+  if !element.get_is_connected() {
+    floating_update_stack(id, false)
+    return None
+  }
+  if !floating_same_element(layer.element, element) {
+    // Incremental rendering may replace a physical node while preserving the
+    // component id. Rebind the native listeners to that live node instead of
+    // permanently dropping the layer from the dismissal stack.
+    let sync = layer.sync.val
+    let return_focus = layer.return_focus.val
+    floating_stop(id)
+    bind_floating_sync(id, sync)
+    guard floating_layers.get(id) is Some(rebound) &&
+      floating_same_element(rebound.element, element) else {
+      floating_update_stack(id, false)
+      return None
+    }
+    rebound.return_focus.val = return_focus
+    return Some(rebound)
+  }
+  Some(layer)
+}
+
+///|
+#cfg(target="js")
+fn floating_layer_is_open(layer : FloatingLayerBinding) -> Bool {
+  if layer.html.to_html_dialog_element() is Some(dialog) {
+    dialog.open()
+  } else {
+    layer.open.val
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_top_layer() -> FloatingLayerBinding? {
+  let stack = floating_stack.val
+  for index = stack.length() - 1; index >= 0; index = index - 1 {
+    let id = stack[index]
+    if floating_live_layer(id) is Some(layer) && floating_layer_is_open(layer) {
+      return Some(layer)
+    }
+    floating_update_stack(id, false)
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn floating_event_inside(event : @dom.Event, element : @dom.Element) -> Bool {
+  if ui_element_contains_target(element, event.target()) {
+    return true
+  }
+  for target in event.composed_path() {
+    if target.to_node() is Some(node) && element.contains(node) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+#cfg(target="js")
+fn tooltip_provider_mark_closed(provider : @dom.Element) -> Unit {
+  let now = if ui_has_window() {
+    @dom.window().get_performance().now()
+  } else {
+    0.0
+  }
+  for entry in tooltip_provider_closes {
+    if floating_same_element(entry.element, provider) {
+      entry.closed_at.val = now
+      return
+    }
+  }
+  tooltip_provider_closes.push({ element: provider, closed_at: Ref(now) })
+}
+
+///|
+#cfg(target="js")
+fn tooltip_provider_last_close(provider : @dom.Element) -> Double? {
+  for entry in tooltip_provider_closes {
+    if floating_same_element(entry.element, provider) {
+      return Some(entry.closed_at.val)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn floating_restore_focus(layer : FloatingLayerBinding) -> Unit {
+  if layer.element.get_attribute("data-restore-focus").unwrap_or("") == "false" {
+    return
+  }
+  let document = @dom.document()
+  let final_id = layer.element
+    .get_attribute("data-final-focus-id")
+    .unwrap_or("")
+  if ui_element_by_id(final_id) is Some(final_element) &&
+    final_element.get_is_connected() &&
+    final_element.to_html_element() is Some(final_target) {
+    final_target.focus_with_options(prevent_scroll=true)
+    return
+  }
+  if document.get_active_element() is Some(active) {
+    let active_is_body = if document.get_body() is Some(body) {
+      active.is_same_node(body.as_node())
+    } else {
+      false
+    }
+    if !active_is_body && !layer.element.contains(active.as_node()) {
+      return
+    }
+  }
+  let target = if layer.return_focus.val is Some(element) &&
+    element.get_is_connected() {
+    Some(element)
+  } else {
+    let trigger_id = layer.element
+      .get_attribute("data-trigger-id")
+      .unwrap_or("")
+    if ui_element_by_id(trigger_id) is Some(element) {
+      element.to_html_element()
+    } else {
+      None
+    }
+  }
+  if target is Some(element) && element.get_is_connected() {
+    element.focus_with_options(prevent_scroll=true)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_notify(layer : FloatingLayerBinding, open : Bool) -> Unit {
+  // A replaced node can deliver a delayed toggle/close event after a new node
+  // with the same component id has mounted. Adopt the live node first, then
+  // ignore notifications originating from the detached binding.
+  guard floating_live_layer(layer.id) is Some(current) &&
+    floating_same_element(current.element, layer.element) else {
+    return
+  }
+  let changed = layer.open.val != open
+  layer.open.val = open
+  floating_update_stack(layer.id, open)
+  if !changed {
+    return
+  }
+  if !open {
+    floating_stop(layer.id)
+    if layer.element.get_attribute("data-slot").unwrap_or("") ==
+      "tooltip-content" &&
+      layer.element.closest("[data-slot=\"tooltip-provider\"]")
+      is Some(provider) {
+      tooltip_provider_mark_closed(provider)
+    }
+    if ui_has_window() {
+      @dom.window().queue_microtask(() => floating_restore_focus(layer))
+    } else {
+      floating_restore_focus(layer)
+    }
+  }
+  (layer.sync.val)(open)
+}
+
+///|
+#cfg(target="js")
+fn floating_request_layer_close(layer : FloatingLayerBinding) -> Unit {
+  if floating_request_close.get(layer.id) is Some(request) {
+    request()
+  } else if layer.html.to_html_dialog_element() is Some(dialog) {
+    if dialog.open() {
+      dialog.close()
+    }
+    floating_notify(layer, false)
+  } else if layer.html.get_popover() is Some(_) {
+    if layer.open.val {
+      layer.html.hide_popover()
+    }
+    floating_notify(layer, false)
+  } else {
+    floating_notify(layer, false)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_has_nested(layer : FloatingLayerBinding) -> Bool {
+  let stack = floating_stack.val
+  let mut found_current = false
+  for id in stack {
+    if id == layer.id {
+      found_current = true
+    } else if found_current &&
+      floating_live_layer(id) is Some(nested) &&
+      floating_layer_is_open(nested) &&
+      !floating_same_element(layer.element, nested.element) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+#cfg(target="js")
+fn floating_bind_document_events() -> Unit {
+  let document = @dom.document()
+  if floating_bound_document.val is Some(bound) &&
+    bound.to_node().is_same_node(document.to_node()) {
+    return
+  }
+  floating_bound_document.val = Some(document)
+  document.add_event_listener("keydown", event => {
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    if keyboard.key() != "Escape" || event.get_default_prevented() {
+      return
+    }
+    guard floating_top_layer() is Some(layer) else { return }
+    event.prevent_default()
+    event.stop_propagation()
+    floating_request_layer_close(layer)
+  })
+  document.add_event_listener_with_options(
+    "pointerdown",
+    event => {
+      guard floating_top_layer() is Some(layer) else { return }
+      if layer.element.get_attribute("data-light-dismiss").unwrap_or("") ==
+        "true" &&
+        !floating_event_inside(event, layer.element) {
+        floating_request_layer_close(layer)
+      }
+    },
+    capture=true,
+  )
+}
+
+///|
+#cfg(target="js")
+fn bind_floating_sync(id : String, sync : (Bool) -> Unit) -> Unit {
+  guard ui_element_by_id(id) is Some(element) else { return }
+  guard element.to_html_element() is Some(html) else { return }
+  if floating_layers.get(id) is Some(layer) &&
+    floating_same_element(layer.element, element) {
+    layer.sync.val = sync
+    return
+  }
+  let initially_open = if html.to_html_dialog_element() is Some(dialog) {
+    dialog.open()
+  } else if html.get_popover() is Some(_) {
+    element.matches(":popover-open")
+  } else {
+    false
+  }
+  let layer : FloatingLayerBinding = {
+    id,
+    element,
+    html,
+    sync: Ref(sync),
+    open: Ref(initially_open),
+    return_focus: Ref(None),
+    had_nested_pointer: Ref(false),
+  }
+  floating_layers[id] = layer
+  floating_update_stack(id, initially_open)
+  floating_bind_document_events()
+  if html.to_html_dialog_element() is Some(dialog) {
+    dialog.add_event_listener("close", _ => floating_notify(layer, false))
+    dialog.add_event_listener("pointerdown", event => {
+      if event.target().to_node() is Some(target) &&
+        layer.element.is_same_node(target) {
+        layer.had_nested_pointer.val = floating_has_nested(layer)
+      }
+    })
+    dialog.add_event_listener("click", event => {
+      guard event.target().to_node() is Some(target) else { return }
+      if !layer.element.is_same_node(target) {
+        return
+      }
+      let had_nested = layer.had_nested_pointer.val ||
+        floating_has_nested(layer)
+      layer.had_nested_pointer.val = false
+      if had_nested {
+        return
+      }
+      guard event.to_mouse_event() is Some(mouse) else { return }
+      let rect = layer.element.get_bounding_client_rect()
+      let x = mouse.get_client_x().to_double()
+      let y = mouse.get_client_y().to_double()
+      let outside = x < rect.get_left() ||
+        x > rect.get_right() ||
+        y < rect.get_top() ||
+        y > rect.get_bottom()
+      if outside && dialog.open() {
+        dialog.close()
+      }
+    })
+  } else {
+    html.add_event_listener("toggle", _ => {
+      // The element's top-layer state is the source of truth. Some browser
+      // and test environments deliver a plain Event for native light-dismiss,
+      // so requiring a ToggleEvent cast can leave Rabbita's open state stale.
+      floating_notify(layer, element.matches(":popover-open"))
+    })
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_focus_initial(layer : FloatingLayerBinding) -> Unit {
+  if layer.element.get_attribute("data-initial-focus").unwrap_or("") != "true" {
+    return
+  }
+  let requested_id = layer.element
+    .get_attribute("data-initial-focus-id")
+    .unwrap_or("")
+  let requested = ui_element_by_id(requested_id)
+  let selector = "button:not([disabled]),a[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex=\"-1\"])"
+  let target = if requested is Some(element) &&
+    layer.element.contains(element.as_node()) {
+    Some(element)
+  } else {
+    match layer.element.query_selector(selector) {
+      Some(element) => Some(element)
+      None => Some(layer.element)
+    }
+  }
+  if target is Some(element) {
+    ui_focus_element_without_scroll(element)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_capture_return_focus(layer : FloatingLayerBinding) -> Unit {
+  if @dom.document().get_active_element() is Some(active) &&
+    !layer.element.contains(active.as_node()) &&
+    active.to_html_element() is Some(html) {
+    layer.return_focus.val = Some(html)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_close_other_tooltips(layer : FloatingLayerBinding) -> Unit {
+  if layer.element.get_attribute("data-slot").unwrap_or("") != "tooltip-content" ||
+    layer.element.closest("[data-slot=\"tooltip-provider\"]") is None {
+    return
+  }
+  guard layer.element.closest("[data-slot=\"tooltip-provider\"]")
+    is Some(provider) else {
+    return
+  }
+  for other in provider.query_selector_all("[data-slot=\"tooltip-content\"]") {
+    if !floating_same_element(other, layer.element) {
+      let other_id = other.get_attribute("id").unwrap_or("")
+      if floating_live_layer(other_id) is Some(other_layer) &&
+        floating_layer_is_open(other_layer) {
+        floating_request_layer_close(other_layer)
+      }
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn set_floating_open(id : String, open : Bool) -> Bool {
+  guard ui_has_document() else { return false }
+  guard ui_element_by_id(id) is Some(element) && element.get_is_connected() else {
+    return false
+  }
+  if floating_live_layer(id) is None {
+    bind_floating_sync(id, _ => ())
+  }
+  guard floating_live_layer(id) is Some(layer) else { return false }
+  if open {
+    floating_capture_return_focus(layer)
+    floating_close_other_tooltips(layer)
+    if layer.html.to_html_dialog_element() is Some(dialog) {
+      if !dialog.open() {
+        dialog.show_modal()
+      }
+      floating_notify(layer, true)
+    } else if layer.html.get_popover() is Some(_) {
+      if !layer.open.val {
+        layer.html.show_popover()
+      }
+      floating_notify(layer, true)
+    } else {
+      floating_notify(layer, true)
+    }
+    if ui_has_window() {
+      ignore(
+        @dom.window().request_animation_frame(_ => floating_focus_initial(layer)),
+      )
+    } else {
+      floating_focus_initial(layer)
+    }
+  } else {
+    if layer.html.to_html_dialog_element() is Some(dialog) {
+      if dialog.open() {
+        dialog.close()
+      }
+    } else if layer.html.get_popover() is Some(_) {
+      if layer.open.val {
+        layer.html.hide_popover()
+      }
+    }
+    floating_notify(layer, false)
+  }
+  true
+}
+
+///|
+#cfg(target="js")
+fn toggle_floating(id : String) -> Unit {
+  if floating_live_layer(id) is None {
+    bind_floating_sync(id, _ => ())
+  }
+  if floating_live_layer(id) is Some(layer) {
+    ignore(set_floating_open(id, !floating_layer_is_open(layer)))
+  }
+}
+
+///|
+#cfg(target="js")
+priv struct FloatingPositioningBinding {
+  element : @dom.Element
+  html : @dom.HTMLElement
+  mode : String
+  frame : Ref[Double?]
+  observing : Ref[Bool]
+  listener : Ref[@dom.Listener?]
+  resize_observer : Ref[@dom.ResizeObserver?]
+  mutation_observer : Ref[@dom.MutationObserver?]
+  intersection_observer : Ref[@dom.IntersectionObserver?]
+}
+
+///|
+#cfg(target="js")
+priv struct FloatingCoordinates {
+  side : String
+  left : Double
+  top : Double
+}
+
+///|
+#cfg(target="js")
+let floating_positionings : Map[String, FloatingPositioningBinding] = Map([])
+
+///|
+#cfg(target="js")
+fn floating_normalize_side(side : String) -> String {
+  match side {
+    "top" | "right" | "bottom" | "left" => side
+    _ => "bottom"
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_normalize_align(align : String) -> String {
+  match align {
+    "start" | "center" | "end" => align
+    _ => "center"
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_opposite_side(side : String) -> String {
+  match side {
+    "top" => "bottom"
+    "bottom" => "top"
+    "left" => "right"
+    "right" => "left"
+    _ => "top"
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_has_tooltip_arrow(element : @dom.Element) -> Bool {
+  element.query_selector("[data-slot=\"tooltip-arrow\"]") is Some(_)
+}
+
+///|
+#cfg(target="js")
+fn floating_set_tooltip_arrow_side(
+  element : @dom.Element,
+  html : @dom.HTMLElement,
+  side : String,
+) -> Unit {
+  if !floating_has_tooltip_arrow(element) {
+    return
+  }
+  let names = [
+    "--rui-tooltip-arrow-top", "--rui-tooltip-arrow-right", "--rui-tooltip-arrow-bottom",
+    "--rui-tooltip-arrow-left", "--rui-tooltip-arrow-margin-top", "--rui-tooltip-arrow-margin-left",
+  ]
+  let values = match side {
+    "right" => ["50%", "auto", "auto", "-0.25rem", "-0.3125rem", "0"]
+    "bottom" => ["-0.25rem", "auto", "auto", "50%", "0", "-0.3125rem"]
+    "left" => ["50%", "-0.25rem", "auto", "auto", "-0.3125rem", "0"]
+    _ => ["auto", "auto", "-0.25rem", "50%", "0", "-0.3125rem"]
+  }
+  let style = html.get_style()
+  for index, name in names {
+    if style.get_property_value(name) != values[index] {
+      style.set_property(name, values[index])
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_infer_tooltip_side(
+  popup : @dom.Element,
+  reference : @dom.Element,
+) -> String {
+  let anchor = reference.get_bounding_client_rect()
+  let floating = popup.get_bounding_client_rect()
+  if floating.get_bottom() <= anchor.get_top() + 1.0 {
+    "top"
+  } else if floating.get_top() >= anchor.get_bottom() - 1.0 {
+    "bottom"
+  } else if floating.get_right() <= anchor.get_left() + 1.0 {
+    "left"
+  } else if floating.get_left() >= anchor.get_right() - 1.0 {
+    "right"
+  } else {
+    let dx = (
+        floating.get_left() +
+        floating.get_right() -
+        anchor.get_left() -
+        anchor.get_right()
+      ) /
+      2.0
+    let dy = (
+        floating.get_top() +
+        floating.get_bottom() -
+        anchor.get_top() -
+        anchor.get_bottom()
+      ) /
+      2.0
+    if dx.abs() > dy.abs() {
+      if dx < 0.0 {
+        "left"
+      } else {
+        "right"
+      }
+    } else if dy < 0.0 {
+      "top"
+    } else {
+      "bottom"
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_positioning_stop(binding : FloatingPositioningBinding) -> Unit {
+  if !binding.observing.val {
+    return
+  }
+  binding.observing.val = false
+  if binding.frame.val is Some(frame) && ui_has_window() {
+    @dom.window().cancel_animation_frame(frame)
+  }
+  binding.frame.val = None
+  if binding.listener.val is Some(listener) && ui_has_window() {
+    let window = @dom.window()
+    window.remove_event_listener_with_options("scroll", listener, capture=true)
+    window.remove_event_listener("resize", listener)
+    if window.get_visual_viewport() is Some(viewport) {
+      viewport.remove_event_listener("scroll", listener)
+      viewport.remove_event_listener("resize", listener)
+    }
+  }
+  binding.listener.val = None
+  if binding.resize_observer.val is Some(observer) {
+    observer.disconnect()
+  }
+  binding.resize_observer.val = None
+  if binding.mutation_observer.val is Some(observer) {
+    observer.disconnect()
+  }
+  binding.mutation_observer.val = None
+  if binding.intersection_observer.val is Some(observer) {
+    observer.disconnect()
+  }
+  binding.intersection_observer.val = None
+  binding.element.remove_attribute("data-positioned")
+  binding.element.remove_attribute("data-anchor-hidden")
+}
+
+///|
+#cfg(target="js")
+fn floating_sync_css_arrow(binding : FloatingPositioningBinding) -> Unit {
+  if !binding.observing.val || !binding.element.get_is_connected() {
+    floating_positioning_stop(binding)
+    return
+  }
+  guard ui_element_by_id(
+      binding.element.get_attribute("data-trigger-id").unwrap_or(""),
+    )
+    is Some(reference) &&
+    reference.get_is_connected() else {
+    return
+  }
+  let side = floating_infer_tooltip_side(binding.element, reference)
+  if binding.element.get_attribute("data-side").unwrap_or("") != side {
+    binding.element.set_attribute("data-side", side)
+  }
+  floating_set_tooltip_arrow_side(binding.element, binding.html, side)
+}
+
+///|
+#cfg(target="js")
+fn floating_coordinates(
+  side : String,
+  align : String,
+  anchor : @dom.DOMRect,
+  floating_width : Double,
+  floating_height : Double,
+  side_offset : Double,
+  align_offset : Double,
+  rtl : Bool,
+) -> FloatingCoordinates {
+  let mut left = anchor.get_left()
+  let mut top = anchor.get_bottom() + side_offset
+  if side == "top" {
+    top = anchor.get_top() - floating_height - side_offset
+  } else if side == "left" {
+    left = anchor.get_left() - floating_width - side_offset
+  } else if side == "right" {
+    left = anchor.get_right() + side_offset
+  }
+  if side == "top" || side == "bottom" {
+    let start = if rtl {
+      anchor.get_right() - floating_width
+    } else {
+      anchor.get_left()
+    }
+    let end = if rtl {
+      anchor.get_left()
+    } else {
+      anchor.get_right() - floating_width
+    }
+    if align == "start" {
+      left = start + align_offset
+    } else if align == "center" {
+      left = anchor.get_left() +
+        (anchor.get_width() - floating_width) / 2.0 +
+        align_offset
+    } else {
+      left = end + align_offset
+    }
+  } else if align == "start" {
+    top = anchor.get_top() + align_offset
+  } else if align == "center" {
+    top = anchor.get_top() +
+      (anchor.get_height() - floating_height) / 2.0 +
+      align_offset
+  } else {
+    top = anchor.get_bottom() - floating_height + align_offset
+  }
+  { side, left, top }
+}
+
+///|
+#cfg(target="js")
+fn floating_overflow_total(
+  candidate : FloatingCoordinates,
+  floating_width : Double,
+  floating_height : Double,
+  clip_left : Double,
+  clip_top : Double,
+  clip_right : Double,
+  clip_bottom : Double,
+) -> Double {
+  (clip_left - candidate.left).max(0.0) +
+  (clip_top - candidate.top).max(0.0) +
+  (candidate.left + floating_width - clip_right).max(0.0) +
+  (candidate.top + floating_height - clip_bottom).max(0.0)
+}
+
+///|
+#cfg(target="js")
+fn floating_position_fallback(binding : FloatingPositioningBinding) -> Unit {
+  if !binding.element.get_is_connected() {
+    floating_positioning_stop(binding)
+    return
+  }
+  guard ui_element_by_id(
+      binding.element.get_attribute("data-trigger-id").unwrap_or(""),
+    )
+    is Some(trigger) &&
+    trigger.get_is_connected() else {
+    return
+  }
+  let anchor = trigger.get_bounding_client_rect()
+  let measured = binding.element.get_bounding_client_rect()
+  let offset_width = binding.html.get_offset_width()
+  let offset_height = binding.html.get_offset_height()
+  let floating_width = if offset_width > 0.0 {
+    offset_width
+  } else {
+    measured.get_width()
+  }
+  let floating_height = if offset_height > 0.0 {
+    offset_height
+  } else {
+    measured.get_height()
+  }
+  let side = floating_normalize_side(
+    match binding.element.get_attribute("data-requested-side").unwrap_or("") {
+      "" => binding.element.get_attribute("data-side").unwrap_or("")
+      value => value
+    },
+  )
+  let align = floating_normalize_align(
+    match binding.element.get_attribute("data-requested-align").unwrap_or("") {
+      "" => binding.element.get_attribute("data-align").unwrap_or("")
+      value => value
+    },
+  )
+  let side_offset = ui_parse_double_or(
+    binding.element.get_attribute("data-side-offset").unwrap_or(""),
+    0.0,
+  )
+  let align_offset = ui_parse_double_or(
+    binding.element.get_attribute("data-align-offset").unwrap_or(""),
+    0.0,
+  )
+  let (viewport_left, viewport_top, viewport_width, viewport_height) = if ui_has_window() &&
+    @dom.window().get_visual_viewport() is Some(viewport) {
+    (
+      viewport.get_offset_left(),
+      viewport.get_offset_top(),
+      viewport.get_width(),
+      viewport.get_height(),
+    )
+  } else if @dom.document().get_document_element() is Some(root) {
+    (0.0, 0.0, root.get_client_width(), root.get_client_height())
+  } else {
+    (0.0, 0.0, 0.0, 0.0)
+  }
+  let padding = ui_parse_double_or(
+    binding.element.get_attribute("data-collision-padding").unwrap_or(""),
+    0.0,
+  ).max(0.0)
+  let clip_left = viewport_left + padding
+  let clip_top = viewport_top + padding
+  let clip_right = viewport_left + viewport_width - padding
+  let clip_bottom = viewport_top + viewport_height - padding
+  let rtl = ui_element_is_rtl(trigger)
+  let preferred = floating_coordinates(
+    side, align, anchor, floating_width, floating_height, side_offset, align_offset,
+    rtl,
+  )
+  let opposite = floating_coordinates(
+    floating_opposite_side(side),
+    align,
+    anchor,
+    floating_width,
+    floating_height,
+    side_offset,
+    align_offset,
+    rtl,
+  )
+  let preferred_overflow = floating_overflow_total(
+    preferred, floating_width, floating_height, clip_left, clip_top, clip_right,
+    clip_bottom,
+  )
+  let opposite_overflow = floating_overflow_total(
+    opposite, floating_width, floating_height, clip_left, clip_top, clip_right, clip_bottom,
+  )
+  let placed = if preferred_overflow <= 0.0 {
+    preferred
+  } else if opposite_overflow <= 0.0 || opposite_overflow < preferred_overflow {
+    opposite
+  } else {
+    preferred
+  }
+  let mut left = placed.left
+  let mut top = placed.top
+  let sticky = match
+    binding.element.get_attribute("data-sticky").unwrap_or("") {
+    "" => "partial"
+    value => value
+  }
+  if placed.side == "top" || placed.side == "bottom" {
+    left = left.max(clip_left).min((clip_right - floating_width).max(clip_left))
+    if sticky == "partial" {
+      left = left
+        .max(anchor.get_left() - floating_width)
+        .min(anchor.get_right())
+    }
+  } else {
+    top = top.max(clip_top).min((clip_bottom - floating_height).max(clip_top))
+    if sticky == "partial" {
+      top = top.max(anchor.get_top() - floating_height).min(anchor.get_bottom())
+    }
+  }
+  let anchor_hidden = anchor.get_right() <= viewport_left ||
+    anchor.get_left() >= viewport_left + viewport_width ||
+    anchor.get_bottom() <= viewport_top ||
+    anchor.get_top() >= viewport_top + viewport_height
+  binding.element.set_attribute("data-side", placed.side)
+  binding.element.set_attribute("data-align", align)
+  floating_set_tooltip_arrow_side(binding.element, binding.html, placed.side)
+  if anchor_hidden {
+    binding.element.set_attribute("data-anchor-hidden", "")
+  } else {
+    binding.element.remove_attribute("data-anchor-hidden")
+  }
+  let style = binding.html.get_style()
+  style.set_property("--rui-floating-left", "\{left.round().to_int()}px")
+  style.set_property("--rui-floating-top", "\{top.round().to_int()}px")
+  style.set_property(
+    "--rui-floating-anchor-width",
+    "\{anchor.get_width().round().to_int()}px",
+  )
+  style.set_property(
+    "--rui-floating-anchor-height",
+    "\{anchor.get_height().round().to_int()}px",
+  )
+  style.set_property(
+    "--rui-floating-available-width",
+    "\{(clip_right - clip_left).max(0.0).round().to_int()}px",
+  )
+  style.set_property(
+    "--rui-floating-available-height",
+    "\{(clip_bottom - clip_top).max(0.0).round().to_int()}px",
+  )
+  let origin_align = match align {
+    "start" => "0%"
+    "end" => "100%"
+    _ => "50%"
+  }
+  let origin = match placed.side {
+    "bottom" => origin_align + " 0%"
+    "top" => origin_align + " 100%"
+    "right" => "0% " + origin_align
+    _ => "100% " + origin_align
+  }
+  style.set_property("--rui-floating-transform-origin", origin)
+  binding.element.set_attribute("data-positioned", "true")
+}
+
+///|
+#cfg(target="js")
+fn floating_positioning_run(binding : FloatingPositioningBinding) -> Unit {
+  if binding.mode == "css-arrow" {
+    floating_sync_css_arrow(binding)
+  } else {
+    floating_position_fallback(binding)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_positioning_schedule(binding : FloatingPositioningBinding) -> Unit {
+  if binding.frame.val is Some(_) {
+    return
+  }
+  if ui_has_window() {
+    binding.frame.val = Some(
+      @dom.window().request_animation_frame(_ => {
+        binding.frame.val = None
+        floating_positioning_run(binding)
+      }),
+    )
+  } else {
+    floating_positioning_run(binding)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_positioning_start(binding : FloatingPositioningBinding) -> Unit {
+  if binding.observing.val {
+    return
+  }
+  binding.observing.val = true
+  let listener : @dom.Listener = _ => floating_positioning_schedule(binding)
+  binding.listener.val = Some(listener)
+  if ui_has_window() {
+    let window = @dom.window()
+    window.add_event_listener_with_options(
+      "scroll",
+      listener,
+      capture=true,
+      passive=true,
+    )
+    window.add_event_listener_with_options("resize", listener, passive=true)
+    if window.get_visual_viewport() is Some(viewport) {
+      viewport.add_event_listener_with_options("scroll", listener, passive=true)
+      viewport.add_event_listener_with_options("resize", listener, passive=true)
+    }
+  }
+  let trigger = ui_element_by_id(
+    binding.element.get_attribute("data-trigger-id").unwrap_or(""),
+  )
+  let resize_observer = @dom.ResizeObserver::new((_entries, _observer) => {
+    floating_positioning_schedule(binding)
+  })
+  if trigger is Some(element) {
+    resize_observer.observe(element)
+  }
+  resize_observer.observe(binding.element)
+  binding.resize_observer.val = Some(resize_observer)
+  if binding.mode == "css-arrow" {
+    let mutation_observer = @dom.MutationObserver::new((_records, _observer) => {
+      floating_positioning_schedule(binding)
+    })
+    mutation_observer.observe(
+      binding.element.as_node(),
+      attributes=true,
+      child_list=true,
+      attribute_filter=["style", "data-requested-side"],
+    )
+    binding.mutation_observer.val = Some(mutation_observer)
+  } else {
+    let intersection_observer = @dom.IntersectionObserver::new(
+      (_entries, _observer) => floating_positioning_schedule(binding),
+      threshold=[0.0, 1.0],
+    )
+    if trigger is Some(element) {
+      intersection_observer.observe(element)
+    }
+    binding.intersection_observer.val = Some(intersection_observer)
+    let mutation_observer = @dom.MutationObserver::new((records, _observer) => {
+      let mut input_changed = false
+      for record in records {
+        if record.get_attribute_name() is Some(name) && name != "style" {
+          input_changed = true
+        }
+      }
+      let style = binding.html.get_style()
+      let coordinates_reset = style.get_property_value("--rui-floating-left") ==
+        "" ||
+        style.get_property_value("--rui-floating-top") == ""
+      if input_changed || coordinates_reset {
+        floating_position_fallback(binding)
+      }
+    })
+    mutation_observer.observe(binding.element.as_node(), attributes=true, attribute_filter=[
+      "style", "data-requested-side", "data-requested-align", "data-side-offset",
+      "data-align-offset",
+    ])
+    binding.mutation_observer.val = Some(mutation_observer)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_new_positioning(
+  element : @dom.Element,
+  html : @dom.HTMLElement,
+  mode : String,
+) -> FloatingPositioningBinding {
+  {
+    element,
+    html,
+    mode,
+    frame: Ref(None),
+    observing: Ref(false),
+    listener: Ref(None),
+    resize_observer: Ref(None),
+    mutation_observer: Ref(None),
+    intersection_observer: Ref(None),
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_use_positioning(
+  id : String,
+  element : @dom.Element,
+  html : @dom.HTMLElement,
+  mode : String,
+) -> FloatingPositioningBinding {
+  if floating_positionings.get(id) is Some(current) &&
+    floating_same_element(current.element, element) &&
+    current.mode == mode {
+    return current
+  }
+  if floating_positionings.get(id) is Some(current) {
+    floating_positioning_stop(current)
+  }
+  let binding = floating_new_positioning(element, html, mode)
+  floating_positionings[id] = binding
+  floating_set_stop_positioning(id, () => floating_positioning_stop(binding))
+  binding
+}
+
+///|
+#cfg(target="js")
+fn position_floating(id : String) -> Unit {
+  guard ui_has_document() else { return }
+  guard ui_element_by_id(id) is Some(element) && element.get_is_connected() else {
+    return
+  }
+  guard element.to_html_element() is Some(html) else { return }
+  let trigger = ui_element_by_id(
+    element.get_attribute("data-trigger-id").unwrap_or(""),
+  )
+  let style = html.get_style()
+  let position_area = style.get_property_value("position-area")
+  let position_fallbacks = style.get_property_value("position-try-fallbacks")
+  let css_anchored = trigger is Some(_) &&
+    @dom.CSS::supports("anchor-name", "--rui-anchor") &&
+    @dom.CSS::supports("position-anchor", "--rui-anchor") &&
+    @dom.CSS::supports("position-area", position_area) &&
+    @dom.CSS::supports("position-try-fallbacks", position_fallbacks)
+  if css_anchored {
+    if floating_positionings.get(id) is Some(current) {
+      floating_positioning_stop(current)
+      ignore(floating_positionings.remove(id))
+      ignore(floating_stop_positioning.remove(id))
+    }
+    ignore(style.remove_property("--rui-floating-left"))
+    ignore(style.remove_property("--rui-floating-top"))
+    ignore(style.remove_property("--rui-floating-anchor-width"))
+    ignore(style.remove_property("--rui-floating-anchor-height"))
+    ignore(style.remove_property("--rui-floating-available-width"))
+    ignore(style.remove_property("--rui-floating-available-height"))
+    element.set_attribute("data-positioning", "css-anchor")
+    element.set_attribute("data-positioned", "true")
+    element.remove_attribute("data-anchor-hidden")
+    if floating_has_tooltip_arrow(element) {
+      let binding = floating_use_positioning(id, element, html, "css-arrow")
+      floating_positioning_start(binding)
+      floating_sync_css_arrow(binding)
+    }
+  } else {
+    element.set_attribute("data-positioning", "javascript-fallback")
+    let binding = floating_use_positioning(id, element, html, "fallback")
+    floating_positioning_start(binding)
+    // AfterRender already runs inside Rabbita's frame flush. Measuring and
+    // writing here keeps the first visible frame anchored to its trigger.
+    floating_position_fallback(binding)
+  }
+}
+
+///|
+#cfg(target="js")
+fn floating_bind_sync_cmd(id : String, sync : @cmd.Emit[Bool]) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => bind_floating_sync(id, open => scheduler.add(sync(open))),
+      purpose="floating-sync-bind",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn floating_set_open_when_ready(id : String, open : Bool) -> Unit {
+  ui_after_ready("floating-set-open:" + id, () => {
+    let ready = set_floating_open(id, open)
+    if ready && open {
+      position_floating(id)
+    }
+    ready
+  })
+}
+
+///|
+#cfg(target="js")
+fn floating_set_open_cmd(id : String, open : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    floating_set_open_when_ready(id, open)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn floating_set_open_cmd(id : String, open : Bool) -> @cmd.Cmd {
+  ignore((id, open))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn floating_toggle_cmd(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    toggle_floating(id)
+    position_floating(id)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn floating_toggle_cmd(id : String) -> @cmd.Cmd {
+  ignore(id)
+  @cmd.none
+}
+
+///|
+/// Imperatively open a mounted popover. Its incremental component synchronizes
+/// through the native `toggle` event.
+pub fn popover_open(id : String) -> @cmd.Cmd {
+  floating_set_open_cmd(id, true)
+}
+
+///|
+pub fn popover_close(id : String) -> @cmd.Cmd {
+  floating_set_open_cmd(id, false)
+}
+
+///|
+pub fn popover_toggle(id : String) -> @cmd.Cmd {
+  floating_toggle_cmd(id)
+}
+
+///|
+/// Render a measurable custom anchor for controlled popover composition.
+///
+/// Pass this element's `id` as `popover_content(trigger_id=...)`. The anchor
+/// may wrap any trigger or visual target; positioning then uses the anchor's
+/// bounding box instead of requiring the trigger itself to be the reference.
+pub fn[C : @html.IsChildren] popover_anchor(
+  id~ : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles(
+      [UiBoxSizing, PopoverAnchorStyle, popup_anchor_style(id)],
+      style,
+    ),
+    id~,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "popover-anchor"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] popover_trigger(
+  target_id~ : String,
+  open? : Bool = false,
+  disabled? : Bool = false,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let resolved_id = id.unwrap_or(target_id + "-trigger")
+  let element_attrs = popup_state_attrs(attrs, "popover-trigger", open)
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+    .aria_haspopup("dialog")
+    .aria_expanded(ui_bool(open))
+    .aria_controls(target_id)
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  if !disabled && on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+        popup_anchor_style(resolved_id),
+      ],
+      style,
+    ),
+    id=resolved_id,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] popover_content(
+  id~ : String,
+  trigger_id~ : String,
+  open? : Bool = false,
+  modal? : Bool = false,
+  initial_focus? : Bool = true,
+  initial_focus_id? : String,
+  restore_focus? : Bool = true,
+  final_focus_id? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  title_id? : String,
+  description_id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = popup_state_attrs(attrs, "popover-content", open)
+    .role("dialog")
+    .tabindex(-1)
+    .data_set("modal", ui_bool(modal))
+    .data_set("initial-focus", ui_bool(initial_focus))
+    .data_set("restore-focus", ui_bool(restore_focus))
+    .data_set("trigger-id", trigger_id)
+    .data_set("requested-side", popup_side_value(side))
+    .data_set("requested-align", popup_align_value(align))
+    .data_set("side", popup_side_value(side))
+    .data_set("align", popup_align_value(align))
+    .data_set("side-offset", "\{side_offset}")
+    .data_set("align-offset", "\{align_offset}")
+    .data_set("collision-padding", "0")
+    .data_set("sticky", "partial")
+  if modal {
+    ignore(element_attrs.aria_modal("true"))
+  } else {
+    ignore(element_attrs.popover("auto"))
+  }
+  if initial_focus_id is Some(initial_focus_id) {
+    ignore(element_attrs.data_set("initial-focus-id", initial_focus_id))
+  }
+  if final_focus_id is Some(final_focus_id) {
+    ignore(element_attrs.data_set("final-focus-id", final_focus_id))
+  }
+  if title_id is Some(title_id) {
+    ignore(element_attrs.aria_labelledby(title_id))
+  }
+  if description_id is Some(description_id) {
+    ignore(element_attrs.aria_describedby(description_id))
+  }
+  let content_style = ui_styles(
+    [
+      UiBoxSizing,
+      UiFontSans,
+      UiTextRendering,
+      PopoverContentStyle,
+      PopupTransition100Style,
+      popup_floating_anchor_style(
+        trigger_id, side, align, side_offset, align_offset,
+      ),
+      popup_state_style(open),
+    ],
+    style,
+  )
+  if modal {
+    let native_open = floating_dialog_open(open)
+    @html.dialog(
+      style=content_style,
+      id~,
+      class?,
+      title?,
+      open?=native_open,
+      closedby="any",
+      attrs=element_attrs,
+      children,
+    )
+  } else {
+    @html.div(
+      style=content_style,
+      id~,
+      class?,
+      title?,
+      attrs=element_attrs,
+      children,
+    )
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] popover_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, PopoverHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "popover-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] popover_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.h2(
+    style=ui_styles([UiBoxSizing, PopoverTitleStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "popover-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] popover_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    style=ui_styles([UiBoxSizing, PopoverDescriptionStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "popover-description"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] popover_close_button(
+  target_id~ : String,
+  disabled? : Bool = false,
+  variant? : ButtonVariant = Ghost,
+  size? : ButtonSize = Sm,
+  aria_label? : String = "Close",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "popover-close")
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+  ignore(element_attrs.aria_label(aria_label))
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  if !disabled {
+    ignore(element_attrs.on_click(_ => popover_close(target_id)))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+priv enum PopoverMsg {
+  PopoverToggleRequested
+  PopoverNativeChanged(Bool)
+}
+
+///|
+#cfg(target="js")
+fn popover_notify_cmd(
+  on_open_change : @cmd.Emit[Bool]?,
+  open : Bool,
+) -> @cmd.Cmd {
+  if on_open_change is Some(notify) {
+    notify(open)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn[T : @html.IsChildren, C : @html.IsChildren] render_popover(
+  id : String,
+  open : Bool,
+  disabled : Bool,
+  modal : Bool,
+  initial_focus : Bool,
+  initial_focus_id : String?,
+  restore_focus : Bool,
+  final_focus_id : String?,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+  trigger_variant : ButtonVariant,
+  trigger_size : ButtonSize,
+  title_id : String?,
+  description_id : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  trigger_attrs : @html.Attrs?,
+  trigger_style : Array[String],
+  content_attrs : @html.Attrs?,
+  content_style : Array[String],
+  on_trigger_click : @cmd.Cmd?,
+  trigger : T,
+  content : C,
+) -> @html.Html {
+  let trigger_id = id + "-trigger"
+  let root_attrs = popup_state_attrs(attrs, "popover", open)
+  let on_click = on_trigger_click
+  let attrs = trigger_attrs
+  let popup_attrs = content_attrs
+  @html.span(
+    style=ui_styles([UiBoxSizing, PopoverRootStyle], style),
+    attrs=root_attrs,
+    [
+      popover_trigger(
+        target_id=id,
+        open~,
+        disabled~,
+        variant=trigger_variant,
+        size=trigger_size,
+        on_click?,
+        id=trigger_id,
+        attrs?,
+        style=trigger_style,
+        trigger,
+      ),
+      popover_content(
+        id~,
+        trigger_id~,
+        open~,
+        modal~,
+        initial_focus~,
+        initial_focus_id?,
+        restore_focus~,
+        final_focus_id?,
+        side~,
+        align~,
+        side_offset~,
+        align_offset~,
+        title_id?,
+        description_id?,
+        attrs?=popup_attrs,
+        style=content_style,
+        content,
+      ),
+    ],
+  )
+}
+
+///|
+/// Build a stateful Rabbita popover backed by native browser primitives.
+///
+/// The default non-modal mode uses the HTML Popover API for light-dismiss and
+/// Escape. `modal=true` uses `<dialog>` for inert background and Tab
+/// containment. Initial and final focus IDs configure focus entry and
+/// restoration. `id` is also used by `popover_open`, `popover_close`, and
+/// `popover_toggle`.
+#cfg(target="js")
+pub fn[T : @html.IsChildren, C : @html.IsChildren] popover(
+  id~ : String,
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  modal? : Bool = false,
+  initial_focus? : Bool = true,
+  initial_focus_id? : String,
+  restore_focus? : Bool = true,
+  final_focus_id? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  trigger_variant? : ButtonVariant = Outline,
+  trigger_size? : ButtonSize = Default,
+  title_id? : String,
+  description_id? : String,
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  trigger : T,
+  content : C,
+) -> @rabbita.Val[@html.Html] {
+  let initial_open = default_open && !disabled
+  let (open, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      let sync = emit.map(value => PopoverNativeChanged(value))
+      (
+        initial_open,
+        @cmd.batch([
+          floating_bind_sync_cmd(id, sync),
+          if initial_open {
+            floating_set_open_cmd(id, true)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(_, msg, current) => {
+      match msg {
+        PopoverToggleRequested =>
+          if disabled {
+            (current, @cmd.none)
+          } else {
+            let next = !current
+            (
+              next,
+              @cmd.batch([
+                floating_set_open_cmd(id, next),
+                popover_notify_cmd(on_open_change, next),
+              ]),
+            )
+          }
+        PopoverNativeChanged(next) =>
+          if next == current {
+            (current, @cmd.none)
+          } else {
+            (next, popover_notify_cmd(on_open_change, next))
+          }
+      }
+    },
+  )
+  open.view(open => {
+    render_popover(
+      id,
+      open,
+      disabled,
+      modal,
+      initial_focus,
+      initial_focus_id,
+      restore_focus,
+      final_focus_id,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      trigger_variant,
+      trigger_size,
+      title_id,
+      description_id,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      Some(emit(PopoverToggleRequested)),
+      trigger,
+      content,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: renders the initial state as a constant incremental
+/// value. Browser interaction is available on the JavaScript target.
+#cfg(not(target="js"))
+pub fn[T : @html.IsChildren, C : @html.IsChildren] popover(
+  id~ : String,
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  modal? : Bool = false,
+  initial_focus? : Bool = true,
+  initial_focus_id? : String,
+  restore_focus? : Bool = true,
+  final_focus_id? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  trigger_variant? : ButtonVariant = Outline,
+  trigger_size? : ButtonSize = Default,
+  title_id? : String,
+  description_id? : String,
+  on_open_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  trigger : T,
+  content : C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_open_change)
+  @rabbita.Val::constant(
+    render_popover(
+      id,
+      default_open && !disabled,
+      disabled,
+      modal,
+      initial_focus,
+      initial_focus_id,
+      restore_focus,
+      final_focus_id,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      trigger_variant,
+      trigger_size,
+      title_id,
+      description_id,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      None,
+      trigger,
+      content,
+    ),
+  )
+}

--- a/rui/popover_position_wbtest.mbt
+++ b/rui/popover_position_wbtest.mbt
@@ -1,0 +1,473 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_floating_position_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const styles = new Map()
+  #|   const frames = []
+  #|   const windowListeners = {}
+  #|   const viewportListeners = {}
+  #|   let anchorTop = 100
+  #|   let arrowEnabled = false
+  #|   let popupRect = {
+  #|     left: 40,
+  #|     right: 160,
+  #|     top: 130,
+  #|     bottom: 178,
+  #|     width: 120,
+  #|     height: 48,
+  #|   }
+  #|   let removed = 0
+  #|   let measurements = 0
+  #|   let observer = null
+  #|   let open = true
+  #|   class FakeNode {
+  #|     constructor() {
+  #|       this.nodeType = 0
+  #|       this.parentNode = null
+  #|     }
+  #|     isSameNode(other) { return this === other }
+  #|   }
+  #|   class FakeElement extends FakeNode {
+  #|     constructor() {
+  #|       super()
+  #|       this.nodeType = 1
+  #|       this.isConnected = true
+  #|       this.dataset = {}
+  #|     }
+  #|     getAttribute(name) {
+  #|       if (!name.startsWith("data-")) return this[name] ?? ""
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       return this.dataset[key] ?? ""
+  #|     }
+  #|     setAttribute(name, value) {
+  #|       if (!name.startsWith("data-")) {
+  #|         this[name] = String(value)
+  #|         return
+  #|       }
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       this.dataset[key] = String(value)
+  #|     }
+  #|     removeAttribute(name) {
+  #|       if (!name.startsWith("data-")) {
+  #|         delete this[name]
+  #|         return
+  #|       }
+  #|       const key = name.slice(5).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+  #|       delete this.dataset[key]
+  #|     }
+  #|   }
+  #|   class FakeHTMLElement extends FakeElement {
+  #|     focus() {}
+  #|   }
+  #|   class FakeHTMLDialogElement extends FakeHTMLElement {}
+  #|   const trigger = Object.assign(new FakeHTMLElement(), {
+  #|     isConnected: true,
+  #|     getBoundingClientRect: () => {
+  #|       measurements += 1
+  #|       return {
+  #|         left: 40,
+  #|         right: 120,
+  #|         top: anchorTop,
+  #|         bottom: anchorTop + 24,
+  #|         width: 80,
+  #|         height: 24,
+  #|       }
+  #|     },
+  #|   })
+  #|   const popupListeners = {}
+  #|   const popup = Object.assign(new FakeHTMLElement(), {
+  #|     isConnected: true,
+  #|     popover: "manual",
+  #|     dataset: {
+  #|       triggerId: id + "-trigger",
+  #|       side: "bottom",
+  #|       align: "start",
+  #|       sideOffset: "6",
+  #|       alignOffset: "3",
+  #|     },
+  #|     matches: selector => selector === ":popover-open" && open,
+  #|     addEventListener: (type, callback) => { popupListeners[type] = callback },
+  #|     removeEventListener: type => { delete popupListeners[type] },
+  #|     getBoundingClientRect: () => {
+  #|       measurements += 1
+  #|       return popupRect
+  #|     },
+  #|     querySelector: selector => selector === '[data-slot="tooltip-arrow"]'
+  #|       && arrowEnabled ? {} : null,
+  #|     showPopover: () => { open = true },
+  #|     hidePopover: () => { open = false },
+  #|     offsetWidth: 120,
+  #|     offsetHeight: 48,
+  #|     style: {
+  #|       setProperty: (key, value) => styles.set(key, value),
+  #|       getPropertyValue: key => styles.get(key) || "",
+  #|       removeProperty: key => styles.delete(key),
+  #|     },
+  #|   })
+  #|   const visualViewport = {
+  #|     offsetLeft: 0,
+  #|     offsetTop: 0,
+  #|     width: 800,
+  #|     height: 600,
+  #|     addEventListener: (type, callback) => {
+  #|       viewportListeners[type] = callback
+  #|     },
+  #|     removeEventListener: type => {
+  #|       delete viewportListeners[type]
+  #|       removed += 1
+  #|     },
+  #|   }
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     hadRequestAnimationFrame: own("requestAnimationFrame"),
+  #|     cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  #|     hadCancelAnimationFrame: own("cancelAnimationFrame"),
+  #|     ResizeObserver: globalThis.ResizeObserver,
+  #|     hadResizeObserver: own("ResizeObserver"),
+  #|     MutationObserver: globalThis.MutationObserver,
+  #|     hadMutationObserver: own("MutationObserver"),
+  #|     IntersectionObserver: globalThis.IntersectionObserver,
+  #|     hadIntersectionObserver: own("IntersectionObserver"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     Element: globalThis.Element,
+  #|     hadElement: own("Element"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     HTMLDialogElement: globalThis.HTMLDialogElement,
+  #|     hadHTMLDialogElement: own("HTMLDialogElement"),
+  #|     CSS: globalThis.CSS,
+  #|     hadCSS: own("CSS"),
+  #|     floatingStack: globalThis.__ruiFloatingStack,
+  #|     hadFloatingStack: own("__ruiFloatingStack"),
+  #|     styles,
+  #|     frames,
+  #|     windowListeners,
+  #|     viewportListeners,
+  #|     popup,
+  #|     trigger,
+  #|     setAnchorTop: value => { anchorTop = value },
+  #|     enableArrow: () => { arrowEnabled = true },
+  #|     setPopupRect: value => { popupRect = value },
+  #|     removed: () => removed,
+  #|     measurements: () => measurements,
+  #|     getObserver: () => observer,
+  #|   }
+  #|   globalThis.Node = FakeNode
+  #|   globalThis.Element = FakeElement
+  #|   globalThis.HTMLElement = FakeHTMLElement
+  #|   globalThis.HTMLDialogElement = FakeHTMLDialogElement
+  #|   globalThis.__ruiFloatingStack = []
+  #|   globalThis.document = Object.assign(new FakeNode(), {
+  #|     activeElement: null,
+  #|     body: new FakeHTMLElement(),
+  #|     documentElement: Object.assign(new FakeElement(), {
+  #|       clientWidth: 800,
+  #|       clientHeight: 600,
+  #|     }),
+  #|     getElementById: value => {
+  #|       if (value === id) return popup
+  #|       if (value === id + "-trigger") return trigger
+  #|       return null
+  #|     },
+  #|     addEventListener() {},
+  #|     removeEventListener() {},
+  #|   })
+  #|   globalThis.window = {
+  #|     visualViewport,
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: property => property === "direction" ? "ltr" : "",
+  #|     }),
+  #|     queueMicrotask: callback => callback(),
+  #|     requestAnimationFrame: callback => {
+  #|       frames.push(callback)
+  #|       return frames.length
+  #|     },
+  #|     cancelAnimationFrame: () => {},
+  #|     addEventListener: (type, callback) => {
+  #|       windowListeners[type] = callback
+  #|     },
+  #|     removeEventListener: type => {
+  #|       delete windowListeners[type]
+  #|       removed += 1
+  #|     },
+  #|   }
+  #|   globalThis.requestAnimationFrame = callback => {
+  #|     frames.push(callback)
+  #|     return frames.length
+  #|   }
+  #|   globalThis.cancelAnimationFrame = () => {}
+  #|   globalThis.CSS = { supports: () => false }
+  #|   globalThis.ResizeObserver = class {
+  #|     constructor(callback) {
+  #|       this.callback = callback
+  #|       this.disconnected = false
+  #|       observer = this
+  #|     }
+  #|     observe() {}
+  #|     disconnect() { this.disconnected = true }
+  #|   }
+  #|   globalThis.MutationObserver = class {
+  #|     observe() {}
+  #|     disconnect() {}
+  #|   }
+  #|   globalThis.IntersectionObserver = class {
+  #|     observe() {}
+  #|     unobserve() {}
+  #|     disconnect() {}
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_enable_css_anchor_position_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture
+  #|   fixture.styles.set("position-area", "bottom span-x-end")
+  #|   fixture.styles.set(
+  #|     "position-try-fallbacks",
+  #|     "flip-inline,flip-block,flip-inline flip-block",
+  #|   )
+  #|   globalThis.CSS = { supports: () => true }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_enable_flipped_tooltip_arrow_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture
+  #|   fixture.enableArrow()
+  #|   fixture.popup.dataset.requestedSide = "top"
+  #|   fixture.popup.dataset.side = "top"
+  #|   fixture.setPopupRect({
+  #|     left: 40,
+  #|     right: 160,
+  #|     top: 130,
+  #|     bottom: 178,
+  #|     width: 120,
+  #|     height: 48,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_style(key : String) -> String =
+  #| key => globalThis.__ruiFloatingPositionFixture.styles.get(key) || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_frames() -> Int =
+  #| () => globalThis.__ruiFloatingPositionFixture.frames.length
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_measurements() -> Int =
+  #| () => globalThis.__ruiFloatingPositionFixture.measurements()
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_listener_count() -> Int =
+  #| () => {
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture
+  #|   return Object.keys(fixture.windowListeners).length
+  #|     + Object.keys(fixture.viewportListeners).length
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_mode() -> String =
+  #| () => globalThis.__ruiFloatingPositionFixture.popup.dataset.positioning || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_side() -> String =
+  #| () => globalThis.__ruiFloatingPositionFixture.popup.dataset.side || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_anchor_hidden() -> Bool =
+  #| () => globalThis.__ruiFloatingPositionFixture.popup.dataset.anchorHidden !== undefined
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_scroll_floating_position_fixture(top : Int) -> Unit =
+  #| top => {
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture
+  #|   fixture.setAnchorTop(top)
+  #|   fixture.windowListeners.scroll?.()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_flush_floating_position_fixture_frame() -> Unit =
+  #| () => globalThis.__ruiFloatingPositionFixture.frames.shift()?.()
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_clear_floating_position_fixture_styles() -> Unit =
+  #| () => globalThis.__ruiFloatingPositionFixture.styles.clear()
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_floating_position_fixture_stopped() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture
+  #|   return fixture.removed() >= 4
+  #|     && Boolean(fixture.getObserver()?.disconnected)
+  #|     && fixture.popup.dataset.positioned === undefined
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_floating_position_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiFloatingPositionFixture
+  #|   if (!fixture) return
+  #|   fixture.popup.__ruiFloatingStopPositioning?.()
+  #|   const restore = (key, had, value) => {
+  #|     if (had) globalThis[key] = value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   restore("document", fixture.hadDocument, fixture.document)
+  #|   restore("window", fixture.hadWindow, fixture.window)
+  #|   restore(
+  #|     "requestAnimationFrame",
+  #|     fixture.hadRequestAnimationFrame,
+  #|     fixture.requestAnimationFrame,
+  #|   )
+  #|   restore(
+  #|     "cancelAnimationFrame",
+  #|     fixture.hadCancelAnimationFrame,
+  #|     fixture.cancelAnimationFrame,
+  #|   )
+  #|   restore(
+  #|     "ResizeObserver",
+  #|     fixture.hadResizeObserver,
+  #|     fixture.ResizeObserver,
+  #|   )
+  #|   restore(
+  #|     "MutationObserver",
+  #|     fixture.hadMutationObserver,
+  #|     fixture.MutationObserver,
+  #|   )
+  #|   restore(
+  #|     "IntersectionObserver",
+  #|     fixture.hadIntersectionObserver,
+  #|     fixture.IntersectionObserver,
+  #|   )
+  #|   restore("Node", fixture.hadNode, fixture.Node)
+  #|   restore("Element", fixture.hadElement, fixture.Element)
+  #|   restore("HTMLElement", fixture.hadHTMLElement, fixture.HTMLElement)
+  #|   restore(
+  #|     "HTMLDialogElement",
+  #|     fixture.hadHTMLDialogElement,
+  #|     fixture.HTMLDialogElement,
+  #|   )
+  #|   restore("CSS", fixture.hadCSS, fixture.CSS)
+  #|   restore(
+  #|     "__ruiFloatingStack",
+  #|     fixture.hadFloatingStack,
+  #|     fixture.floatingStack,
+  #|   )
+  #|   delete globalThis.__ruiFloatingPositionFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "CSS anchored floating layers do not measure or subscribe to scrolling" {
+  ffi_install_floating_position_fixture("css-anchored-layer")
+  ffi_enable_css_anchor_position_fixture()
+  position_floating("css-anchored-layer")
+  let mode = ffi_floating_position_fixture_mode()
+  let measurements = ffi_floating_position_fixture_measurements()
+  let listeners = ffi_floating_position_fixture_listener_count()
+  let frames = ffi_floating_position_fixture_frames()
+  let left = ffi_floating_position_fixture_style("--rui-floating-left")
+  let top = ffi_floating_position_fixture_style("--rui-floating-top")
+  ffi_restore_floating_position_fixture()
+  assert_eq(mode, "css-anchor")
+  assert_eq(measurements, 0)
+  assert_eq(listeners, 0)
+  assert_eq(frames, 0)
+  assert_eq(left, "")
+  assert_eq(top, "")
+}
+
+///|
+#cfg(target="js")
+test "CSS anchor collision updates the tooltip arrow to the rendered side" {
+  ffi_install_floating_position_fixture("flipped-tooltip")
+  ffi_enable_css_anchor_position_fixture()
+  ffi_enable_flipped_tooltip_arrow_fixture()
+  position_floating("flipped-tooltip")
+  let side = ffi_floating_position_fixture_side()
+  let arrow_top = ffi_floating_position_fixture_style("--rui-tooltip-arrow-top")
+  let arrow_bottom = ffi_floating_position_fixture_style(
+    "--rui-tooltip-arrow-bottom",
+  )
+  floating_stop("flipped-tooltip")
+  ffi_restore_floating_position_fixture()
+  assert_eq(side, "bottom")
+  assert_eq(arrow_top, "-0.25rem")
+  assert_eq(arrow_bottom, "auto")
+}
+
+///|
+#cfg(target="js")
+test "floating layer positions in the current frame and follows scrolling" {
+  ffi_install_floating_position_fixture("anchored-layer")
+  position_floating("anchored-layer")
+  let initial_left = ffi_floating_position_fixture_style("--rui-floating-left")
+  let initial_top = ffi_floating_position_fixture_style("--rui-floating-top")
+  let initial_frames = ffi_floating_position_fixture_frames()
+  ffi_scroll_floating_position_fixture(160)
+  let queued_frames = ffi_floating_position_fixture_frames()
+  ffi_flush_floating_position_fixture_frame()
+  let scrolled_top = ffi_floating_position_fixture_style("--rui-floating-top")
+  floating_stop("anchored-layer")
+  ffi_restore_floating_position_fixture()
+  assert_eq(initial_left, "43px")
+  assert_eq(initial_top, "130px")
+  assert_eq(initial_frames, 0)
+  assert_eq(queued_frames, 1)
+  assert_eq(scrolled_top, "190px")
+}
+
+///|
+#cfg(target="js")
+test "fallback marks a detached anchor without freezing its coordinates" {
+  ffi_install_floating_position_fixture("detached-layer")
+  position_floating("detached-layer")
+  ffi_scroll_floating_position_fixture(700)
+  ffi_flush_floating_position_fixture_frame()
+  let detached = ffi_floating_position_fixture_anchor_hidden()
+  ffi_scroll_floating_position_fixture(180)
+  ffi_flush_floating_position_fixture_frame()
+  let restored = ffi_floating_position_fixture_anchor_hidden()
+  floating_stop("detached-layer")
+  ffi_restore_floating_position_fixture()
+  assert_true(detached)
+  assert_false(restored)
+}
+
+///|
+#cfg(target="js")
+test "floating layer restores runtime coordinates after a style rerender" {
+  ffi_install_floating_position_fixture("rerendered-layer")
+  position_floating("rerendered-layer")
+  ffi_clear_floating_position_fixture_styles()
+  position_floating("rerendered-layer")
+  let left = ffi_floating_position_fixture_style("--rui-floating-left")
+  let top = ffi_floating_position_fixture_style("--rui-floating-top")
+  ignore(set_floating_open("rerendered-layer", false))
+  let stopped = ffi_floating_position_fixture_stopped()
+  ffi_restore_floating_position_fixture()
+  assert_eq(left, "43px")
+  assert_eq(top, "130px")
+  assert_true(stopped)
+}

--- a/rui/popover_test.mbt
+++ b/rui/popover_test.mbt
@@ -1,0 +1,347 @@
+///|
+fn popover_test_icon(path : String) -> @html.Html {
+  @html.span(
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(width=16, height=16, view_box="0 0 24 24", [
+      @svg.path(
+        d=path,
+        fill="none",
+        stroke="currentColor",
+        stroke_width=2,
+        attrs=@svg.Attrs::build()
+          .stroke_linecap("round")
+          .stroke_linejoin("round"),
+      ),
+    ]),
+  )
+}
+
+///|
+test "popover exposes native top-layer dialog semantics and CSS anchoring" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render(
+    @rui.popover_content(
+      id="account-popover",
+      trigger_id="account-popover-trigger",
+      open=true,
+      side=Right,
+      align=Start,
+      side_offset=8,
+      align_offset=2,
+      title_id="account-popover-title",
+      description_id="account-popover-description",
+      attrs~,
+      style=["width:24rem", "background:rebeccapurple"],
+      [
+        @rui.popover_header([
+          @rui.popover_title(id="account-popover-title", "Account"),
+          @rui.popover_description(
+            id="account-popover-description",
+            "Manage the current account.",
+          ),
+        ]),
+        @rui.popover_close_button(target_id="account-popover", "Done"),
+      ],
+    ),
+  )
+  assert_contains(html, "id=\"account-popover\"")
+  assert_contains(html, "popover=\"auto\"")
+  assert_contains(html, "role=\"dialog\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "data-modal=\"false\"")
+  assert_contains(html, "data-initial-focus=\"true\"")
+  assert_contains(html, "data-restore-focus=\"true\"")
+  assert_contains(html, "aria-labelledby=\"account-popover-title\"")
+  assert_contains(html, "aria-describedby=\"account-popover-description\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-open=\"\"")
+  assert_contains(html, "data-side=\"right\"")
+  assert_contains(html, "data-align=\"start\"")
+  assert_contains(html, "data-side-offset=\"8\"")
+  assert_contains(html, "data-align-offset=\"2\"")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_contains(html, "position-area:right span-y-end")
+  assert_contains(
+    html, "position-try-fallbacks:flip-block,flip-inline,flip-block flip-inline",
+  )
+  assert_not_contains(html, "-10000px")
+  assert_contains(html, "data-slot=\"popover-header\"")
+  assert_contains(html, "data-slot=\"popover-title\"")
+  assert_contains(html, "data-slot=\"popover-description\"")
+  assert_contains(html, "data-slot=\"popover-close\"")
+  assert_contains(html, "width:24rem;background:rebeccapurple")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-state")
+}
+
+///|
+test "modal popover uses native dialog focus containment" {
+  let html = render(
+    @rui.popover_content(
+      id="modal-popover",
+      trigger_id="modal-popover-trigger",
+      open=true,
+      modal=true,
+      initial_focus_id="modal-popover-name",
+      final_focus_id="after-modal-popover",
+      @html.input(id="modal-popover-name", value="Ada"),
+    ),
+  )
+  assert_contains(html, "<dialog")
+  assert_contains(html, "id=\"modal-popover\"")
+  assert_contains(html, "closedby=\"any\"")
+  assert_contains(html, "role=\"dialog\"")
+  assert_contains(html, "aria-modal=\"true\"")
+  assert_contains(html, "data-modal=\"true\"")
+  assert_contains(html, "data-initial-focus-id=\"modal-popover-name\"")
+  assert_contains(html, "data-final-focus-id=\"after-modal-popover\"")
+  assert_not_contains(html, "popover=\"auto\"")
+}
+
+///|
+test "popover trigger links its dialog and accepts caller style overrides" {
+  let html = render(
+    @rui.popover_trigger(
+      target_id="command-popover",
+      open=true,
+      variant=Secondary,
+      size=Sm,
+      style=["background:rebeccapurple"],
+      "Commands",
+    ),
+  )
+  assert_contains(html, "type=\"button\"")
+  assert_contains(html, "aria-haspopup=\"dialog\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "aria-controls=\"command-popover\"")
+  assert_contains(html, "data-slot=\"popover-trigger\"")
+  assert_contains(html, "data-variant=\"secondary\"")
+  assert_contains(html, "data-size=\"sm\"")
+  assert_contains(html, "id=\"command-popover-trigger\"")
+  assert_contains(html, "anchor-name:--rui-anchor_")
+  assert_contains(html, "background:rebeccapurple")
+}
+
+///|
+test "popover anchor supplies the content positioning reference" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render(
+    @html.div([
+      @rui.popover_anchor(
+        id="custom-popover-anchor",
+        attrs~,
+        style=["min-width:10rem"],
+        @rui.popover_trigger(
+          target_id="custom-popover",
+          id="custom-popover-trigger",
+          "Custom trigger",
+        ),
+      ),
+      @rui.popover_content(
+        id="custom-popover",
+        trigger_id="custom-popover-anchor",
+        "Anchored content",
+      ),
+    ]),
+  )
+  assert_contains(html, "id=\"custom-popover-anchor\"")
+  assert_contains(html, "data-slot=\"popover-anchor\"")
+  assert_contains(html, "position:relative;display:inline-flex")
+  assert_contains(html, "anchor-name:--rui-anchor_")
+  assert_contains(html, "min-width:10rem")
+  assert_contains(html, "data-trigger-id=\"custom-popover-anchor\"")
+  assert_contains(html, "id=\"custom-popover-trigger\"")
+
+  let original = render(@html.span(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+}
+
+///|
+test "popover owns and renders its initial incremental state" {
+  let html = render_incremental(() => {
+    @rui.popover(
+      id="filters-popover",
+      default_open=true,
+      side=Bottom,
+      align=End,
+      title_id="filters-title",
+      trigger_style=["min-width:8rem"],
+      content_style=["width:20rem"],
+      "Filters",
+      @rui.popover_title(id="filters-title", "Filters"),
+    )
+  })
+  assert_contains(html, "id=\"filters-popover-trigger\"")
+  assert_contains(html, "id=\"filters-popover\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-side=\"bottom\"")
+  assert_contains(html, "data-align=\"end\"")
+  assert_contains(html, "min-width:8rem")
+  assert_contains(html, "width:20rem")
+
+  // These commands form the black-box imperative control surface.
+  ignore(@rui.popover_open("filters-popover"))
+  ignore(@rui.popover_close("filters-popover"))
+  ignore(@rui.popover_toggle("filters-popover"))
+}
+
+///|
+test "disabled popover normalizes an open default to closed" {
+  let html = render_incremental(() => {
+    @rui.popover(
+      id="disabled-popover",
+      default_open=true,
+      disabled=true,
+      "Unavailable",
+      "Cannot open",
+    )
+  })
+  assert_contains(html, "disabled")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "aria-expanded=\"false\"")
+  assert_contains(html, "data-state=\"closed\"")
+  assert_not_contains(html, "data-state=\"open\"")
+}
+
+///|
+test "tooltip provider and parts expose Vega and native semantics" {
+  let provider = render(
+    @rui.tooltip_provider(
+      delay=350,
+      close_delay=75,
+      style=["--rui-tooltip-test:1"],
+      "Shared tooltip configuration",
+    ),
+  )
+  assert_contains(provider, "data-slot=\"tooltip-provider\"")
+  assert_contains(provider, "data-delay=\"350\"")
+  assert_contains(provider, "data-close-delay=\"75\"")
+  assert_contains(provider, "data-timeout=\"400\"")
+  assert_contains(provider, "display:contents")
+  assert_contains(provider, "--rui-tooltip-test:1")
+
+  let trigger = render(
+    @rui.tooltip_trigger(
+      content_id="save-tooltip",
+      open=true,
+      size=IconSm,
+      attrs=@html.Attrs::build().aria_label("Save"),
+      popover_test_icon(
+        "M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2ZM17 21v-8H7v8M7 3v5h8",
+      ),
+    ),
+  )
+  assert_contains(trigger, "data-slot=\"tooltip-trigger\"")
+  assert_contains(trigger, "aria-describedby=\"save-tooltip\"")
+  assert_contains(trigger, "data-state=\"open\"")
+  assert_contains(trigger, "aria-label=\"Save\"")
+  assert_contains(trigger, "id=\"save-tooltip-trigger\"")
+  assert_contains(trigger, "anchor-name:--rui-anchor_")
+
+  let content = render(
+    @rui.tooltip_content(
+      id="save-tooltip",
+      trigger_id="save-tooltip-trigger",
+      open=true,
+      side=Left,
+      align=End,
+      style=["background:rebeccapurple"],
+      arrow_style=["background:rebeccapurple"],
+      "Save changes",
+    ),
+  )
+  assert_contains(content, "popover=\"manual\"")
+  assert_contains(content, "role=\"tooltip\"")
+  assert_contains(content, "data-slot=\"tooltip-content\"")
+  assert_contains(content, "data-initial-focus=\"false\"")
+  assert_contains(content, "data-restore-focus=\"false\"")
+  assert_contains(content, "data-slot=\"tooltip-content-body\"")
+  assert_contains(content, "data-slot=\"tooltip-arrow\"")
+  assert_contains(content, "aria-hidden=\"true\"")
+  assert_contains(content, "data-side=\"left\"")
+  assert_contains(content, "position-anchor:--rui-anchor_")
+  assert_contains(content, "position-area:left span-y-start")
+  assert_contains(content, "data-align=\"end\"")
+  assert_contains(content, "background:rebeccapurple")
+}
+
+///|
+test "tooltip provider normalizes delays and exposes instant phase timeout" {
+  let html = render(
+    @rui.tooltip_provider(delay=-10, close_delay=-20, timeout=650, "Tooltips"),
+  )
+  assert_contains(html, "data-delay=\"0\"")
+  assert_contains(html, "data-close-delay=\"0\"")
+  assert_contains(html, "data-timeout=\"650\"")
+}
+
+///|
+test "tooltip root owns incremental open state and behavior options" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render_incremental(() => {
+    @rui.tooltip(
+      id="copy-tooltip",
+      default_open=true,
+      delay=120,
+      close_delay=30,
+      close_on_click=false,
+      hoverable=false,
+      side=Bottom,
+      attrs~,
+      trigger_style=["color:rebeccapurple"],
+      content_style=["max-width:12rem"],
+      "Copy",
+      "Copy to clipboard",
+    )
+  })
+  assert_contains(html, "id=\"copy-tooltip-root\"")
+  assert_contains(html, "id=\"copy-tooltip-trigger\"")
+  assert_contains(html, "id=\"copy-tooltip\"")
+  assert_contains(html, "data-slot=\"tooltip\"")
+  assert_contains(html, "data-delay=\"120\"")
+  assert_contains(html, "data-close-delay=\"30\"")
+  assert_contains(html, "data-close-on-click=\"false\"")
+  assert_contains(html, "data-hoverable=\"false\"")
+  assert_contains(html, "aria-describedby=\"copy-tooltip\"")
+  assert_contains(html, "role=\"tooltip\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "color:rebeccapurple")
+  assert_contains(html, "max-width:12rem")
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+  assert_not_contains(original, "data-state")
+
+  ignore(@rui.tooltip_open("copy-tooltip"))
+  ignore(@rui.tooltip_close("copy-tooltip"))
+  ignore(@rui.tooltip_toggle("copy-tooltip"))
+}
+
+///|
+test "closed tooltip omits the trigger description relationship and arrow" {
+  let trigger = render(
+    @rui.tooltip_trigger(content_id="closed-tooltip", open=false, "Help"),
+  )
+  assert_not_contains(trigger, "aria-describedby")
+  assert_contains(trigger, "data-state=\"closed\"")
+
+  let content = render(
+    @rui.tooltip_content(
+      id="closed-tooltip",
+      trigger_id="closed-tooltip-trigger",
+      show_arrow=false,
+      "Hidden help",
+    ),
+  )
+  assert_contains(content, "data-state=\"closed\"")
+  assert_not_contains(content, "data-slot=\"tooltip-arrow\"")
+  assert_contains(content, "visibility:hidden")
+  assert_contains(content, "opacity:0")
+  assert_contains(content, "pointer-events:none")
+}

--- a/rui/popup_animation_test.mbt
+++ b/rui/popup_animation_test.mbt
@@ -1,0 +1,176 @@
+///|
+test "floating surfaces retain native top-layer entry and exit transitions" {
+  let common = "display 100ms allow-discrete,overlay 100ms allow-discrete;transition-behavior:allow-discrete"
+  let primitives = render(
+    @html.div([
+      @rui.popover_content(
+        id="animation-popover",
+        trigger_id="animation-popover-trigger",
+        open=true,
+        "Popover",
+      ),
+      @rui.tooltip_content(
+        id="animation-tooltip",
+        trigger_id="animation-tooltip-trigger",
+        open=true,
+        "Tooltip",
+      ),
+      @rui.hover_card_content(
+        id="animation-hover-card",
+        trigger_id="animation-hover-card-trigger",
+        open=true,
+        "Hover card",
+      ),
+    ]),
+  )
+  assert_contains(primitives, "data-slot=\"popover-content\"")
+  assert_contains(primitives, "data-slot=\"tooltip-content\"")
+  assert_contains(primitives, "data-slot=\"hover-card-content\"")
+  assert_contains(primitives, common)
+  assert_contains(
+    primitives, "visibility:visible;opacity:1;pointer-events:auto;transform:scale(1)",
+  )
+
+  let select_html = render_incremental(() => {
+    @rui.select(
+      id="animation-select",
+      options=[@rui.select_option(value="one", label="One")],
+      default_open=true,
+    )
+  })
+  assert_contains(select_html, "data-slot=\"select-content\"")
+  assert_contains(select_html, common)
+
+  let combobox_html = render_incremental(() => {
+    @rui.combobox(
+      id="animation-combobox",
+      options=[@rui.combobox_option(value="one", label="One")],
+      default_open=true,
+    )
+  })
+  assert_contains(combobox_html, "data-slot=\"combobox-content\"")
+  assert_contains(combobox_html, common)
+}
+
+///|
+test "menu and navigation popup families share the discrete transition recipe" {
+  let common = "display 100ms allow-discrete,overlay 100ms allow-discrete;transition-behavior:allow-discrete"
+  let menu_html = render_incremental(() => {
+    @rui.dropdown_menu(id="animation-menu", default_open=true, scope => {
+      @html.div([
+        @rui.dropdown_menu_trigger(scope, "Menu"),
+        @rui.dropdown_menu_content(scope, [
+          @rui.dropdown_menu_item(scope, "Item"),
+          @rui.dropdown_menu_sub(scope, value="more", sub => {
+            @html.div([
+              @rui.dropdown_menu_sub_trigger(sub, "More"),
+              @rui.dropdown_menu_sub_content(
+                sub,
+                @rui.dropdown_menu_item(scope, "Nested"),
+              ),
+            ])
+          }),
+        ]),
+      ])
+    })
+  })
+  assert_contains(menu_html, "data-slot=\"dropdown-menu-content\"")
+  assert_contains(menu_html, "data-slot=\"dropdown-menu-sub-content\"")
+  assert_contains(menu_html, common)
+
+  let navigation_html = render_incremental(() => {
+    @rui.navigation_menu(
+      id="animation-navigation",
+      default_value="docs",
+      viewport=false,
+      scope => {
+        @rui.navigation_menu_list(
+          scope,
+          @rui.navigation_menu_item(scope, value="docs", item => {
+            @html.fragment([
+              @rui.navigation_menu_trigger(item, "Docs"),
+              @rui.navigation_menu_content(item, "Navigation content"),
+            ])
+          }),
+        )
+      },
+    )
+  })
+  assert_contains(navigation_html, "data-slot=\"navigation-menu-content\"")
+  assert_contains(
+    navigation_html, "display 150ms allow-discrete,overlay 150ms allow-discrete;transition-behavior:allow-discrete",
+  )
+}
+
+///|
+test "theme provides closed first frames and reduced-motion fallback" {
+  let html = render(@rui.theme(@html.nothing))
+  assert_contains(html, "@starting-style")
+  assert_contains(
+    html, "[data-slot=\"sidebar-mobile-layer\"]:popover-open [data-slot=\"sidebar-overlay\"][data-state=\"open\"]",
+  )
+  assert_contains(
+    html, "[data-slot=\"sidebar-mobile-layer\"]:popover-open [data-slot=\"sidebar\"][data-mobile=\"true\"][data-state=\"expanded\"][data-side=\"left\"]",
+  )
+  assert_contains(
+    html, "[data-slot=\"sidebar-mobile-layer\"]:popover-open [data-slot=\"sidebar\"][data-mobile=\"true\"][data-state=\"expanded\"][data-side=\"right\"]",
+  )
+  assert_contains(html, "transform:translateX(-100%) !important")
+  assert_contains(html, "transform:translateX(100%) !important")
+  assert_contains(
+    html, "[data-slot=\"popover-content\"],[data-slot=\"tooltip-content\"],[data-slot=\"hover-card-content\"]",
+  )
+  assert_contains(
+    html, "[data-submenu-owner])[data-state=\"open\"]:popover-open",
+  )
+  assert_contains(
+    html, "[data-submenu-owner][data-state=\"open\"]:not(:popover-open)",
+  )
+  assert_contains(html, "pointer-events:none !important")
+  assert_contains(
+    html, "dialog[data-slot=\"popover-content\"][data-state=\"open\"][open]",
+  )
+  assert_contains(html, "transform:scale(0.95) !important")
+  assert_contains(html, "@keyframes rui-sheet-enter")
+  assert_contains(
+    html, "from { opacity:0;transform:var(--rui-sheet-closed-transform); }",
+  )
+  assert_contains(html, "@keyframes rui-sheet-exit")
+  assert_contains(html, "@keyframes rui-drawer-enter")
+  assert_contains(
+    html, "to { opacity:0;transform:var(--rui-drawer-closed-transform); }",
+  )
+  assert_contains(html, "@keyframes rui-drawer-exit")
+  assert_contains(
+    html, ":where([data-slot=\"sheet-overlay\"],[data-slot=\"drawer-overlay\"])[data-state=\"open\"]",
+  )
+  assert_contains(html, "animation:rui-edge-overlay-enter 200ms ease-out")
+  assert_not_contains(html, "animation-fill-mode:forwards")
+  assert_not_contains(
+    html, "dialog[data-slot=\"sheet-native\"][open] [data-slot=\"sheet-content\"]",
+  )
+  assert_not_contains(
+    html, "dialog[data-slot=\"drawer-native\"][open] [data-slot=\"drawer-content\"]",
+  )
+  assert_contains(html, "@media (prefers-reduced-motion:reduce)")
+  assert_contains(
+    html, "[data-slot=\"command-dialog-content\"],[data-slot=\"sidebar-mobile-layer\"],[data-slot=\"sidebar-shell\"]",
+  )
+  assert_contains(html, "transition-duration:0s !important")
+  assert_contains(html, "transition-delay:0s !important")
+  assert_contains(
+    html, "[data-slot=\"sidebar\"][data-collapsible=\"offcanvas\"][data-state=\"collapsed\"] > :not([data-slot=\"sidebar-rail\"])",
+  )
+  assert_contains(
+    html, "[data-slot=\"sidebar-menu-item\"]:hover > [data-slot=\"sidebar-menu-action\"] {\n      --rui-sidebar-action-fg:",
+  )
+  assert_not_contains(
+    html, "[data-slot=\"sidebar-menu-item\"]:hover > [data-slot=\"sidebar-menu-action\"] {\n      --rui-button-fg:",
+  )
+  assert_contains(
+    html, "[data-slot=\"sidebar-menu-button\"][data-active=\"true\"] ~ [data-slot=\"sidebar-menu-action\"] {\n    --rui-sidebar-action-fg:",
+  )
+  assert_not_contains(
+    html, "[data-slot=\"sidebar-menu-button\"][data-active=\"true\"] ~ [data-slot=\"sidebar-menu-action\"] {\n    --rui-button-fg:",
+  )
+}

--- a/rui/progress.mbt
+++ b/rui/progress.mbt
@@ -1,0 +1,336 @@
+///|
+priv enum ProgressState {
+  Indeterminate
+  Progressing
+  Complete
+}
+
+///|
+const ProgressBaseStyle : String = "display:flex;width:100%;min-width:0;flex-wrap:wrap;align-items:center;gap:0.75rem"
+
+///|
+const ProgressTrackStyle : String = "position:relative;display:flex;width:100%;height:0.5rem;align-items:center;overflow-x:hidden;border-radius:9999px;background:color-mix(in oklab,var(--rui-primary,oklch(0.205 0 0)) 20%,transparent)"
+
+///|
+const ProgressIndicatorStyle : String = "height:100%;flex:none;background:var(--rui-primary,oklch(0.205 0 0));transition:width 150ms ease"
+
+///|
+const ProgressIndeterminateStyle : String = "position:absolute;inset-block:0;inset-inline-start:-40%;inline-size:40%;animation:rui-progress-indeterminate 1.4s ease-in-out infinite"
+
+///|
+const ProgressIndeterminateCss : String =
+  #|@keyframes rui-progress-indeterminate {
+  #|  from { inset-inline-start:-40%; }
+  #|  to { inset-inline-start:100%; }
+  #|}
+  #|@media (prefers-reduced-motion:reduce) {
+  #|  [data-slot="progress-indicator"][data-state="indeterminate"] {
+  #|    animation:none !important;
+  #|    inset-inline-start:30%;
+  #|  }
+  #|}
+  #|
+
+///|
+#warnings("-alert_xss_vulnerable")
+fn progress_indeterminate_stylesheet() -> @html.Html {
+  // Static library CSS is required for keyframes; no caller input reaches it.
+  let attrs = @html.Attrs::build()
+    .data_set("rui-style", "progress-indeterminate")
+    .inner_html(ProgressIndeterminateCss)
+  @html.style_tag(attrs~, ([] : Array[@html.Html]))
+}
+
+///|
+const ProgressLabelStyle : String = "font-size:0.875rem;line-height:1.25rem;font-weight:500"
+
+///|
+const ProgressValueStyle : String = "margin-inline-start:auto;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem;font-variant-numeric:tabular-nums"
+
+///|
+fn progress_effective_max(min : Int, max : Int) -> Int {
+  if max < min {
+    min
+  } else {
+    max
+  }
+}
+
+///|
+fn progress_clamped_value(value : Int, min : Int, max : Int) -> Int {
+  let max = progress_effective_max(min, max)
+  if max == min {
+    min
+  } else if value < min {
+    min
+  } else if value > max {
+    max
+  } else {
+    value
+  }
+}
+
+///|
+fn progress_percentage(value : Int, min : Int, max : Int) -> Int {
+  let max = progress_effective_max(min, max)
+  if max == min {
+    100
+  } else {
+    let clamped = progress_clamped_value(value, min, max)
+    (clamped - min) * 100 / (max - min)
+  }
+}
+
+///|
+fn progress_state(value : Int?, min : Int, max : Int) -> ProgressState {
+  if value is Some(value) {
+    let max = progress_effective_max(min, max)
+    if progress_clamped_value(value, min, max) == max {
+      Complete
+    } else {
+      Progressing
+    }
+  } else {
+    Indeterminate
+  }
+}
+
+///|
+fn progress_state_attrs(
+  attrs : @html.Attrs?,
+  state : ProgressState,
+  slot : String,
+) -> @html.Attrs {
+  let element_attrs = ui_attrs(attrs).data_set("slot", slot)
+  match state {
+    Indeterminate =>
+      element_attrs
+      .data_set("state", "indeterminate")
+      .data_set("indeterminate", "")
+    Progressing =>
+      element_attrs.data_set("state", "progressing").data_set("progressing", "")
+    Complete =>
+      element_attrs.data_set("state", "complete").data_set("complete", "")
+  }
+}
+
+///|
+fn progress_indicator_width(value : Int?, min : Int, max : Int) -> String {
+  if value is Some(value) {
+    "width:\{progress_percentage(value, min, max)}%"
+  } else {
+    ProgressIndeterminateStyle
+  }
+}
+
+///|
+fn progress_aria_text(value : Int?, min : Int, max : Int) -> String {
+  if value is Some(value) {
+    "\{progress_percentage(value, min, max)}%"
+  } else {
+    "indeterminate progress"
+  }
+}
+
+///|
+fn progress_display_text(value : Int?, min : Int, max : Int) -> String {
+  if value is Some(value) {
+    "\{progress_percentage(value, min, max)}%"
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render an ARIA progress group and append Vega's track and
+/// indicator automatically after optional label/value children.
+///
+/// Determinate values are clamped to `min...max`. A `max` below `min` is
+/// normalized to `min`. `None` renders the indeterminate state and omits
+/// `aria-valuenow`.
+pub fn progress(
+  value? : Int,
+  min? : Int = 0,
+  max? : Int = 100,
+  aria_label? : String,
+  aria_value_text? : String,
+  labelledby? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children? : Array[@html.Html] = [],
+) -> @html.Html {
+  let state = progress_state(value, min, max)
+  let effective_max = progress_effective_max(min, max)
+  let element_attrs = progress_state_attrs(attrs, state, "progress")
+    .role("progressbar")
+    .aria_valuemin("\{min}")
+    .aria_valuemax("\{effective_max}")
+  if value is Some(value) {
+    ignore(
+      element_attrs.aria_valuenow("\{progress_clamped_value(value, min, max)}"),
+    )
+  }
+  if aria_label is Some(aria_label) {
+    ignore(element_attrs.aria_label(aria_label))
+  }
+  if labelledby is Some(labelledby) {
+    ignore(element_attrs.aria_labelledby(labelledby))
+  }
+  ignore(
+    element_attrs.aria_valuetext(
+      aria_value_text.unwrap_or(progress_aria_text(value, min, max)),
+    ),
+  )
+  let root_children : Array[@html.Html] = []
+  for child in children {
+    root_children.push(child)
+  }
+  root_children.push(
+    progress_track(value?, min~, max~, [progress_indicator(value?, min~, max~)]),
+  )
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, ProgressBaseStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    root_children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] progress_track(
+  value? : Int,
+  min? : Int = 0,
+  max? : Int = 100,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, ProgressTrackStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=progress_state_attrs(
+      attrs,
+      progress_state(value, min, max),
+      "progress-track",
+    ),
+    children,
+  )
+}
+
+///|
+pub fn progress_indicator(
+  value? : Int,
+  min? : Int = 0,
+  max? : Int = 100,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let indicator = @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        ProgressIndicatorStyle,
+        progress_indicator_width(value, min, max),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=progress_state_attrs(
+      attrs,
+      progress_state(value, min, max),
+      "progress-indicator",
+    ),
+    @html.nothing,
+  )
+  if value is Some(_) {
+    indicator
+  } else {
+    @html.fragment([progress_indeterminate_stylesheet(), indicator])
+  }
+}
+
+///|
+/// Render a progress label. Pass the same `id` to `progress(labelledby=...)`
+/// because a stateless Rabbita function cannot register the label implicitly.
+pub fn[C : @html.IsChildren] progress_label(
+  value? : Int,
+  min? : Int = 0,
+  max? : Int = 100,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = progress_state_attrs(
+    attrs,
+    progress_state(value, min, max),
+    "progress-label",
+  ).role("presentation")
+  @html.span(
+    style=ui_styles([UiBoxSizing, ProgressLabelStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the formatted percentage, or an empty span for indeterminate state.
+/// `text` overrides the default formatting while preserving `aria-hidden`.
+pub fn progress_value(
+  value? : Int,
+  min? : Int = 0,
+  max? : Int = 100,
+  text? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = progress_state_attrs(
+    attrs,
+    progress_state(value, min, max),
+    "progress-value",
+  ).aria_hidden("true")
+  @html.span(
+    style=ui_styles([UiBoxSizing, ProgressValueStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    text.unwrap_or(progress_display_text(value, min, max)),
+  )
+}

--- a/rui/radio_group.mbt
+++ b/rui/radio_group.mbt
@@ -1,0 +1,376 @@
+///|
+pub(all) enum RadioGroupOrientation {
+  RadioVertical
+  RadioHorizontal
+} derive(Debug, Eq)
+
+///|
+const RadioGroupVerticalStyle : String = "display:grid;width:100%;gap:0.75rem"
+
+///|
+const RadioGroupHorizontalStyle : String = "display:flex;width:100%;flex-wrap:wrap;align-items:center;gap:0.75rem"
+
+///|
+const RadioGroupItemBaseStyle : String = "position:relative;display:inline-grid;width:1rem;height:1rem;flex-shrink:0;place-content:center;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-primary-foreground,oklch(0.985 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:9999px;margin:0;padding:0;background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-primary-foreground,oklch(0.985 0 0))));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));cursor:pointer;appearance:none;-webkit-appearance:none;outline-offset:2px;vertical-align:middle"
+
+///|
+const RadioGroupItemCheckedStyle : String = "--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-bg:radial-gradient(circle at center,var(--rui-primary,oklch(0.205 0 0)) 0 0.25rem,transparent 0.27rem),var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-primary,oklch(0.205 0 0))"
+
+///|
+const RadioGroupItemUncheckedStyle : String = "--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-bg:var(--rui-input-background,transparent)"
+
+///|
+const RadioGroupItemInvalidStyle : String = "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+fn radio_group_orientation_value(orientation : RadioGroupOrientation) -> String {
+  match orientation {
+    RadioVertical => "vertical"
+    RadioHorizontal => "horizontal"
+  }
+}
+
+///|
+fn radio_group_orientation_style(orientation : RadioGroupOrientation) -> String {
+  match orientation {
+    RadioVertical => RadioGroupVerticalStyle
+    RadioHorizontal => RadioGroupHorizontalStyle
+  }
+}
+
+///|
+fn radio_group_item_state_style(checked : Bool) -> String {
+  if checked {
+    RadioGroupItemCheckedStyle
+  } else {
+    RadioGroupItemUncheckedStyle
+  }
+}
+
+///|
+fn radio_group_item_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    RadioGroupItemInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+#cfg(target="js")
+fn radio_group_move_and_select(event : @dom.KeyboardEvent) -> Bool {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.shift_key() {
+    return false
+  }
+  guard ui_roving_context(
+      event, "[data-slot=\"radio-group-item\"]", "[data-slot=\"radio-group\"]", "[data-slot=\"radio-group-item\"]",
+    )
+    is Some(context) else {
+    return false
+  }
+  guard ui_roving_target(
+      context,
+      event.key(),
+      "both",
+      ui_element_is_rtl(context.root),
+    )
+    is Some(target) else {
+    return false
+  }
+  ui_focus_element_without_scroll(target)
+  ui_click_element(target)
+  true
+}
+
+///|
+#cfg(target="js")
+fn radio_group_bind_keyboard(attrs : @html.Attrs) -> Unit {
+  ignore(
+    attrs.on_keydown(event => {
+      if radio_group_move_and_select(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn radio_group_bind_keyboard(attrs : @html.Attrs) -> Unit {
+  ignore(attrs)
+}
+
+///|
+/// Lay out native radio inputs as a Vega-style radio group.
+///
+/// Each item remains a real `<input type="radio">`, so same-name items retain
+/// the browser's arrow-key navigation and form behavior.
+pub fn[C : @html.IsChildren] radio_group_root(
+  orientation? : RadioGroupOrientation = RadioVertical,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "radio-group")
+    .data_set("orientation", radio_group_orientation_value(orientation))
+    .role("radiogroup")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, radio_group_orientation_style(orientation)],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render one native radio item for the incremental group.
+///
+/// Pass the same `name` and `on_value_change` to sibling items. The callback
+/// receives the activated item's `value`.
+fn render_radio_group_item(
+  value~ : String,
+  name? : String,
+  checked? : Bool = false,
+  disabled? : Bool = false,
+  required? : Bool,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_value_change? : @cmd.Emit[String],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let state = if checked { "checked" } else { "unchecked" }
+  let control_attrs = ui_attrs(attrs)
+    .data_set("slot", "radio-group-item")
+    .data_set("state", state)
+    .data_set(state, "")
+  if disabled {
+    ignore(control_attrs.disabled(true).data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(control_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  if aria_label is Some(label) {
+    ignore(control_attrs.aria_label(label))
+  }
+  radio_group_bind_keyboard(control_attrs)
+  let on_change = on_value_change
+  @html.input(
+    input_type=@html.Radio,
+    name?,
+    value~,
+    checked~,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiTransition,
+        RadioGroupItemBaseStyle,
+        radio_group_item_state_style(checked),
+        radio_group_item_invalid_style(invalid),
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    required?,
+    on_change?,
+    attrs=control_attrs,
+  )
+}
+
+///|
+/// Opaque state shared by `radio_group` and its items.
+struct RadioGroupScope {
+  value : String
+  name : String?
+  disabled : Bool
+  required : Bool
+  invalid : Bool
+  emit : @cmd.Emit[String]
+}
+
+///|
+/// Render one compound group state for the incremental wrapper.
+fn[C : @html.IsChildren] render_radio_group(
+  value~ : String,
+  name? : String,
+  disabled? : Bool = false,
+  required? : Bool = false,
+  invalid? : Bool = false,
+  orientation? : RadioGroupOrientation = RadioVertical,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (RadioGroupScope) -> C,
+) -> @html.Html {
+  let emit = @cmd.Emit(next => {
+    if on_value_change is Some(notify) {
+      notify(next)
+    } else {
+      @cmd.none
+    }
+  })
+  let scope = { value, name, disabled, required, invalid, emit }
+  let root_attrs = ui_attrs(attrs).data_set("value", value)
+  if disabled {
+    ignore(root_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(root_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  radio_group_root(
+    orientation~,
+    id?,
+    class?,
+    title?,
+    aria_label?,
+    attrs=root_attrs,
+    style~,
+    children(scope),
+  )
+}
+
+///|
+/// Build a black-box radio group with component-local incremental selection.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] radio_group(
+  default_value? : String = "",
+  name? : String,
+  disabled? : Bool = false,
+  required? : Bool = false,
+  invalid? : Bool = false,
+  orientation? : RadioGroupOrientation = RadioVertical,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (RadioGroupScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let (value, set_value) = @rabbita.create_variable(default_value)
+  value.view(value => {
+    render_radio_group(
+      value~,
+      name?,
+      disabled~,
+      required~,
+      invalid~,
+      orientation~,
+      on_value_change=@cmd.Emit(next => {
+        let update = set_value(_ => next)
+        if on_value_change is Some(notify) {
+          @cmd.batch([update, notify(next)])
+        } else {
+          update
+        }
+      }),
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      attrs?,
+      style~,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] radio_group(
+  default_value? : String = "",
+  name? : String,
+  disabled? : Bool = false,
+  required? : Bool = false,
+  invalid? : Bool = false,
+  orientation? : RadioGroupOrientation = RadioVertical,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (RadioGroupScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_value_change)
+  @rabbita.Val::constant(
+    render_radio_group(
+      value=default_value,
+      name?,
+      disabled~,
+      required~,
+      invalid~,
+      orientation~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      attrs?,
+      style~,
+      children,
+    ),
+  )
+}
+
+///|
+/// Render one item bound to the local state owned by `radio_group`.
+pub fn radio_group_item(
+  scope~ : RadioGroupScope,
+  value~ : String,
+  disabled? : Bool = false,
+  required? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let disabled = scope.disabled || disabled
+  let name = scope.name
+  render_radio_group_item(
+    value~,
+    name?,
+    checked=scope.value == value,
+    disabled~,
+    required=scope.required || required,
+    invalid=scope.invalid || invalid,
+    id?,
+    class?,
+    title?,
+    aria_label?,
+    on_value_change=@cmd.Emit(_ => (scope.emit)(value)),
+    attrs?,
+    style~,
+  )
+}

--- a/rui/radio_group_wbtest.mbt
+++ b/rui/radio_group_wbtest.mbt
@@ -1,0 +1,139 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_radio_group_fixture(rtl : Bool) -> Unit =
+  #| rtl => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiRadioGroupFixture = {
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     focused: -1,
+  #|     selected: -1,
+  #|   }
+  #|   class FixtureHTMLElement {
+  #|     constructor() { this.nodeType = 1 }
+  #|   }
+  #|   globalThis.HTMLElement = FixtureHTMLElement
+  #|   globalThis.window = globalThis
+  #|   const group = {
+  #|     nodeType: 1,
+  #|     dataset: { orientation: "horizontal" },
+  #|     querySelectorAll: selector => selector === '[data-slot="radio-group-item"]'
+  #|       ? fixture.items
+  #|       : [],
+  #|   }
+  #|   const makeItem = (index, disabled = false) => {
+  #|     const item = new FixtureHTMLElement()
+  #|     item.disabled = disabled
+  #|     item.getAttribute = name => name === "aria-disabled" && disabled ? "true" : ""
+  #|     item.hasAttribute = name => name === "disabled" && disabled
+  #|     item.closest = selector => selector === '[data-slot="radio-group-item"]'
+  #|       ? fixture.items[index]
+  #|       : selector === '[data-slot="radio-group"]' ? group : null
+  #|     item.focus = () => { fixture.focused = index }
+  #|     item.click = () => { fixture.selected = index }
+  #|     return item
+  #|   }
+  #|   fixture.group = group
+  #|   fixture.items = [makeItem(0), makeItem(1, true), makeItem(2)]
+  #|   globalThis.getComputedStyle = node => ({
+  #|     getPropertyValue: name => name === "direction" && node === group && rtl
+  #|       ? "rtl"
+  #|       : "ltr",
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_radio_group_fixture_event(
+  index : Int,
+  key : String,
+  modified : Bool,
+) -> @dom.KeyboardEvent =
+  #| (index, key, modified) => ({
+  #|   target: globalThis.__ruiRadioGroupFixture.items[index],
+  #|   key,
+  #|   altKey: modified,
+  #|   ctrlKey: false,
+  #|   metaKey: false,
+  #|   shiftKey: false,
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_radio_group_fixture_focused() -> Int =
+  #| () => globalThis.__ruiRadioGroupFixture.focused
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_radio_group_fixture_selected() -> Int =
+  #| () => globalThis.__ruiRadioGroupFixture.selected
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_radio_group_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiRadioGroupFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadGetComputedStyle) globalThis.getComputedStyle = fixture.getComputedStyle
+  #|   else delete globalThis.getComputedStyle
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiRadioGroupFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "radio group arrows select, focus, skip disabled items, and honor RTL" {
+  ffi_install_radio_group_fixture(false)
+  let moved = radio_group_move_and_select(
+    ffi_radio_group_fixture_event(0, "ArrowRight", false),
+  )
+  let ltr_focus = ffi_radio_group_fixture_focused()
+  let ltr_selected = ffi_radio_group_fixture_selected()
+  ffi_restore_radio_group_fixture()
+
+  ffi_install_radio_group_fixture(true)
+  let rtl_moved = radio_group_move_and_select(
+    ffi_radio_group_fixture_event(0, "ArrowLeft", false),
+  )
+  let rtl_focus = ffi_radio_group_fixture_focused()
+  let rtl_selected = ffi_radio_group_fixture_selected()
+  ffi_restore_radio_group_fixture()
+
+  assert_true(moved)
+  assert_eq(ltr_focus, 2)
+  assert_eq(ltr_selected, 2)
+  assert_true(rtl_moved)
+  assert_eq(rtl_focus, 2)
+  assert_eq(rtl_selected, 2)
+}
+
+///|
+#cfg(target="js")
+test "radio group Home and End select endpoints while modifiers pass through" {
+  ffi_install_radio_group_fixture(false)
+  let end_moved = radio_group_move_and_select(
+    ffi_radio_group_fixture_event(0, "End", false),
+  )
+  let end_selected = ffi_radio_group_fixture_selected()
+  let home_moved = radio_group_move_and_select(
+    ffi_radio_group_fixture_event(2, "Home", false),
+  )
+  let home_selected = ffi_radio_group_fixture_selected()
+  let modified = radio_group_move_and_select(
+    ffi_radio_group_fixture_event(0, "ArrowRight", true),
+  )
+  ffi_restore_radio_group_fixture()
+
+  assert_true(end_moved)
+  assert_eq(end_selected, 2)
+  assert_true(home_moved)
+  assert_eq(home_selected, 0)
+  assert_false(modified)
+}

--- a/rui/resizable.mbt
+++ b/rui/resizable.mbt
@@ -1,0 +1,1011 @@
+///|
+pub(all) enum ResizablePanelSide {
+  FirstPanel
+  SecondPanel
+} derive(Debug, Eq)
+
+///|
+priv enum ResizableGroupMsg {
+  SetResizableGroupSizes(Array[Int])
+  ResizeResizableGroupAt(Int, Int)
+}
+
+///|
+/// Opaque render scope owned by [`resizable_group`].
+struct ResizableGroupScope {
+  id : String
+  sizes : Array[Int]
+  min_sizes : Array[Int]
+  max_sizes : Array[Int]
+  orientation : SeparatorOrientation
+  aria_label : String
+  emit : @cmd.Emit[ResizableGroupMsg]
+}
+
+///|
+/// Opaque compatibility scope owned by [`resizable_panel_group`].
+struct ResizableScope {
+  group : ResizableGroupScope
+  control_id : String
+}
+
+///|
+priv struct ResizableHandleBounds {
+  valid : Bool
+  value : Int
+  min : Int
+  max : Int
+}
+
+///|
+fn resizable_int_min(left : Int, right : Int) -> Int {
+  if left < right {
+    left
+  } else {
+    right
+  }
+}
+
+///|
+fn resizable_int_max(left : Int, right : Int) -> Int {
+  if left > right {
+    left
+  } else {
+    right
+  }
+}
+
+///|
+fn resizable_clamp(value : Int, min : Int, max : Int) -> Int {
+  if value < min {
+    min
+  } else if value > max {
+    max
+  } else {
+    value
+  }
+}
+
+///|
+fn resizable_parse(value : String, fallback : Int) -> Int {
+  @string.parse_int(value) catch {
+    _ => fallback
+  }
+}
+
+///|
+fn resizable_value_at(values : Array[Int], index : Int, fallback : Int) -> Int {
+  values.get(index).unwrap_or(fallback)
+}
+
+///|
+fn resizable_sum(values : Array[Int]) -> Int {
+  let mut total = 0
+  for value in values {
+    total += value
+  }
+  total
+}
+
+///|
+fn resizable_prefix_size(values : Array[Int], end : Int) -> Int {
+  let mut total = 0
+  for index, value in values {
+    if index < end {
+      total += value
+    }
+  }
+  total
+}
+
+///|
+fn resizable_pointer_percent(
+  orientation : SeparatorOrientation,
+  client_x : Int,
+  client_y : Int,
+  group_left : Int,
+  group_top : Int,
+  group_width : Int,
+  group_height : Int,
+) -> Int? {
+  let (position, start, length) = if orientation is Vertical {
+    (client_y, group_top, group_height)
+  } else {
+    (client_x, group_left, group_width)
+  }
+  if length <= 0 {
+    return None
+  }
+  let offset = resizable_clamp(position - start, 0, length)
+  Some((offset * 100 + length / 2) / length)
+}
+
+///|
+fn resizable_normalize_sizes(
+  values : Array[Int],
+  min_sizes : Array[Int],
+  max_sizes : Array[Int],
+) -> Array[Int] {
+  if values.length() == 0 {
+    return [100]
+  }
+  let sizes : Array[Int] = []
+  for index, value in values {
+    sizes.push(resizable_clamp(value, min_sizes[index], max_sizes[index]))
+  }
+  let total = resizable_sum(sizes)
+  if total < 100 {
+    let mut remaining = 100 - total
+    for index, size in sizes {
+      if remaining > 0 {
+        let capacity = max_sizes[index] - size
+        let delta = resizable_int_min(capacity, remaining)
+        sizes[index] = size + delta
+        remaining -= delta
+      }
+    }
+    // Infeasible max constraints cannot satisfy both policies. Preserve the
+    // layout invariant (sum 100) and leave the impossible bound visible in the
+    // handle range instead of producing a broken flex layout.
+    if remaining > 0 {
+      let last = sizes.length() - 1
+      sizes[last] += remaining
+    }
+  } else if total > 100 {
+    let mut remaining = total - 100
+    for index, size in sizes {
+      if remaining > 0 {
+        let capacity = size - min_sizes[index]
+        let delta = resizable_int_min(capacity, remaining)
+        sizes[index] = size - delta
+        remaining -= delta
+      }
+    }
+    if remaining > 0 {
+      let last = sizes.length() - 1
+      sizes[last] -= remaining
+    }
+  }
+  sizes
+}
+
+///|
+fn resizable_prepare_layout(
+  default_sizes : Array[Int],
+  min_sizes : Array[Int],
+  max_sizes : Array[Int],
+) -> (Array[Int], Array[Int], Array[Int]) {
+  let defaults = if default_sizes.length() == 0 {
+    [100]
+  } else {
+    default_sizes.copy()
+  }
+  let minimums : Array[Int] = []
+  let maximums : Array[Int] = []
+  for index, _ in defaults {
+    let minimum = resizable_clamp(
+      resizable_value_at(min_sizes, index, 0),
+      0,
+      100,
+    )
+    let maximum = resizable_clamp(
+      resizable_value_at(max_sizes, index, 100),
+      minimum,
+      100,
+    )
+    minimums.push(minimum)
+    maximums.push(maximum)
+  }
+  (resizable_normalize_sizes(defaults, minimums, maximums), minimums, maximums)
+}
+
+///|
+fn resizable_handle_bounds(
+  sizes : Array[Int],
+  min_sizes : Array[Int],
+  max_sizes : Array[Int],
+  between : Int,
+) -> ResizableHandleBounds {
+  if between < 0 || between + 1 >= sizes.length() {
+    return { valid: false, value: 0, min: 0, max: 0 }
+  }
+  let left = sizes[between]
+  let right = sizes[between + 1]
+  let pair_total = left + right
+  let minimum = resizable_int_max(
+    min_sizes[between],
+    pair_total - max_sizes[between + 1],
+  )
+  let maximum = resizable_int_min(
+    max_sizes[between],
+    pair_total - min_sizes[between + 1],
+  )
+  if minimum > maximum {
+    { valid: false, value: left, min: left, max: left }
+  } else {
+    { valid: true, value: left, min: minimum, max: maximum }
+  }
+}
+
+///|
+fn resizable_resize_between(
+  sizes : Array[Int],
+  min_sizes : Array[Int],
+  max_sizes : Array[Int],
+  between : Int,
+  requested : Int,
+) -> Array[Int] {
+  let next = sizes.copy()
+  let bounds = resizable_handle_bounds(sizes, min_sizes, max_sizes, between)
+  if !bounds.valid {
+    return next
+  }
+  let pair_total = sizes[between] + sizes[between + 1]
+  let left = resizable_clamp(requested, bounds.min, bounds.max)
+  next[between] = left
+  next[between + 1] = pair_total - left
+  next
+}
+
+///|
+fn resizable_resize_at_percent(
+  sizes : Array[Int],
+  min_sizes : Array[Int],
+  max_sizes : Array[Int],
+  between : Int,
+  percent : Int,
+) -> Array[Int] {
+  resizable_resize_between(
+    sizes,
+    min_sizes,
+    max_sizes,
+    between,
+    percent - resizable_prefix_size(sizes, between),
+  )
+}
+
+///|
+fn resizable_key_size(
+  size : Int,
+  min : Int,
+  max : Int,
+  orientation : SeparatorOrientation,
+  key : String,
+) -> Int? {
+  let requested = match (orientation, key) {
+    (_, "Home") => Some(min)
+    (_, "End") => Some(max)
+    (Horizontal, "ArrowLeft") => Some(size - 1)
+    (Horizontal, "ArrowRight") => Some(size + 1)
+    (Vertical, "ArrowUp") => Some(size - 1)
+    (Vertical, "ArrowDown") => Some(size + 1)
+    _ => None
+  }
+  requested.map(next => resizable_clamp(next, min, max))
+}
+
+///|
+fn resizable_key_for_direction(
+  orientation : SeparatorOrientation,
+  key : String,
+  rtl : Bool,
+) -> String {
+  if orientation is Horizontal && rtl {
+    match key {
+      "ArrowLeft" => "ArrowRight"
+      "ArrowRight" => "ArrowLeft"
+      _ => key
+    }
+  } else {
+    key
+  }
+}
+
+///|
+fn resizable_key_sizes(
+  sizes : Array[Int],
+  min_sizes : Array[Int],
+  max_sizes : Array[Int],
+  between : Int,
+  orientation : SeparatorOrientation,
+  key : String,
+) -> Array[Int]? {
+  let bounds = resizable_handle_bounds(sizes, min_sizes, max_sizes, between)
+  if !bounds.valid {
+    return None
+  }
+  resizable_key_size(bounds.value, bounds.min, bounds.max, orientation, key).map(requested => {
+      resizable_resize_between(sizes, min_sizes, max_sizes, between, requested)
+    },
+  )
+}
+
+///|
+fn resizable_is_arrow_key(key : String) -> Bool {
+  key == "ArrowLeft" ||
+  key == "ArrowRight" ||
+  key == "ArrowUp" ||
+  key == "ArrowDown"
+}
+
+///|
+#cfg(target="js")
+priv struct ResizablePointerActive {
+  pointer_id : Int
+  between : Int
+  handle : @dom.Element
+}
+
+///|
+#cfg(target="js")
+priv struct ResizablePointerBinding {
+  root : @dom.Element
+  mut resize : (Int, Int, Int, Int, Int, Int, Int) -> Unit
+  mut active : ResizablePointerActive?
+}
+
+///|
+#cfg(target="js")
+let resizable_pointer_bindings : Array[ResizablePointerBinding] = []
+
+///|
+#cfg(target="js")
+fn resizable_prune_pointer_bindings() -> Unit {
+  let mut index = 0
+  while index < resizable_pointer_bindings.length() {
+    if resizable_pointer_bindings[index].root.get_is_connected() {
+      index += 1
+    } else {
+      ignore(resizable_pointer_bindings.remove(index))
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn resizable_pointer_binding(root : @dom.Element) -> ResizablePointerBinding? {
+  for binding in resizable_pointer_bindings {
+    if binding.root.is_same_node(root.as_node()) {
+      return Some(binding)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn resizable_update_pointer(
+  binding : ResizablePointerBinding,
+  pointer : @dom.PointerEvent,
+) -> Unit {
+  guard binding.active is Some(active) else { return }
+  guard active.pointer_id == pointer.get_pointer_id() else { return }
+  let rect = binding.root.get_bounding_client_rect()
+  let client_x = if binding.root.get_attribute("data-orientation").unwrap_or("") ==
+    "horizontal" &&
+    ui_element_is_rtl(binding.root) {
+    rect.get_left() +
+    rect.get_width() -
+    (pointer.get_client_x().to_double() - rect.get_left())
+  } else {
+    pointer.get_client_x().to_double()
+  }
+  (binding.resize)(
+    active.between,
+    client_x.round().to_int(),
+    pointer.get_client_y(),
+    rect.get_left().round().to_int(),
+    rect.get_top().round().to_int(),
+    rect.get_width().round().to_int(),
+    rect.get_height().round().to_int(),
+  )
+}
+
+///|
+#cfg(target="js")
+fn resizable_finish_pointer(
+  binding : ResizablePointerBinding,
+  pointer : @dom.PointerEvent,
+) -> Unit {
+  guard binding.active is Some(active) else { return }
+  guard active.pointer_id == pointer.get_pointer_id() else { return }
+  active.handle.remove_attribute("data-resizing")
+  binding.active = None
+  if binding.root.has_pointer_capture(active.pointer_id) {
+    binding.root.release_pointer_capture(active.pointer_id)
+  }
+}
+
+///|
+#cfg(target="js")
+fn resizable_bind_pointer_listeners(binding : ResizablePointerBinding) -> Unit {
+  binding.root.add_event_listener("pointerdown", event => {
+    guard event.to_pointer_event() is Some(pointer) else { return }
+    if pointer.get_button() != 0 || binding.active is Some(_) {
+      return
+    }
+    guard pointer.target().to_element() is Some(target) else { return }
+    guard target.closest("[data-slot=\"resizable-handle\"][data-between]")
+      is Some(handle) else {
+      return
+    }
+    guard binding.root.contains(handle.as_node()) else { return }
+    guard handle.closest("[data-slot=\"resizable-panel-group\"]") is Some(owner) &&
+      owner.is_same_node(binding.root.as_node()) else {
+      return
+    }
+    guard handle.query_selector("[data-slot=\"resizable-control\"]")
+      is Some(control) else {
+      return
+    }
+    if !ui_element_is_enabled(control) {
+      return
+    }
+    let between = ui_parse_int_or(
+      handle.get_attribute("data-between").unwrap_or(""),
+      -1,
+    )
+    if between < 0 {
+      return
+    }
+    binding.active = Some({
+      pointer_id: pointer.get_pointer_id(),
+      between,
+      handle,
+    })
+    handle.set_attribute("data-resizing", "true")
+    ui_focus_element_without_scroll(control)
+    pointer.prevent_default()
+    binding.root.set_pointer_capture(pointer.get_pointer_id())
+    resizable_update_pointer(binding, pointer)
+  })
+  binding.root.add_event_listener("pointermove", event => {
+    guard event.to_pointer_event() is Some(pointer) else { return }
+    if binding.active is Some(_) {
+      pointer.prevent_default()
+      resizable_update_pointer(binding, pointer)
+    }
+  })
+  let finish : @dom.Listener = event => {
+    if event.to_pointer_event() is Some(pointer) {
+      resizable_finish_pointer(binding, pointer)
+    }
+  }
+  binding.root.add_event_listener("pointerup", finish)
+  binding.root.add_event_listener("pointercancel", finish)
+  binding.root.add_event_listener("lostpointercapture", finish)
+}
+
+///|
+#cfg(target="js")
+fn bind_resizable_pointer(
+  id : String,
+  resize : (Int, Int, Int, Int, Int, Int, Int) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  resizable_prune_pointer_bindings()
+  if resizable_pointer_binding(root) is Some(binding) {
+    binding.resize = resize
+    return
+  }
+  let binding : ResizablePointerBinding = { root, resize, active: None }
+  resizable_pointer_bindings.push(binding)
+  resizable_bind_pointer_listeners(binding)
+}
+
+///|
+#cfg(target="js")
+fn resizable_event_is_rtl(event : @dom.KeyboardEvent) -> Bool {
+  event.current_target().to_option() is Some(current_target) &&
+  current_target.to_element() is Some(target) &&
+  target.closest("[data-slot=\"resizable-panel-group\"]") is Some(group) &&
+  ui_element_is_rtl(group)
+}
+
+///|
+#cfg(target="js")
+fn resizable_bind_pointer_cmd(
+  id : String,
+  orientation : SeparatorOrientation,
+  emit : @cmd.Emit[ResizableGroupMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      id,
+      () => {
+        bind_resizable_pointer(id, (
+          between,
+          client_x,
+          client_y,
+          left,
+          top,
+          width,
+          height,
+        ) => {
+          if resizable_pointer_percent(
+              orientation, client_x, client_y, left, top, width, height,
+            )
+            is Some(percent) {
+            scheduler.add(emit(ResizeResizableGroupAt(between, percent)))
+          }
+        })
+      },
+      purpose="resizable-pointer-bind",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn resizable_group_input_attrs(
+  scope : ResizableGroupScope,
+  between : Int,
+  label : String,
+) -> @html.Attrs {
+  let attrs = @html.Attrs::build()
+    .data_set("slot", "resizable-control")
+    .aria_label(label)
+    .aria_orientation(separator_orientation_value(scope.orientation))
+  ignore(
+    attrs.on_keydown(event => {
+      let key = resizable_key_for_direction(
+        scope.orientation,
+        event.key(),
+        resizable_event_is_rtl(event),
+      )
+      let next = resizable_key_sizes(
+        scope.sizes,
+        scope.min_sizes,
+        scope.max_sizes,
+        between,
+        scope.orientation,
+        key,
+      )
+      if next is Some(next) {
+        event.prevent_default()
+        if next == scope.sizes {
+          @cmd.none
+        } else {
+          (scope.emit)(SetResizableGroupSizes(next))
+        }
+      } else if resizable_is_arrow_key(key) {
+        // A native range also handles orthogonal arrow keys. Suppress them so
+        // its keyboard axis remains identical to the visible panel-group axis.
+        event.prevent_default()
+        @cmd.none
+      } else {
+        @cmd.none
+      }
+    }),
+  )
+  attrs
+}
+
+///|
+#cfg(not(target="js"))
+fn resizable_group_input_attrs(
+  scope : ResizableGroupScope,
+  between : Int,
+  label : String,
+) -> @html.Attrs {
+  ignore(between)
+  @html.Attrs::build()
+  .data_set("slot", "resizable-control")
+  .aria_label(label)
+  .aria_orientation(separator_orientation_value(scope.orientation))
+}
+
+///|
+fn[C : @html.IsChildren] render_resizable_group(
+  scope : ResizableGroupScope,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (ResizableGroupScope) -> C,
+) -> @html.Html {
+  let orientation_value = separator_orientation_value(scope.orientation)
+  let first_size = resizable_value_at(scope.sizes, 0, 100)
+  @html.div(
+    id=scope.id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "resizable-panel-group")
+      .data_set("orientation", orientation_value)
+      .data_set("size", "\{first_size}")
+      .data_set("sizes", scope.sizes.map(size => "\{size}").join(","))
+      .data_set("panel-count", "\{scope.sizes.length()}"),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "display:flex;width:100%;height:100%;min-width:0;min-height:0;overflow:hidden",
+        if scope.orientation is Vertical {
+          "flex-direction:column"
+        } else {
+          "flex-direction:row"
+        },
+      ],
+      style,
+    ),
+    children(scope),
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn[C : @html.IsChildren] resizable_group(
+  id~ : String,
+  default_sizes~ : Array[Int],
+  min_sizes? : Array[Int] = [],
+  max_sizes? : Array[Int] = [],
+  orientation? : SeparatorOrientation = Horizontal,
+  aria_label? : String = "Resize panels",
+  on_resize? : @cmd.Emit[Array[Int]],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ResizableGroupScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let (initial, minimums, maximums) = resizable_prepare_layout(
+    default_sizes, min_sizes, max_sizes,
+  )
+  let (sizes, emit) = @rabbita.create_state_with_init(
+    init=emit => (initial, resizable_bind_pointer_cmd(id, orientation, emit)),
+    update=fn(_, msg, current) {
+      let next = match msg {
+        SetResizableGroupSizes(sizes) => sizes
+        ResizeResizableGroupAt(between, percent) =>
+          resizable_resize_at_percent(
+            current, minimums, maximums, between, percent,
+          )
+      }
+      let command = if next != current && on_resize is Some(notify) {
+        notify(next.copy())
+      } else {
+        @cmd.none
+      }
+      (next, command)
+    },
+  )
+  sizes.view(sizes => {
+    render_resizable_group(
+      {
+        id,
+        sizes,
+        min_sizes: minimums,
+        max_sizes: maximums,
+        orientation,
+        aria_label,
+        emit,
+      },
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] resizable_group(
+  id~ : String,
+  default_sizes~ : Array[Int],
+  min_sizes? : Array[Int] = [],
+  max_sizes? : Array[Int] = [],
+  orientation? : SeparatorOrientation = Horizontal,
+  aria_label? : String = "Resize panels",
+  on_resize? : @cmd.Emit[Array[Int]],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ResizableGroupScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_resize)
+  let (sizes, minimums, maximums) = resizable_prepare_layout(
+    default_sizes, min_sizes, max_sizes,
+  )
+  let emit = @cmd.Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_resizable_group(
+      {
+        id,
+        sizes,
+        min_sizes: minimums,
+        max_sizes: maximums,
+        orientation,
+        aria_label,
+        emit,
+      },
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    ),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] resizable_group_panel(
+  scope~ : ResizableGroupScope,
+  index~ : Int,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let size = resizable_value_at(scope.sizes, index, 0)
+  let panel_id = id.unwrap_or("\{scope.id}-panel-\{index}")
+  @html.div(
+    id=panel_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "resizable-panel")
+      .data_set("index", "\{index}")
+      .data_set("size", "\{size}"),
+    style=ui_styles(
+      [UiBoxSizing, "min-width:0;min-height:0;overflow:auto;flex:0 0 \{size}%"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+fn render_resizable_handle(
+  scope : ResizableGroupScope,
+  between : Int,
+  outer_id : String?,
+  control_id : String,
+  with_handle : Bool,
+  aria_label : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let vertical = scope.orientation is Vertical
+  let bounds = resizable_handle_bounds(
+    scope.sizes,
+    scope.min_sizes,
+    scope.max_sizes,
+    between,
+  )
+  let label = aria_label.unwrap_or(scope.aria_label)
+  let input_attrs = resizable_group_input_attrs(scope, between, label)
+  if !bounds.valid {
+    ignore(input_attrs.disabled(true))
+  }
+  let id = outer_id
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .role("separator")
+      .aria_orientation(if vertical { "horizontal" } else { "vertical" })
+      .aria_valuemin("\{bounds.min}")
+      .aria_valuemax("\{bounds.max}")
+      .aria_valuenow("\{bounds.value}")
+      .data_set("slot", "resizable-handle")
+      .data_set("orientation", if vertical { "horizontal" } else { "vertical" })
+      .data_set("between", "\{between}"),
+    style=ui_styles(
+      [
+        "position:relative;z-index:1;display:flex;flex-shrink:0;align-items:center;justify-content:center;outline:none",
+        "touch-action:none;user-select:none",
+        if vertical {
+          "width:100%;height:0;cursor:row-resize"
+        } else {
+          "width:0;height:100%;cursor:col-resize"
+        },
+      ],
+      style,
+    ),
+    [
+      @html.span(
+        attrs=@html.Attrs::build()
+          .data_set("slot", "resizable-handle-line")
+          .aria_hidden("true"),
+        style=[
+          "position:absolute;z-index:0;display:block;background:var(--rui-border,oklch(0.922 0 0));pointer-events:none",
+          if vertical {
+            "left:0;top:-0.5px;width:100%;height:1px"
+          } else {
+            "left:-0.5px;top:0;width:1px;height:100%"
+          },
+        ],
+        "",
+      ),
+      @html.span(
+        attrs=@html.Attrs::build()
+          .data_set("slot", "resizable-handle-hit-area")
+          .aria_hidden("true"),
+        style=[
+          "position:absolute;z-index:2;display:block",
+          if vertical {
+            "left:0;top:-2px;width:100%;height:4px;cursor:row-resize"
+          } else {
+            "left:-2px;top:0;width:4px;height:100%;cursor:col-resize"
+          },
+        ],
+        "",
+      ),
+      if with_handle {
+        @html.span(
+          attrs=@html.Attrs::build()
+            .data_set("slot", "resizable-handle-grip")
+            .aria_hidden("true"),
+          style=[
+            "position:relative;z-index:1;display:block;width:0.25rem;height:1.5rem;flex-shrink:0;border-radius:9999px;background:var(--rui-border,oklch(0.922 0 0));pointer-events:none",
+            if vertical {
+              "transform:rotate(90deg)"
+            } else {
+              ""
+            },
+          ],
+          "",
+        )
+      } else {
+        @html.nothing
+      },
+      @html.input(
+        input_type=@html.Range,
+        value="\{bounds.value}",
+        min=bounds.min,
+        max=bounds.max,
+        step=1,
+        id=control_id,
+        on_input=scope.emit.map(text => {
+          SetResizableGroupSizes(
+            resizable_resize_between(
+              scope.sizes,
+              scope.min_sizes,
+              scope.max_sizes,
+              between,
+              resizable_parse(text, bounds.value),
+            ),
+          )
+        }),
+        attrs=input_attrs,
+        style=[
+          "position:absolute;z-index:2;margin:0;opacity:0;pointer-events:none",
+          if vertical {
+            "left:0;top:-2px;width:100%;height:4px;writing-mode:vertical-lr;cursor:row-resize"
+          } else {
+            "left:-2px;top:0;width:4px;height:100%;writing-mode:horizontal-tb;cursor:col-resize"
+          },
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+pub fn resizable_group_handle(
+  scope~ : ResizableGroupScope,
+  between~ : Int,
+  with_handle? : Bool = false,
+  aria_label? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let handle_id = "\{scope.id}-handle-\{between}"
+  render_resizable_handle(
+    scope,
+    between,
+    Some(handle_id),
+    handle_id + "-input",
+    with_handle,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] resizable_panel_group(
+  id~ : String,
+  default_size? : Int = 50,
+  min? : Int = 10,
+  max? : Int = 90,
+  orientation? : SeparatorOrientation = Horizontal,
+  aria_label? : String = "Resize panels",
+  on_resize? : @cmd.Emit[Int],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ResizableScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let min = resizable_clamp(min, 0, 100)
+  let max = resizable_clamp(max, min, 100)
+  let initial = resizable_clamp(default_size, min, max)
+  let on_resize = if on_resize is Some(notify) {
+    Some(notify.map(sizes => resizable_value_at(sizes, 0, initial)))
+  } else {
+    None
+  }
+  resizable_group(
+    id~,
+    default_sizes=[initial, 100 - initial],
+    min_sizes=[min, 100 - max],
+    max_sizes=[max, 100 - min],
+    orientation~,
+    aria_label~,
+    on_resize?,
+    class?,
+    title?,
+    attrs?,
+    style~,
+    group => children({ group, control_id: "\{id}-handle" }),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] resizable_panel(
+  scope~ : ResizableScope,
+  side~ : ResizablePanelSide,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let side_value = if side is FirstPanel { "first" } else { "second" }
+  let index = if side is FirstPanel { 0 } else { 1 }
+  let size = resizable_value_at(scope.group.sizes, index, 0)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "resizable-panel")
+      .data_set("side", side_value)
+      .data_set("size", "\{size}"),
+    style=ui_styles(
+      [UiBoxSizing, "min-width:0;min-height:0;overflow:auto;flex:0 0 \{size}%"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn resizable_handle(
+  scope~ : ResizableScope,
+  with_handle? : Bool = false,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  render_resizable_handle(
+    scope.group,
+    0,
+    id,
+    scope.control_id,
+    with_handle,
+    aria_label,
+    class,
+    title,
+    attrs,
+    style,
+  )
+}

--- a/rui/resizable_test.mbt
+++ b/rui/resizable_test.mbt
@@ -1,0 +1,149 @@
+///|
+#cfg(target="js")
+extern "js" fn install_resizable_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_incremental_resizable(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_resizable_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_incremental_resizable(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn resizable_id_occurs_once(html : String, id : String) -> Bool {
+  let token = "id=\"\{id}\""
+  let first = html.find(token)
+  first is Some(_) && first == html.rev_find(token)
+}
+
+///|
+test "generic resizable renders three panels and two unique handles" {
+  let html = render_incremental_resizable(() => {
+    @rui.resizable_group(
+      id="workspace-layout",
+      default_sizes=[20, 30, 50],
+      min_sizes=[10, 20, 25],
+      max_sizes=[50, 60, 70],
+      aria_label="Resize workspace panes",
+      scope => {
+        [
+          @rui.resizable_group_panel(scope~, index=0, "Navigation"),
+          @rui.resizable_group_handle(scope~, between=0, with_handle=true),
+          @rui.resizable_group_panel(scope~, index=1, "Editor"),
+          @rui.resizable_group_handle(scope~, between=1, with_handle=true),
+          @rui.resizable_group_panel(scope~, index=2, "Inspector"),
+        ]
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"resizable-panel-group\"")
+  assert_contains(html, "data-sizes=\"20,30,50\"")
+  assert_contains(html, "data-panel-count=\"3\"")
+  assert_contains(html, "data-orientation=\"horizontal\"")
+  assert_contains(html, "flex-direction:row")
+  assert_contains(html, "data-between=\"0\"")
+  assert_contains(html, "data-between=\"1\"")
+  assert_contains(html, "data-index=\"0\" data-size=\"20\"")
+  assert_contains(html, "data-index=\"1\" data-size=\"30\"")
+  assert_contains(html, "data-index=\"2\" data-size=\"50\"")
+  assert_contains(
+    html, "box-sizing:border-box;min-width:0;min-height:0;overflow:auto;flex:0 0 20%",
+  )
+  assert_contains(html, "data-slot=\"resizable-control\"")
+  assert_contains(html, "data-slot=\"resizable-handle-line\"")
+  assert_contains(html, "data-slot=\"resizable-handle-hit-area\"")
+  assert_contains(html, "data-slot=\"resizable-handle-grip\"")
+  assert_contains(html, "width:0.25rem;height:1.5rem")
+  assert_contains(html, "border-radius:9999px")
+  assert_not_contains(html, "width:0.75rem;height:1rem")
+  assert_contains(html, "aria-label=\"Resize workspace panes\"")
+  assert_contains(html, "aria-orientation=\"horizontal\"")
+  assert_contains(html, "writing-mode:horizontal-tb")
+  assert_contains(html, "touch-action:none")
+  assert_true(resizable_id_occurs_once(html, "workspace-layout"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-panel-0"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-panel-1"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-panel-2"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-handle-0"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-handle-0-input"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-handle-1"))
+  assert_true(resizable_id_occurs_once(html, "workspace-layout-handle-1-input"))
+}
+
+///|
+test "generic vertical resizable aligns layout range and separator axes" {
+  let html = render_incremental_resizable(() => {
+    @rui.resizable_group(
+      id="stack-layout",
+      default_sizes=[25, 35, 40],
+      orientation=@rui.Vertical,
+      scope => {
+        [
+          @rui.resizable_group_panel(scope~, index=0, "Top"),
+          @rui.resizable_group_handle(scope~, between=0),
+          @rui.resizable_group_panel(scope~, index=1, "Middle"),
+          @rui.resizable_group_handle(scope~, between=1),
+          @rui.resizable_group_panel(scope~, index=2, "Bottom"),
+        ]
+      },
+    )
+  })
+  assert_contains(html, "data-sizes=\"25,35,40\"")
+  assert_contains(html, "data-orientation=\"vertical\"")
+  assert_contains(html, "flex-direction:column")
+  assert_contains(html, "role=\"separator\" aria-orientation=\"horizontal\"")
+  assert_contains(html, "data-slot=\"resizable-control\"")
+  assert_contains(html, "aria-orientation=\"vertical\"")
+  assert_contains(html, "writing-mode:vertical-lr")
+  assert_contains(html, "cursor:row-resize")
+  assert_contains(html, "data-orientation=\"horizontal\"")
+  assert_true(resizable_id_occurs_once(html, "stack-layout-handle-0"))
+  assert_true(resizable_id_occurs_once(html, "stack-layout-handle-1"))
+}
+
+///|
+test "legacy two panel API keeps its sizing and control contract" {
+  let html = render_incremental_resizable(() => {
+    @rui.resizable_panel_group(
+      id="compat-split",
+      default_size=47,
+      min=12,
+      max=82,
+      scope => {
+        [
+          @rui.resizable_panel(scope~, side=@rui.FirstPanel, "Primary"),
+          @rui.resizable_handle(scope~, with_handle=true),
+          @rui.resizable_panel(scope~, side=@rui.SecondPanel, "Secondary"),
+        ]
+      },
+    )
+  })
+  assert_contains(html, "id=\"compat-split\"")
+  assert_contains(html, "data-size=\"47\"")
+  assert_contains(html, "data-sizes=\"47,53\"")
+  assert_contains(html, "data-side=\"first\" data-size=\"47\"")
+  assert_contains(html, "data-side=\"second\" data-size=\"53\"")
+  assert_contains(
+    html, "box-sizing:border-box;min-width:0;min-height:0;overflow:auto;flex:0 0 47%",
+  )
+  assert_contains(html, "id=\"compat-split-handle\"")
+  assert_not_contains(html, "id=\"compat-split-handle-0\"")
+}

--- a/rui/resizable_wbtest.mbt
+++ b/rui/resizable_wbtest.mbt
@@ -1,0 +1,354 @@
+///|
+test "resizable keyboard follows the panel group axis" {
+  assert_eq(resizable_key_size(47, 10, 90, Horizontal, "ArrowRight"), Some(48))
+  assert_eq(resizable_key_size(47, 10, 90, Horizontal, "ArrowLeft"), Some(46))
+  assert_eq(resizable_key_size(47, 10, 90, Horizontal, "ArrowUp"), None)
+  assert_eq(resizable_key_size(47, 10, 90, Vertical, "ArrowDown"), Some(48))
+  assert_eq(resizable_key_size(47, 10, 90, Vertical, "ArrowUp"), Some(46))
+  assert_eq(resizable_key_size(47, 10, 90, Vertical, "ArrowRight"), None)
+}
+
+///|
+test "resizable keyboard clamps arrows and supports Home and End" {
+  assert_eq(resizable_key_size(10, 10, 90, Horizontal, "ArrowLeft"), Some(10))
+  assert_eq(resizable_key_size(90, 10, 90, Vertical, "ArrowDown"), Some(90))
+  assert_eq(resizable_key_size(47, 10, 90, Horizontal, "Home"), Some(10))
+  assert_eq(resizable_key_size(47, 10, 90, Vertical, "End"), Some(90))
+}
+
+///|
+test "resizable horizontal keyboard mirrors left and right in RTL" {
+  assert_eq(
+    resizable_key_for_direction(Horizontal, "ArrowLeft", true),
+    "ArrowRight",
+  )
+  assert_eq(
+    resizable_key_for_direction(Horizontal, "ArrowRight", true),
+    "ArrowLeft",
+  )
+  assert_eq(
+    resizable_key_for_direction(Vertical, "ArrowLeft", true),
+    "ArrowLeft",
+  )
+  assert_eq(resizable_key_for_direction(Horizontal, "Home", true), "Home")
+}
+
+///|
+test "three panel resize changes only the selected adjacent pair" {
+  let sizes = [20, 30, 50]
+  let minimums = [10, 20, 25]
+  let maximums = [50, 60, 70]
+  let first = resizable_resize_between(sizes, minimums, maximums, 0, 45)
+  assert_eq(first, [30, 20, 50])
+  assert_eq(resizable_sum(first), 100)
+  let second = resizable_resize_between(sizes, minimums, maximums, 1, 60)
+  assert_eq(second, [20, 55, 25])
+  assert_eq(resizable_sum(second), 100)
+  assert_eq(sizes, [20, 30, 50])
+}
+
+///|
+test "three panel handles clamp per-panel bounds and reject invalid gaps" {
+  let sizes = [20, 30, 50]
+  let minimums = [10, 20, 25]
+  let maximums = [50, 60, 70]
+  assert_eq(resizable_resize_between(sizes, minimums, maximums, 0, -100), [
+    10, 40, 50,
+  ])
+  assert_eq(resizable_resize_between(sizes, minimums, maximums, 1, 100), [
+    20, 55, 25,
+  ])
+  assert_eq(resizable_resize_between(sizes, minimums, maximums, 2, 10), sizes)
+}
+
+///|
+test "three panel keyboard updates the matching handle and axis" {
+  let sizes = [20, 30, 50]
+  let minimums = [10, 20, 25]
+  let maximums = [50, 60, 70]
+  assert_eq(
+    resizable_key_sizes(sizes, minimums, maximums, 0, Horizontal, "ArrowRight"),
+    Some([21, 29, 50]),
+  )
+  assert_eq(
+    resizable_key_sizes(sizes, minimums, maximums, 1, Horizontal, "ArrowUp"),
+    None,
+  )
+  assert_eq(
+    resizable_key_sizes(sizes, minimums, maximums, 1, Vertical, "ArrowDown"),
+    Some([20, 31, 49]),
+  )
+  assert_eq(
+    resizable_key_sizes(sizes, minimums, maximums, 1, Vertical, "ArrowRight"),
+    None,
+  )
+}
+
+///|
+test "pointer geometry follows horizontal and vertical group axes" {
+  assert_eq(
+    resizable_pointer_percent(Horizontal, 260, 999, 100, 40, 400, 800),
+    Some(40),
+  )
+  assert_eq(
+    resizable_pointer_percent(Vertical, 999, 240, 100, 40, 400, 800),
+    Some(25),
+  )
+  assert_eq(
+    resizable_pointer_percent(Horizontal, -20, 0, 100, 40, 400, 800),
+    Some(0),
+  )
+  assert_eq(
+    resizable_pointer_percent(Vertical, 0, 1000, 100, 40, 400, 800),
+    Some(100),
+  )
+  assert_eq(
+    resizable_pointer_percent(Horizontal, 100, 100, 100, 40, 0, 800),
+    None,
+  )
+}
+
+///|
+test "absolute pointer percent targets only its adjacent pair" {
+  let sizes = [20, 30, 50]
+  let minimums = [10, 20, 25]
+  let maximums = [50, 60, 70]
+  assert_eq(resizable_resize_at_percent(sizes, minimums, maximums, 0, 35), [
+    30, 20, 50,
+  ])
+  assert_eq(resizable_resize_at_percent(sizes, minimums, maximums, 1, 65), [
+    20, 45, 35,
+  ])
+}
+
+///|
+test "layout preparation fills defaults to a bounded total of one hundred" {
+  let (sizes, minimums, maximums) = resizable_prepare_layout(
+    [15, 25, 40],
+    [10, 20, 25],
+    [50, 60, 70],
+  )
+  assert_eq(sizes, [35, 25, 40])
+  assert_eq(minimums, [10, 20, 25])
+  assert_eq(maximums, [50, 60, 70])
+  assert_eq(resizable_sum(sizes), 100)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_resizable_pointer_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const listeners = {}
+  #|   const fixture = globalThis.__ruiResizablePointerFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own("PointerEvent"),
+  #|     direction: "ltr",
+  #|     listeners,
+  #|     captures: 0,
+  #|     releases: 0,
+  #|     prevented: 0,
+  #|     focuses: [0, 0],
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class PointerEvent {
+  #|     constructor(init) {
+  #|       Object.assign(this, init)
+  #|       this.button = init.button ?? 0
+  #|       this.isPrimary = init.isPrimary ?? true
+  #|       this.pointerType = init.pointerType ?? "mouse"
+  #|       this.defaultPrevented = false
+  #|     }
+  #|     preventDefault() {
+  #|       this.defaultPrevented = true
+  #|       fixture.prevented += 1
+  #|     }
+  #|   }
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement, PointerEvent })
+  #|   const controls = [0, 1].map(index => {
+  #|     const control = new HTMLElement()
+  #|     Object.assign(control, {
+  #|       focus: () => { fixture.focuses[index] += 1 },
+  #|       hasAttribute: () => false,
+  #|       getAttribute: () => "",
+  #|     })
+  #|     return control
+  #|   })
+  #|   const handles = [0, 1].map(index => {
+  #|     const handle = new HTMLElement()
+  #|     const attributes = { "data-between": String(index) }
+  #|     Object.assign(handle, {
+  #|       getAttribute: name => attributes[name] || "",
+  #|       setAttribute: (name, value) => { attributes[name] = value },
+  #|       querySelector: () => controls[index],
+  #|       closest: selector => selector.includes("panel-group")
+  #|         ? fixture.root
+  #|         : handle,
+  #|       removeAttribute: name => {
+  #|         delete attributes[name]
+  #|       },
+  #|     })
+  #|     return handle
+  #|   })
+  #|   const root = new HTMLElement()
+  #|   Object.assign(root, {
+  #|     getAttribute: name => name === "data-orientation" ? "horizontal" : "",
+  #|     contains: node => handles.includes(node),
+  #|     addEventListener: (type, callback) => { listeners[type] = callback },
+  #|     getBoundingClientRect: () => ({
+  #|       left: 100, top: 40, width: 400, height: 800,
+  #|     }),
+  #|     setPointerCapture(pointerId) {
+  #|       this.__capturedPointerId = pointerId
+  #|       fixture.captures += 1
+  #|     },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId !== pointerId) return
+  #|       delete this.__capturedPointerId
+  #|       fixture.releases += 1
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|   })
+  #|   fixture.root = root
+  #|   fixture.handles = handles
+  #|   globalThis.document = { getElementById: value => value === id ? root : null }
+  #|   globalThis.window = {
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: name => name === "direction" ? fixture.direction : "",
+  #|     }),
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_set_resizable_pointer_direction(direction : String) -> Unit =
+  #| direction => {
+  #|   globalThis.__ruiResizablePointerFixture.direction = direction
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_resizable_pointer_fixture(
+  between : Int,
+  pointer_id : Int,
+  client_x : Int,
+  client_y : Int,
+) -> Unit =
+  #| (between, pointerId, clientX, clientY) => {
+  #|   const fixture = globalThis.__ruiResizablePointerFixture
+  #|   const event = new PointerEvent({
+  #|     button: 0,
+  #|     pointerId,
+  #|     clientX,
+  #|     clientY,
+  #|     target: fixture.handles[between],
+  #|     currentTarget: fixture.root,
+  #|   })
+  #|   fixture.listeners.pointerdown(event)
+  #|   fixture.listeners.pointermove(new PointerEvent({
+  #|     ...event,
+  #|     clientX: clientX + 20,
+  #|     target: fixture.handles[between],
+  #|     currentTarget: fixture.root,
+  #|   }))
+  #|   fixture.listeners.pointerup(event)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_resizable_pointer_fixture_count(kind : Int) -> Int =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiResizablePointerFixture
+  #|   if (kind === 0) return fixture.captures
+  #|   if (kind === 1) return fixture.releases
+  #|   if (kind === 2) return fixture.prevented
+  #|   return fixture.focuses[0] + fixture.focuses[1]
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_resizable_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiResizablePointerFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiResizablePointerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "pointer binding captures and independently dispatches multiple handles" {
+  let calls = Ref(0)
+  let last_between = Ref(-1)
+  let last_client_x = Ref(-1)
+  let last_width = Ref(-1)
+  ffi_install_resizable_pointer_fixture("pointer-layout")
+  bind_resizable_pointer("pointer-layout", (
+    between,
+    client_x,
+    _,
+    _,
+    _,
+    width,
+    _,
+  ) => {
+    calls.val += 1
+    last_between.val = between
+    last_client_x.val = client_x
+    last_width.val = width
+  })
+  ffi_fire_resizable_pointer_fixture(0, 7, 180, 200)
+  ffi_fire_resizable_pointer_fixture(1, 8, 320, 300)
+  let captures = ffi_resizable_pointer_fixture_count(0)
+  let releases = ffi_resizable_pointer_fixture_count(1)
+  let prevented = ffi_resizable_pointer_fixture_count(2)
+  let focuses = ffi_resizable_pointer_fixture_count(3)
+  ffi_restore_resizable_pointer_fixture()
+  assert_eq(calls.val, 4)
+  assert_eq(last_between.val, 1)
+  assert_eq(last_client_x.val, 340)
+  assert_eq(last_width.val, 400)
+  assert_eq(captures, 2)
+  assert_eq(releases, 2)
+  assert_eq(prevented, 4)
+  assert_eq(focuses, 2)
+}
+
+///|
+#cfg(target="js")
+test "horizontal pointer geometry mirrors in RTL" {
+  let last_client_x = Ref(-1)
+  ffi_install_resizable_pointer_fixture("rtl-pointer-layout")
+  ffi_set_resizable_pointer_direction("rtl")
+  bind_resizable_pointer("rtl-pointer-layout", (_, client_x, _, _, _, _, _) => {
+    last_client_x.val = client_x
+  })
+  ffi_fire_resizable_pointer_fixture(0, 7, 180, 200)
+  ffi_restore_resizable_pointer_fixture()
+  assert_eq(last_client_x.val, 400)
+}

--- a/rui/rtl_style_test.mbt
+++ b/rui/rtl_style_test.mbt
@@ -1,0 +1,107 @@
+///|
+test "form controls use logical inline spacing and indicators" {
+  let native_html = render(
+    @rui.direction(
+      direction=@rui.Rtl,
+      @rui.native_select(@rui.native_select_option(value="one", "One")),
+    ),
+  )
+  assert_contains(native_html, "padding-inline:0.625rem 2.25rem")
+  assert_contains(native_html, "inset-inline-end:0.875rem")
+  assert_not_contains(native_html, "padding-right:2.25rem")
+  assert_not_contains(native_html, "right:0.875rem")
+
+  let group_html = render(
+    @rui.input_group([
+      @rui.input_group_addon(align=@rui.InputInlineStart, "Start"),
+      @rui.input_group_input(),
+      @rui.input_group_addon(align=@rui.InputInlineEnd, "End"),
+    ]),
+  )
+  assert_contains(group_html, "padding-inline-start:0.5rem")
+  assert_contains(group_html, "padding-inline-end:0.5rem")
+  assert_not_contains(group_html, "padding-left:0.5rem")
+  assert_not_contains(group_html, "padding-right:0.5rem")
+}
+
+///|
+test "select and combobox mirror item affordances in rtl" {
+  let select_html = render_incremental(() => {
+    @rui.select(
+      id="rtl-select",
+      options=[@rui.select_option(value="one", label="One")],
+      default_value="one",
+      default_open=true,
+    )
+  })
+  assert_contains(select_html, "text-align:start")
+  assert_contains(select_html, "padding-inline:0.5rem 2rem")
+  assert_contains(select_html, "inset-inline-end:0.5rem")
+  assert_not_contains(select_html, "text-align:left")
+  assert_not_contains(select_html, "right:0.5rem")
+
+  let combobox_html = render_incremental(() => {
+    @rui.combobox(
+      id="rtl-combobox",
+      options=[@rui.combobox_option(value="one", label="One")],
+      multiple=true,
+      default_values=["one"],
+      default_open=true,
+    )
+  })
+  assert_contains(combobox_html, "text-align:start")
+  assert_contains(combobox_html, "padding-inline:0.5rem 2rem")
+  assert_contains(combobox_html, "inset-inline-end:0.5rem")
+  assert_contains(combobox_html, "margin-inline-start:-0.25rem")
+  assert_not_contains(combobox_html, "text-align:left")
+  assert_not_contains(combobox_html, "right:0.5rem")
+  assert_not_contains(combobox_html, "margin-left:-0.25rem")
+}
+
+///|
+test "otp connected toggles and alert actions carry rtl-safe recipes" {
+  let otp_html = render_incremental(() => {
+    @rui.input_otp(id="rtl-otp", max_length=2, default_value="1")
+  })
+  assert_contains(otp_html, "border-block:1px solid var(--rui-otp-border")
+  assert_contains(otp_html, "border-inline-end:1px solid var(--rui-otp-border")
+  assert_not_contains(otp_html, "border-right:1px")
+
+  let alert_html = render(
+    @rui.alert([@rui.alert_title("Notice"), @rui.alert_action("Action")]),
+  )
+  assert_contains(alert_html, "margin-inline-start:1rem")
+  assert_contains(
+    alert_html, "translate(var(--rui-alert-action-offset-inline,0.25rem),-0.125rem)",
+  )
+  assert_not_contains(alert_html, "margin-left:1rem")
+
+  let theme_html = render(@rui.theme(@html.nothing))
+  assert_contains(
+    theme_html, "border-inline-start:1px solid var(--rui-otp-border",
+  )
+  assert_contains(theme_html, "border-start-start-radius")
+  assert_contains(theme_html, "border-end-end-radius")
+  assert_contains(
+    theme_html, "[data-slot=\"toggle-group\"][data-spacing=\"0\"][data-orientation=\"horizontal\"]:dir(rtl) > [data-slot=\"toggle-group-item\"]:last-child",
+  )
+  assert_contains(
+    theme_html, "[data-slot=\"toggle-group\"][data-spacing=\"0\"][data-orientation=\"horizontal\"]:dir(rtl) > [data-slot=\"toggle-group-item\"]:first-child",
+  )
+  assert_contains(
+    theme_html, "[data-slot=\"alert\"]:dir(rtl) > [data-slot=\"alert-action\"]",
+  )
+  assert_contains(theme_html, "--rui-alert-action-offset-inline:-0.25rem")
+}
+
+///|
+test "switch checked endpoint mirrors without runtime positioning" {
+  let html = render_incremental(() => {
+    @rui.switch(default_checked=true, aria_label="Mirrored switch")
+  })
+  assert_contains(html, "data-rui-style=\"switch-rtl\"")
+  assert_contains(
+    html, "[data-slot=\"switch-thumb\"][data-state=\"checked\"]:dir(rtl)",
+  )
+  assert_contains(html, "translateX(calc(-100% + 2px))")
+}

--- a/rui/scroll_area.mbt
+++ b/rui/scroll_area.mbt
@@ -1,0 +1,677 @@
+///|
+pub fn[C : @html.IsChildren] scroll_area(
+  orientation? : SeparatorOrientation = Vertical,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let value = separator_orientation_value(orientation)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "scroll-area")
+      .data_set("orientation", value)
+      .tabindex(0),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "position:relative;width:100%;height:100%;border-radius:inherit;outline-offset:2px;overscroll-behavior:contain;scrollbar-color:var(--rui-border,oklch(0.922 0 0)) transparent;scrollbar-width:thin",
+        if orientation is Vertical {
+          "overflow-y:auto;overflow-x:hidden"
+        } else {
+          "overflow-x:auto;overflow-y:hidden"
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+/// Optional visual scrollbar track for layouts that want shadcn's composition.
+/// Native scrolling remains on `scroll_area`; this element is decorative.
+pub fn scroll_bar(
+  orientation? : SeparatorOrientation = Vertical,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let value = separator_orientation_value(orientation)
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "scroll-area-scrollbar")
+      .data_set("orientation", value)
+      .aria_hidden("true"),
+    style=ui_styles(
+      [
+        "display:flex;pointer-events:none;user-select:none;padding:1px",
+        if orientation is Vertical {
+          "position:absolute;top:0;inset-inline-end:0;width:0.625rem;height:100%"
+        } else {
+          "position:absolute;inset-inline-start:0;bottom:0;width:100%;height:0.625rem;flex-direction:column"
+        },
+      ],
+      style,
+    ),
+    @html.div(
+      attrs=@html.Attrs::build().data_set("slot", "scroll-area-thumb"),
+      style=[
+        "position:relative;flex:1;border-radius:9999px;background:var(--rui-border,oklch(0.922 0 0));opacity:0.7",
+      ],
+      "",
+    ),
+  )
+}
+
+///|
+priv struct ScrollAreaMetrics {
+  offset : Double
+  viewport : Double
+  content : Double
+}
+
+///|
+#cfg(target="js")
+impl Eq for ScrollAreaMetrics with fn equal(a, b) {
+  a.offset == b.offset && a.viewport == b.viewport && a.content == b.content
+}
+
+///|
+#cfg(target="js")
+priv enum ScrollAreaMsg {
+  ScrollAreaMeasured(ScrollAreaMetrics)
+}
+
+///|
+const ScrollAreaManagedRootStyle : String = "position:relative;width:100%;height:100%;min-width:0;min-height:0;overflow:hidden;border-radius:inherit"
+
+///|
+const ScrollAreaManagedViewportStyle : String = "width:100%;height:100%;min-width:0;min-height:0;overscroll-behavior:contain;scrollbar-color:transparent transparent;scrollbar-width:none;-ms-overflow-style:none;outline-offset:2px"
+
+///|
+const ScrollAreaManagedTrackStyle : String = "position:absolute;z-index:1;display:block;user-select:none;transition:opacity 150ms ease"
+
+///|
+const ScrollAreaManagedThumbStyle : String = "position:absolute;display:block;border-radius:9999px;background:var(--rui-border,oklch(0.922 0 0));opacity:0.8;pointer-events:auto;touch-action:none"
+
+///|
+#cfg(target="js")
+priv struct ScrollAreaDimensions {
+  vertical : Bool
+  viewport_size : Double
+  content_size : Double
+  max : Double
+}
+
+///|
+#cfg(target="js")
+priv struct ScrollAreaDrag {
+  pointer_id : Int
+  grab : Double
+}
+
+///|
+#cfg(target="js")
+priv struct ScrollAreaPointerBinding {
+  root : @dom.Element
+  viewport : @dom.Element
+  track : @dom.Element
+  thumb : @dom.Element
+  mut vertical : Bool
+  mut notify : (Double, Double, Double) -> Unit
+  mut drag : ScrollAreaDrag?
+}
+
+///|
+#cfg(target="js")
+let scroll_area_pointer_bindings : Array[ScrollAreaPointerBinding] = []
+
+///|
+#cfg(target="js")
+fn scroll_area_prune_pointer_bindings() -> Unit {
+  let mut index = 0
+  while index < scroll_area_pointer_bindings.length() {
+    if scroll_area_pointer_bindings[index].root.get_is_connected() {
+      index += 1
+    } else {
+      ignore(scroll_area_pointer_bindings.remove(index))
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_pointer_binding(
+  root : @dom.Element,
+) -> ScrollAreaPointerBinding? {
+  for binding in scroll_area_pointer_bindings {
+    if binding.root.is_same_node(root.as_node()) {
+      return Some(binding)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_dimensions(
+  binding : ScrollAreaPointerBinding,
+) -> ScrollAreaDimensions {
+  let viewport_size = if binding.vertical {
+    binding.viewport.get_client_height()
+  } else {
+    binding.viewport.get_client_width()
+  }
+  let content_size = if binding.vertical {
+    binding.viewport.get_scroll_height()
+  } else {
+    binding.viewport.get_scroll_width()
+  }
+  {
+    vertical: binding.vertical,
+    viewport_size,
+    content_size,
+    max: (content_size - viewport_size).max(0.0),
+  }
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_physical_offset(
+  binding : ScrollAreaPointerBinding,
+  dimensions : ScrollAreaDimensions,
+) -> Double {
+  if dimensions.vertical {
+    binding.viewport.get_scroll_top().clamp(min=0.0, max=dimensions.max)
+  } else {
+    let raw = binding.viewport.get_scroll_left()
+    (if ui_element_is_rtl(binding.viewport) {
+      dimensions.max + raw
+    } else {
+      raw
+    }).clamp(min=0.0, max=dimensions.max)
+  }
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_notify_position(binding : ScrollAreaPointerBinding) -> Unit {
+  let dimensions = scroll_area_dimensions(binding)
+  (binding.notify)(
+    scroll_area_physical_offset(binding, dimensions),
+    dimensions.viewport_size,
+    dimensions.content_size,
+  )
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_set_physical_offset(
+  binding : ScrollAreaPointerBinding,
+  value : Double,
+  dimensions : ScrollAreaDimensions,
+) -> Unit {
+  let next = value.clamp(min=0.0, max=dimensions.max)
+  if dimensions.vertical {
+    binding.viewport.set_scroll_top(next)
+  } else if ui_element_is_rtl(binding.viewport) {
+    binding.viewport.set_scroll_left(next - dimensions.max)
+  } else {
+    binding.viewport.set_scroll_left(next)
+  }
+  (binding.notify)(next, dimensions.viewport_size, dimensions.content_size)
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_move_pointer(
+  binding : ScrollAreaPointerBinding,
+  pointer : @dom.PointerEvent,
+) -> Unit {
+  guard binding.drag is Some(drag) else { return }
+  guard drag.pointer_id == pointer.get_pointer_id() else { return }
+  let dimensions = scroll_area_dimensions(binding)
+  let rect = binding.track.get_bounding_client_rect()
+  let track_size = if dimensions.vertical {
+    rect.get_height()
+  } else {
+    rect.get_width()
+  }
+  let thumb_size = if dimensions.content_size > 0.0 {
+    (track_size * dimensions.viewport_size / dimensions.content_size).max(1.0)
+  } else {
+    track_size
+  }
+  let travel = (track_size - thumb_size).max(0.0)
+  let pointer_position = if dimensions.vertical {
+    pointer.get_client_y().to_double() - rect.get_top()
+  } else {
+    pointer.get_client_x().to_double() - rect.get_left()
+  }
+  let start = (pointer_position - drag.grab).clamp(min=0.0, max=travel)
+  scroll_area_set_physical_offset(
+    binding,
+    if travel > 0.0 {
+      start / travel * dimensions.max
+    } else {
+      0.0
+    },
+    dimensions,
+  )
+  pointer.prevent_default()
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_finish_pointer(
+  binding : ScrollAreaPointerBinding,
+  pointer : @dom.PointerEvent,
+) -> Unit {
+  guard binding.drag is Some(drag) else { return }
+  guard drag.pointer_id == pointer.get_pointer_id() else { return }
+  binding.drag = None
+  if binding.track.has_pointer_capture(drag.pointer_id) {
+    binding.track.release_pointer_capture(drag.pointer_id)
+  }
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_bind_pointer_listeners(
+  binding : ScrollAreaPointerBinding,
+) -> Unit {
+  binding.track.add_event_listener("pointerdown", event => {
+    guard event.to_pointer_event() is Some(pointer) else { return }
+    if pointer.get_button() != 0 || binding.drag is Some(_) {
+      return
+    }
+    let dimensions = scroll_area_dimensions(binding)
+    if dimensions.max <= 0.0 {
+      return
+    }
+    let rect = binding.track.get_bounding_client_rect()
+    let track_size = if dimensions.vertical {
+      rect.get_height()
+    } else {
+      rect.get_width()
+    }
+    let thumb_size = (track_size *
+    dimensions.viewport_size /
+    dimensions.content_size).max(1.0)
+    let travel = (track_size - thumb_size).max(0.0)
+    let current_start = scroll_area_physical_offset(binding, dimensions) /
+      dimensions.max *
+      travel
+    let pointer_position = if dimensions.vertical {
+      pointer.get_client_y().to_double() - rect.get_top()
+    } else {
+      pointer.get_client_x().to_double() - rect.get_left()
+    }
+    let on_thumb = pointer.target().to_element() is Some(target) &&
+      target.is_same_node(binding.thumb.as_node())
+    binding.drag = Some({
+      pointer_id: pointer.get_pointer_id(),
+      grab: if on_thumb {
+        pointer_position - current_start
+      } else {
+        thumb_size / 2.0
+      },
+    })
+    binding.track.set_pointer_capture(pointer.get_pointer_id())
+    scroll_area_move_pointer(binding, pointer)
+  })
+  binding.track.add_event_listener("pointermove", event => {
+    if event.to_pointer_event() is Some(pointer) {
+      scroll_area_move_pointer(binding, pointer)
+    }
+  })
+  let finish : @dom.Listener = event => {
+    if event.to_pointer_event() is Some(pointer) {
+      scroll_area_finish_pointer(binding, pointer)
+    }
+  }
+  binding.track.add_event_listener("pointerup", finish)
+  binding.track.add_event_listener("pointercancel", finish)
+  binding.track.add_event_listener("lostpointercapture", finish)
+  binding.viewport.add_event_listener_with_options(
+    "scroll",
+    _ => scroll_area_notify_position(binding),
+    passive=true,
+  )
+}
+
+///|
+#cfg(target="js")
+fn bind_scroll_area_pointer(
+  id : String,
+  vertical : Bool,
+  notify : (Double, Double, Double) -> Unit,
+) -> Unit {
+  guard ui_element_by_id(id) is Some(root) else { return }
+  scroll_area_prune_pointer_bindings()
+  guard root.query_selector("[data-slot=\"scroll-area-viewport\"]")
+    is Some(viewport) else {
+    return
+  }
+  guard root.query_selector("[data-slot=\"scroll-area-scrollbar\"]")
+    is Some(track) else {
+    return
+  }
+  guard root.query_selector("[data-slot=\"scroll-area-thumb\"]") is Some(thumb) else {
+    return
+  }
+  if scroll_area_pointer_binding(root) is Some(binding) {
+    binding.vertical = vertical
+    binding.notify = notify
+    scroll_area_notify_position(binding)
+    return
+  }
+  let binding : ScrollAreaPointerBinding = {
+    root,
+    viewport,
+    track,
+    thumb,
+    vertical,
+    notify,
+    drag: None,
+  }
+  scroll_area_pointer_bindings.push(binding)
+  scroll_area_bind_pointer_listeners(binding)
+  scroll_area_notify_position(binding)
+}
+
+///|
+fn scroll_area_initial_metrics() -> ScrollAreaMetrics {
+  { offset: 0.0, viewport: 0.0, content: 0.0 }
+}
+
+///|
+fn scroll_area_max_offset(metrics : ScrollAreaMetrics) -> Double {
+  if metrics.content > metrics.viewport {
+    metrics.content - metrics.viewport
+  } else {
+    0.0
+  }
+}
+
+///|
+fn scroll_area_is_scrollable(metrics : ScrollAreaMetrics) -> Bool {
+  scroll_area_max_offset(metrics) > 1.0
+}
+
+///|
+fn scroll_area_thumb_size_hundredths(metrics : ScrollAreaMetrics) -> Int {
+  if !scroll_area_is_scrollable(metrics) || metrics.content <= 0.0 {
+    10000
+  } else {
+    (metrics.viewport / metrics.content * 10000.0)
+    .to_int()
+    .clamp(min=100, max=10000)
+  }
+}
+
+///|
+fn scroll_area_thumb_offset_hundredths(metrics : ScrollAreaMetrics) -> Int {
+  let max_offset = scroll_area_max_offset(metrics)
+  if max_offset <= 0.0 {
+    0
+  } else {
+    let available = 10000 - scroll_area_thumb_size_hundredths(metrics)
+    (metrics.offset.clamp(min=0.0, max=max_offset) /
+    max_offset *
+    available.to_double())
+    .to_int()
+    .clamp(min=0, max=available)
+  }
+}
+
+///|
+fn scroll_area_percent(value : Int) -> String {
+  let clamped = value.clamp(min=0, max=10000)
+  let whole = clamped / 100
+  let fraction = clamped % 100
+  if fraction == 0 {
+    "\{whole}%"
+  } else if fraction < 10 {
+    "\{whole}.0\{fraction}%"
+  } else {
+    "\{whole}.\{fraction}%"
+  }
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_initialize_cmd(
+  root_id : String,
+  viewport_id : String,
+  orientation : SeparatorOrientation,
+  emit : @cmd.Emit[ScrollAreaMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_mount(
+      viewport_id,
+      () => {
+        bind_scroll_area_pointer(root_id, orientation is Vertical, (
+          offset,
+          viewport,
+          content,
+        ) => {
+          scheduler.add(emit(ScrollAreaMeasured({ offset, viewport, content })))
+        })
+      },
+      purpose="scroll-area-initialize",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_viewport_attrs(
+  orientation : SeparatorOrientation,
+  emit : @cmd.Emit[ScrollAreaMsg],
+) -> @html.Attrs {
+  ignore(orientation)
+  ignore(emit)
+  @html.Attrs::build()
+}
+
+///|
+#cfg(target="js")
+fn scroll_area_track_attrs(
+  viewport_id : String,
+  orientation : SeparatorOrientation,
+  emit : @cmd.Emit[ScrollAreaMsg],
+) -> @html.Attrs {
+  ignore(viewport_id)
+  ignore(orientation)
+  ignore(emit)
+  @html.Attrs::build()
+}
+
+///|
+fn[C : @html.IsChildren] render_scroll_area_with_scrollbar(
+  metrics : ScrollAreaMetrics,
+  orientation : SeparatorOrientation,
+  id : String,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  viewport_attrs : @html.Attrs,
+  track_attrs : @html.Attrs,
+  children : C,
+) -> @html.Html {
+  let value = separator_orientation_value(orientation)
+  let scrollable = scroll_area_is_scrollable(metrics)
+  let state = if scrollable { "scrollable" } else { "idle" }
+  let size = scroll_area_percent(scroll_area_thumb_size_hundredths(metrics))
+  let offset = scroll_area_percent(scroll_area_thumb_offset_hundredths(metrics))
+  let viewport_id = "\{id}-viewport"
+  @html.div(
+    id~,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "scroll-area")
+      .data_set("managed", "")
+      .data_set("orientation", value)
+      .data_set("state", state)
+      .data_set("scrollable", ui_bool(scrollable)),
+    style=ui_styles([UiBoxSizing, ScrollAreaManagedRootStyle], style),
+    [
+      @html.div(
+        id=viewport_id,
+        attrs=viewport_attrs
+          .data_set("slot", "scroll-area-viewport")
+          .data_set("orientation", value)
+          .data_set("state", state)
+          .data_set("scroll-offset", "\{metrics.offset}")
+          .data_set("viewport-size", "\{metrics.viewport}")
+          .data_set("content-size", "\{metrics.content}")
+          .tabindex(0),
+        style=[
+          UiBoxSizing,
+          ScrollAreaManagedViewportStyle,
+          if orientation is Vertical {
+            "overflow-y:auto;overflow-x:hidden"
+          } else {
+            "overflow-x:auto;overflow-y:hidden"
+          },
+        ],
+        children,
+      ),
+      @html.div(
+        id="\{id}-scrollbar",
+        attrs=track_attrs
+          .data_set("slot", "scroll-area-scrollbar")
+          .data_set("orientation", value)
+          .data_set("state", state)
+          .data_set("thumb-size", size)
+          .data_set("thumb-offset", offset)
+          .aria_hidden("true"),
+        style=[
+          UiBoxSizing,
+          ScrollAreaManagedTrackStyle,
+          if orientation is Vertical {
+            "top:0;inset-inline-end:0;width:var(--rui-scrollbar-size,0.625rem);height:100%"
+          } else {
+            "inset-inline-start:0;bottom:0;width:100%;height:var(--rui-scrollbar-size,0.625rem)"
+          },
+          if scrollable {
+            "opacity:1;pointer-events:auto;cursor:pointer"
+          } else {
+            "opacity:0;pointer-events:none"
+          },
+        ],
+        @html.div(
+          id="\{id}-thumb",
+          attrs=@html.Attrs::build()
+            .data_set("slot", "scroll-area-thumb")
+            .data_set("orientation", value)
+            .data_set("state", state),
+          style=[
+            UiBoxSizing,
+            ScrollAreaManagedThumbStyle,
+            if orientation is Vertical {
+              "top:\{offset};inset-inline-start:1px;width:calc(100% - 2px);height:\{size}"
+            } else {
+              "top:1px;left:\{offset};width:\{size};height:calc(100% - 2px)"
+            },
+          ],
+          "",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+/// A black-box incremental Scroll Area with a proportional custom scrollbar.
+///
+/// The component measures its viewport after the first render, owns the latest
+/// offset/viewport/content metrics in Rabbita state, and refreshes them on each
+/// native scroll event. Wheel, touch, and keyboard scrolling remain native.
+/// Pointer presses on the track jump the thumb to that position; pressing the
+/// thumb preserves its grab offset and drags with pointer capture until release
+/// or cancellation. Horizontal RTL scrolling is normalized before it enters
+/// component state, so the thumb geometry stays logical across browser modes.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] scroll_area_with_scrollbar(
+  orientation? : SeparatorOrientation = Vertical,
+  id~ : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @rabbita.Val[@html.Html] {
+  let viewport_id = "\{id}-viewport"
+  let (metrics, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        scroll_area_initial_metrics(),
+        scroll_area_initialize_cmd(id, viewport_id, orientation, emit),
+      )
+    },
+    update=(_, message, _) => {
+      (
+        match message {
+          ScrollAreaMeasured(metrics) => metrics
+        },
+        @cmd.none,
+      )
+    },
+  )
+  metrics.view(metrics => {
+    render_scroll_area_with_scrollbar(
+      metrics,
+      orientation,
+      id,
+      class,
+      title,
+      attrs,
+      style,
+      scroll_area_viewport_attrs(orientation, emit),
+      scroll_area_track_attrs(viewport_id, orientation, emit),
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] scroll_area_with_scrollbar(
+  orientation? : SeparatorOrientation = Vertical,
+  id~ : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @rabbita.Val[@html.Html] {
+  @rabbita.Val::constant(
+    render_scroll_area_with_scrollbar(
+      scroll_area_initial_metrics(),
+      orientation,
+      id,
+      class,
+      title,
+      attrs,
+      style,
+      @html.Attrs::build(),
+      @html.Attrs::build(),
+      children,
+    ),
+  )
+}

--- a/rui/scroll_area_wbtest.mbt
+++ b/rui/scroll_area_wbtest.mbt
@@ -1,0 +1,345 @@
+///|
+#warnings("-alert_unstable")
+fn render_scroll_area_html(html : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+}
+
+///|
+#cfg(target="js")
+extern "js" fn install_scroll_area_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_scroll_area_incremental(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_scroll_area_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_scroll_area_incremental(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn scroll_area_assert_contains(
+  actual : String,
+  expected : String,
+) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected rendered HTML to contain `\{expected}`; got `\{actual}`")
+  }
+}
+
+///|
+fn scroll_area_assert_not_contains(
+  actual : String,
+  unexpected : String,
+) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail(
+      "expected rendered HTML not to contain `\{unexpected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+extern "js" fn install_scroll_area_pointer_fixture(
+  id : String,
+  direction : String,
+) -> Unit =
+  #| (id, direction) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const listeners = {}
+  #|   const saved = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own('document'),
+  #|     window: globalThis.window,
+  #|     hadWindow: own('window'),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own('EventTarget'),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own('Node'),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own('HTMLElement'),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own('PointerEvent'),
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class PointerEvent {
+  #|     constructor(init) {
+  #|       Object.assign(this, init)
+  #|       this.button = init.button ?? 0
+  #|       this.defaultPrevented = false
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|   }
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement, PointerEvent })
+  #|   const thumb = new HTMLElement()
+  #|   const viewport = new HTMLElement()
+  #|   Object.assign(viewport, {
+  #|     clientHeight: 100,
+  #|     clientWidth: 100,
+  #|     scrollHeight: 1000,
+  #|     scrollWidth: 1000,
+  #|     scrollTop: 0,
+  #|     scrollLeft: 0,
+  #|     addEventListener: (type, callback) => { listeners[`viewport:${type}`] = callback },
+  #|   })
+  #|   const track = new HTMLElement()
+  #|   Object.assign(track, {
+  #|     addEventListener: (type, callback) => { listeners[`track:${type}`] = callback },
+  #|     getBoundingClientRect: () => ({ left: 0, top: 0, width: 100, height: 100 }),
+  #|     setPointerCapture(pointerId) {
+  #|       this.__capturedPointerId = pointerId
+  #|       fixture.captures += 1
+  #|     },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId !== pointerId) return
+  #|       delete this.__capturedPointerId
+  #|       fixture.releases += 1
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|   })
+  #|   const root = new HTMLElement()
+  #|   Object.assign(root, {
+  #|     querySelector: selector => selector.includes('viewport')
+  #|       ? viewport
+  #|       : selector.includes('scrollbar') ? track : thumb,
+  #|   })
+  #|   const fixture = globalThis.__ruiScrollAreaPointerFixture = {
+  #|     ...saved,
+  #|     direction,
+  #|     listeners,
+  #|     root,
+  #|     track,
+  #|     thumb,
+  #|     viewport,
+  #|     captures: 0,
+  #|     releases: 0,
+  #|   }
+  #|   globalThis.document = { getElementById: value => value === id ? root : null }
+  #|   globalThis.window = {
+  #|     getComputedStyle: () => ({
+  #|       getPropertyValue: name => name === 'direction' ? fixture.direction : '',
+  #|     }),
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn fire_scroll_area_pointer_fixture(
+  horizontal : Bool,
+  target_thumb : Bool,
+) -> Unit =
+  #| (horizontal, targetThumb) => {
+  #|   const fixture = globalThis.__ruiScrollAreaPointerFixture
+  #|   const base = new PointerEvent({
+  #|     button: 0,
+  #|     pointerId: 7,
+  #|     clientX: targetThumb ? 95 : 0,
+  #|     clientY: targetThumb ? 5 : 0,
+  #|     target: targetThumb ? fixture.thumb : fixture.track,
+  #|     currentTarget: fixture.track,
+  #|   })
+  #|   fixture.listeners['track:pointerdown'](base)
+  #|   fixture.listeners['track:pointermove'](new PointerEvent({
+  #|     ...base,
+  #|     clientX: horizontal ? 50 : base.clientX,
+  #|     clientY: horizontal ? base.clientY : 50,
+  #|     target: base.target,
+  #|     currentTarget: fixture.track,
+  #|   }))
+  #|   fixture.listeners['track:pointerup'](base)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn scroll_area_pointer_fixture_value(kind : Int) -> Double =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiScrollAreaPointerFixture
+  #|   if (kind === 0) return fixture.viewport.scrollTop
+  #|   if (kind === 1) return fixture.viewport.scrollLeft
+  #|   if (kind === 2) return fixture.captures
+  #|   return fixture.releases
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn restore_scroll_area_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiScrollAreaPointerFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiScrollAreaPointerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "managed scrollbar thumb drags vertically with pointer capture" {
+  let offset = Ref(0.0)
+  install_scroll_area_pointer_fixture("drag-scroll", "ltr")
+  bind_scroll_area_pointer("drag-scroll", true, (next, _, _) => {
+    offset.val = next
+  })
+  fire_scroll_area_pointer_fixture(false, true)
+  let scroll_top = scroll_area_pointer_fixture_value(0)
+  let captures = scroll_area_pointer_fixture_value(2)
+  let releases = scroll_area_pointer_fixture_value(3)
+  restore_scroll_area_pointer_fixture()
+  assert_eq(offset.val, 450.0)
+  assert_eq(scroll_top, 450.0)
+  assert_eq(captures, 1.0)
+  assert_eq(releases, 1.0)
+}
+
+///|
+#cfg(target="js")
+test "managed horizontal scrollbar normalizes RTL scrollLeft" {
+  let offset = Ref(0.0)
+  install_scroll_area_pointer_fixture("rtl-scroll", "rtl")
+  bind_scroll_area_pointer("rtl-scroll", false, (next, _, _) => {
+    offset.val = next
+  })
+  fire_scroll_area_pointer_fixture(true, false)
+  let scroll_left = scroll_area_pointer_fixture_value(1)
+  restore_scroll_area_pointer_fixture()
+  assert_eq(offset.val, 450.0)
+  assert_eq(scroll_left, -450.0)
+}
+
+///|
+test "scroll area metrics produce a proportional bounded thumb" {
+  let middle : ScrollAreaMetrics = {
+    offset: 450.0,
+    viewport: 100.0,
+    content: 1000.0,
+  }
+  assert_eq(scroll_area_thumb_size_hundredths(middle), 1000)
+  assert_eq(scroll_area_thumb_offset_hundredths(middle), 4500)
+  assert_eq(scroll_area_percent(1000), "10%")
+  assert_eq(scroll_area_percent(5), "0.05%")
+  let past_end : ScrollAreaMetrics = {
+    offset: 5000.0,
+    viewport: 100.0,
+    content: 1000.0,
+  }
+  assert_eq(scroll_area_thumb_offset_hundredths(past_end), 9000)
+  let idle : ScrollAreaMetrics = {
+    offset: 0.0,
+    viewport: 200.0,
+    content: 100.0,
+  }
+  assert_eq(scroll_area_thumb_size_hundredths(idle), 10000)
+  assert_eq(scroll_area_thumb_offset_hundredths(idle), 0)
+}
+
+///|
+test "managed vertical scroll area renders its black-box structure" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render_scroll_area_incremental(() => {
+    scroll_area_with_scrollbar(
+      id="managed-scroll",
+      attrs~,
+      style=["height:12rem", "--rui-scrollbar-size:0.75rem"],
+      @html.p("Scrollable content"),
+    )
+  })
+  scroll_area_assert_contains(html, "id=\"managed-scroll\"")
+  scroll_area_assert_contains(html, "data-slot=\"scroll-area\"")
+  scroll_area_assert_contains(html, "data-managed=\"\"")
+  scroll_area_assert_contains(html, "data-orientation=\"vertical\"")
+  scroll_area_assert_contains(html, "data-state=\"idle\"")
+  scroll_area_assert_contains(html, "data-scrollable=\"false\"")
+  scroll_area_assert_contains(html, "id=\"managed-scroll-viewport\"")
+  scroll_area_assert_contains(html, "data-slot=\"scroll-area-viewport\"")
+  scroll_area_assert_contains(html, "tabindex=\"0\"")
+  scroll_area_assert_contains(html, "outline-offset:2px")
+  scroll_area_assert_contains(html, "overflow-y:auto;overflow-x:hidden")
+  scroll_area_assert_contains(html, "id=\"managed-scroll-scrollbar\"")
+  scroll_area_assert_contains(html, "data-slot=\"scroll-area-scrollbar\"")
+  scroll_area_assert_contains(html, "data-thumb-size=\"100%\"")
+  scroll_area_assert_contains(html, "data-thumb-offset=\"0%\"")
+  scroll_area_assert_contains(html, "aria-hidden=\"true\"")
+  scroll_area_assert_contains(html, "id=\"managed-scroll-thumb\"")
+  scroll_area_assert_contains(html, "data-slot=\"scroll-area-thumb\"")
+  scroll_area_assert_contains(
+    html, "top:0%;inset-inline-start:1px;width:calc(100% - 2px);height:100%",
+  )
+  scroll_area_assert_contains(html, "opacity:0;pointer-events:none")
+  scroll_area_assert_contains(html, "height:12rem;--rui-scrollbar-size:0.75rem")
+  scroll_area_assert_contains(html, ">Scrollable content</p>")
+
+  let original = render_scroll_area_html(@html.div(attrs~, @html.nothing))
+  scroll_area_assert_contains(original, "data-owner=\"caller\"")
+  scroll_area_assert_not_contains(original, "data-slot")
+}
+
+///|
+test "managed horizontal scroll area switches its native axis and thumb" {
+  let html = render_scroll_area_incremental(() => {
+    scroll_area_with_scrollbar(
+      orientation=Horizontal,
+      id="horizontal-scroll",
+      style=["width:20rem"],
+      @html.div("Wide content"),
+    )
+  })
+  scroll_area_assert_contains(html, "data-orientation=\"horizontal\"")
+  scroll_area_assert_contains(html, "overflow-x:auto;overflow-y:hidden")
+  scroll_area_assert_contains(
+    html, "inset-inline-start:0;bottom:0;width:100%;height:var(--rui-scrollbar-size,0.625rem)",
+  )
+  scroll_area_assert_contains(
+    html, "top:1px;left:0%;width:100%;height:calc(100% - 2px)",
+  )
+}
+
+///|
+test "pure scroll area and decorative bar remain unchanged alternatives" {
+  let html = render_scroll_area_html(
+    scroll_area(
+      orientation=Horizontal,
+      id="pure-scroll",
+      style=["width:10rem"],
+      [@html.span("Pure content"), scroll_bar(orientation=Horizontal)],
+    ),
+  )
+  scroll_area_assert_contains(html, "id=\"pure-scroll\"")
+  scroll_area_assert_contains(html, "data-slot=\"scroll-area\"")
+  scroll_area_assert_contains(html, "tabindex=\"0\"")
+  scroll_area_assert_contains(html, "outline-offset:2px")
+  scroll_area_assert_contains(html, "overflow-x:auto;overflow-y:hidden")
+  scroll_area_assert_contains(html, "data-slot=\"scroll-area-scrollbar\"")
+  scroll_area_assert_contains(html, "pointer-events:none")
+  scroll_area_assert_not_contains(html, "data-managed")
+  scroll_area_assert_not_contains(html, "scroll-area-viewport")
+}

--- a/rui/select.mbt
+++ b/rui/select.mbt
@@ -1,0 +1,1328 @@
+///|
+/// One option consumed by the black-box [`select`] component.
+struct SelectOption {
+  value : String
+  label : String
+  disabled : Bool
+}
+
+///|
+pub fn select_option(
+  value~ : String,
+  label~ : String,
+  disabled? : Bool = false,
+) -> SelectOption {
+  { value, label, disabled }
+}
+
+///|
+priv struct SelectModel {
+  open : Bool
+  value : String?
+  active : Int
+  search : String
+  search_generation : Int
+} derive(Eq)
+
+///|
+priv enum SelectMsg {
+  SelectToggle
+  SelectNativeChanged(Bool)
+  SelectMove(Int)
+  SelectHighlight(Int)
+  SelectFirst
+  SelectLast
+  SelectChoose(Int)
+  SelectClose
+  SelectDismiss
+  SelectTypeahead(String)
+  SelectClearTypeahead(Int)
+}
+
+///|
+/// Opaque state handle passed by [`select`] to its compound rendering helpers.
+struct SelectScope {
+  id : String
+  options : Array[SelectOption]
+  model : SelectModel
+  placeholder : String
+  disabled : Bool
+  invalid : Bool
+  required : Bool
+  name : String?
+  side : PopupSide
+  align : PopupAlign
+  side_offset : Int
+  align_offset : Int
+  emit : @cmd.Emit[SelectMsg]
+  content_id : Ref[String]
+  trigger_id : Ref[String]
+}
+
+///|
+const SelectRootStyle : String = "position:relative;display:inline-flex;width:100%;min-width:0"
+
+///|
+const SelectTriggerStyle : String = "display:flex;width:100%;height:2.25rem;min-width:0;align-items:center;justify-content:space-between;gap:0.5rem;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));padding:0.25rem 0.625rem;color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));font-size:0.875rem;line-height:1.25rem;text-align:start;white-space:nowrap;outline-offset:2px;box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));cursor:pointer"
+
+///|
+const SelectContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:flex;width:var(--rui-floating-anchor-width,anchor-size(width));min-width:max(8rem,var(--rui-floating-anchor-width,anchor-size(width)));max-width:var(--rui-floating-available-width,calc(100vw - 1rem));max-height:var(--rui-floating-available-height,calc(100vh - 1rem));transform-origin:var(--rui-floating-transform-origin,center);flex-direction:column;overflow-x:hidden;overflow-y:auto;margin:0;border:1px solid var(--rui-border,oklch(0.922 0 0));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-popover,oklch(1 0 0));padding:0;color:var(--rui-popover-foreground,oklch(0.145 0 0));box-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1),0 4px 6px -4px rgb(0 0 0 / 0.1);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const SelectItemStyle : String = "position:relative;display:flex;width:100%;min-height:2rem;align-items:center;gap:0.5rem;border:0;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent));padding-block:0.375rem;padding-inline:0.5rem 2rem;color:var(--rui-menu-item-fg,var(--rui-menu-item-base-fg,inherit));font:inherit;font-size:0.875rem;line-height:1.25rem;text-align:start;white-space:nowrap;outline:none;cursor:pointer"
+
+///|
+fn select_find_value(options : Array[SelectOption], value : String?) -> Int {
+  if value is Some(value) {
+    for index, option in options {
+      if option.value == value && !option.disabled {
+        return index
+      }
+    }
+  }
+  -1
+}
+
+///|
+fn select_first_enabled(options : Array[SelectOption], reverse : Bool) -> Int {
+  if reverse {
+    let mut index = options.length() - 1
+    while index >= 0 {
+      if !options[index].disabled {
+        return index
+      }
+      index -= 1
+    }
+  } else {
+    for index, option in options {
+      if !option.disabled {
+        return index
+      }
+    }
+  }
+  -1
+}
+
+///|
+fn select_next_enabled(
+  options : Array[SelectOption],
+  current : Int,
+  direction : Int,
+) -> Int {
+  let length = options.length()
+  if length == 0 {
+    return -1
+  }
+  let mut index = current
+  let mut remaining = length
+  while remaining > 0 {
+    index = if direction < 0 {
+      if index <= 0 {
+        length - 1
+      } else {
+        index - 1
+      }
+    } else if index < 0 || index >= length - 1 {
+      0
+    } else {
+      index + 1
+    }
+    if !options[index].disabled {
+      return index
+    }
+    remaining -= 1
+  }
+  -1
+}
+
+///|
+fn select_typeahead_index(
+  options : Array[SelectOption],
+  current : Int,
+  search : String,
+) -> Int {
+  if search == "" || options.length() == 0 {
+    return -1
+  }
+  let needle = search.to_lower()
+  let mut offset = 1
+  while offset <= options.length() {
+    let start = if current < 0 { -1 } else { current }
+    let index = (start + offset) % options.length()
+    let option = options[index]
+    if !option.disabled && option.label.to_lower().has_prefix(needle) {
+      return index
+    }
+    offset += 1
+  }
+  -1
+}
+
+///|
+fn select_typeahead_search(current : String, key : String) -> String {
+  let normalized_key = key.to_lower()
+  if current == normalized_key {
+    normalized_key
+  } else {
+    current + normalized_key
+  }
+}
+
+///|
+fn select_label_for(scope : SelectScope) -> String {
+  let index = select_find_value(scope.options, scope.model.value)
+  if index >= 0 {
+    scope.options[index].label
+  } else {
+    scope.placeholder
+  }
+}
+
+///|
+fn select_item_id(scope : SelectScope, index : Int) -> String {
+  "\{scope.id}-item-\{index}"
+}
+
+///|
+fn ui_listbox_run_open_sequence(
+  set_layer : () -> Unit,
+  focus : (() -> Unit)?,
+) -> Unit {
+  set_layer()
+  if focus is Some(focus) {
+    focus()
+  }
+}
+
+///|
+#cfg(target="js")
+fn find_listbox_content_id(root_id : String, slot : String) -> String {
+  guard ui_element_by_id(root_id + "-root") is Some(root) else { return "" }
+  guard ui_find_element(root.query_selector_all("[data-slot]"), element => {
+      element.get_attribute("data-slot").unwrap_or("") == slot
+    })
+    is Some(content) else {
+    return ""
+  }
+  content.get_attribute("id").unwrap_or("")
+}
+
+///|
+#cfg(target="js")
+fn sync_select_trigger_id(root_id : String, content_id : String) -> Unit {
+  guard ui_element_by_id(root_id + "-root") is Some(root) else { return }
+  guard ui_element_by_id(content_id) is Some(content) else { return }
+  guard ui_find_element(root.query_selector_all("[data-slot]"), element => {
+      element.get_attribute("data-slot").unwrap_or("") == "select-trigger"
+    })
+    is Some(trigger) else {
+    return
+  }
+  let trigger_id = trigger.get_attribute("id").unwrap_or("")
+  if trigger_id != "" {
+    content.set_attribute("data-trigger-id", trigger_id)
+  }
+}
+
+///|
+#cfg(target="js")
+fn ui_listbox_set_open_now(
+  root_id : String,
+  slot : String,
+  open : Bool,
+) -> Unit {
+  let content_id = find_listbox_content_id(root_id, slot)
+  if content_id != "" {
+    ignore(set_floating_open(content_id, open))
+    if open {
+      position_floating(content_id)
+    }
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_listbox_set_open_now(
+  root_id : String,
+  slot : String,
+  open : Bool,
+) -> Unit {
+  ignore((root_id, slot, open))
+}
+
+///|
+#cfg(target="js")
+fn ui_listbox_bind_sync_cmd(
+  root_id : String,
+  slot : String,
+  sync : @cmd.Emit[Bool],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    let content_id = find_listbox_content_id(root_id, slot)
+    if content_id != "" {
+      bind_floating_sync(content_id, open => scheduler.add(sync(open)))
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn ui_listbox_bind_sync_cmd(
+  root_id : String,
+  slot : String,
+  sync : @cmd.Emit[Bool],
+) -> @cmd.Cmd {
+  ignore((root_id, slot, sync))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn focus_select_part(root_id : String, slot : String, value : String) -> Unit {
+  // A click focuses its trigger as the browser's default action after the
+  // handler returns. Move focus on the following frame so native activation
+  // cannot overwrite the listbox focus target.
+  ui_after_request_frame(() => {
+    guard ui_element_by_id(root_id + "-root") is Some(root) else { return }
+    let candidates = root
+      .query_selector_all("[data-slot]")
+      .filter(element => {
+        element.get_attribute("data-slot").unwrap_or("") == slot
+      })
+    let target = if slot == "select-item" {
+      ui_find_element(candidates, element => {
+        element.get_attribute("data-value").unwrap_or("") == value
+      })
+    } else {
+      candidates.get(0)
+    }
+    if target is Some(target) {
+      ui_focus_element_without_scroll(target)
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn select_popup_cmd(
+  id : String,
+  open : Bool?,
+  focus_slot : String?,
+  focus_value : String,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    let content_id = find_listbox_content_id(id, "select-content")
+    if content_id != "" {
+      // Resolve the rendered trigger instead of assuming the default id. This
+      // also works when compound parts are evaluated in a different order.
+      sync_select_trigger_id(id, content_id)
+    }
+    let set_layer = () => {
+      if open is Some(open) {
+        ui_listbox_set_open_now(id, "select-content", open)
+      }
+    }
+    let focus : (() -> Unit)? = if focus_slot is Some(slot) {
+      Some(() => focus_select_part(id, slot, focus_value))
+    } else {
+      None
+    }
+    ui_listbox_run_open_sequence(set_layer, focus)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn select_popup_cmd(
+  id : String,
+  open : Bool?,
+  focus_slot : String?,
+  focus_value : String,
+) -> @cmd.Cmd {
+  ignore((id, open, focus_slot, focus_value))
+  @cmd.none
+}
+
+///|
+fn select_open_commands(scope : SelectScope, open : Bool) -> @cmd.Cmd {
+  if open &&
+    scope.model.active >= 0 &&
+    scope.model.active < scope.options.length() {
+    select_popup_cmd(
+      scope.id,
+      Some(true),
+      Some("select-item"),
+      scope.options[scope.model.active].value,
+    )
+  } else if open {
+    select_popup_cmd(scope.id, Some(true), None, "")
+  } else {
+    select_popup_cmd(scope.id, Some(false), Some("select-trigger"), "")
+  }
+}
+
+///|
+#cfg(target="js")
+fn select_root_keydown(
+  scope : SelectScope,
+  event : @dom.KeyboardEvent,
+) -> @cmd.Cmd {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.is_composing() {
+    return @cmd.none
+  }
+  guard event.current_target().to_option() is Some(current_target) &&
+    current_target.to_element() is Some(root) else {
+    return @cmd.none
+  }
+  guard event.target().to_element() is Some(event_target) else {
+    return @cmd.none
+  }
+  guard event_target.closest(
+      "[data-slot=\"select-trigger\"],[data-slot=\"select-item\"]",
+    )
+    is Some(target) &&
+    target.closest("[data-slot=\"select\"]") is Some(owner) &&
+    owner.is_same_node(root.as_node()) else {
+    return @cmd.none
+  }
+  let key = event.key()
+  let slot = target.get_attribute("data-slot").unwrap_or("")
+  if key == "Tab" && scope.model.open {
+    return (scope.emit)(SelectDismiss)
+  }
+  let message : SelectMsg? = match key {
+    "ArrowDown" => Some(SelectMove(1))
+    "ArrowUp" => Some(SelectMove(-1))
+    "Home" => Some(SelectFirst)
+    "End" => Some(SelectLast)
+    "Escape" => Some(SelectClose)
+    "Enter" if slot == "select-item" => Some(SelectChoose(-1))
+    " " if slot == "select-item" && scope.model.search == "" =>
+      Some(SelectChoose(-1))
+    "Enter" | " " if slot == "select-trigger" => Some(SelectToggle)
+    _ => if key.length() == 1 { Some(SelectTypeahead(key)) } else { None }
+  }
+  if message is Some(message) {
+    event.prevent_default()
+    (scope.emit)(message)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn select_bind_root_keyboard(attrs : @html.Attrs, scope : SelectScope) -> Unit {
+  ignore(attrs.on_keydown(event => select_root_keydown(scope, event)))
+}
+
+///|
+#cfg(not(target="js"))
+fn select_bind_root_keyboard(attrs : @html.Attrs, scope : SelectScope) -> Unit {
+  ignore((attrs, scope))
+}
+
+///|
+fn select_notify_bool(notify : @cmd.Emit[Bool]?, value : Bool) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn select_notify_value(notify : @cmd.Emit[String]?, value : String) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+fn select_resolve_active(
+  options : Array[SelectOption],
+  model : SelectModel,
+) -> Int {
+  if model.active >= 0 &&
+    model.active < options.length() &&
+    !options[model.active].disabled {
+    model.active
+  } else {
+    let selected = select_find_value(options, model.value)
+    if selected >= 0 {
+      selected
+    } else {
+      select_first_enabled(options, false)
+    }
+  }
+}
+
+///|
+fn select_scope_root_attrs(
+  scope : SelectScope,
+  attrs : @html.Attrs?,
+) -> @html.Attrs {
+  let root_attrs = popup_state_attrs(attrs, "select", scope.model.open)
+    .data_set("value", scope.model.value.unwrap_or(""))
+    .data_set("searching", ui_bool(scope.model.search != ""))
+  if scope.disabled {
+    ignore(root_attrs.data_set("disabled", "").aria_disabled("true"))
+  }
+  if scope.invalid {
+    ignore(root_attrs.data_set("invalid", "").aria_invalid("true"))
+  }
+  select_bind_root_keyboard(root_attrs, scope)
+  root_attrs
+}
+
+///|
+pub fn select_value(
+  scope~ : SelectScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  prefix? : @html.Html,
+) -> @html.Html {
+  let empty = scope.model.value is None
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "select-value")
+      .data_set("placeholder", ui_bool(empty)),
+    style=ui_styles(
+      [
+        "display:flex;min-width:0;flex:1;align-items:center;gap:0.375rem;overflow:hidden;text-overflow:ellipsis",
+        if empty {
+          "color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    [
+      if prefix is Some(prefix) {
+        prefix
+      } else {
+        @html.nothing
+      },
+      @html.span(
+        style=["min-width:0;overflow:hidden;text-overflow:ellipsis"],
+        select_label_for(scope),
+      ),
+    ],
+  )
+}
+
+///|
+pub fn select_trigger(
+  scope~ : SelectScope,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let resolved_id = id.unwrap_or("\{scope.id}-trigger")
+  scope.trigger_id.val = resolved_id
+  let trigger_attrs = popup_state_attrs(
+      attrs,
+      "select-trigger",
+      scope.model.open,
+    )
+    .role("combobox")
+    .aria_haspopup("listbox")
+    .aria_expanded(ui_bool(scope.model.open))
+    .aria_invalid(ui_bool(scope.invalid))
+  if scope.model.open {
+    ignore(trigger_attrs.aria_controls(scope.content_id.val))
+  }
+  if aria_label is Some(label) {
+    ignore(trigger_attrs.aria_label(label))
+  }
+  if !scope.disabled {
+    ignore(trigger_attrs.on_click(_ => (scope.emit)(SelectToggle)))
+  }
+  @html.button(
+    id=resolved_id,
+    class?,
+    title?,
+    type_="button",
+    disabled=scope.disabled,
+    attrs=trigger_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        SelectTriggerStyle,
+        input_invalid_style(scope.invalid),
+        ui_disabled_style(scope.disabled),
+        popup_anchor_style(resolved_id),
+      ],
+      style,
+    ),
+    [
+      select_value(scope~),
+      @html.span(
+        attrs=@html.Attrs::build().aria_hidden("true"),
+        style=[
+          "display:inline-flex;flex:none;align-items:center;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1",
+        ],
+        ui_chevron_down_icon(),
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] select_group(
+  label_id? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let group_attrs = ui_attrs(attrs)
+    .role("group")
+    .data_set("slot", "select-group")
+  if label_id is Some(label_id) {
+    ignore(group_attrs.aria_labelledby(label_id))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=group_attrs,
+    style=ui_styles(["padding:0.125rem 0"], style),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] select_label(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "select-label"),
+    style=ui_styles(
+      [
+        "padding:0.375rem 0.5rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;line-height:1rem;font-weight:500",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] select_item(
+  scope~ : SelectScope,
+  value~ : String,
+  disabled? : Bool,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let mut index = -1
+  for option_index, option in scope.options {
+    if option.value == value && index < 0 {
+      index = option_index
+    }
+  }
+  let option_disabled = if disabled is Some(disabled) {
+    disabled
+  } else if index >= 0 {
+    scope.options[index].disabled
+  } else {
+    false
+  }
+  let selected = scope.model.value is Some(current) && current == value
+  let active = scope.model.open && index >= 0 && scope.model.active == index
+  let item_attrs = ui_attrs(attrs)
+    .role("option")
+    .aria_selected(ui_bool(selected))
+    .aria_disabled(ui_bool(option_disabled))
+    .data_set("slot", "select-item")
+    .data_set("value", value)
+    .data_set("state", if selected { "checked" } else { "unchecked" })
+    .data_set("highlighted", ui_bool(active))
+    .tabindex(if active { 0 } else { -1 })
+  if option_disabled {
+    ignore(item_attrs.data_set("disabled", ""))
+  }
+  if !option_disabled && index >= 0 {
+    ignore(item_attrs.on_click(_ => (scope.emit)(SelectChoose(index))))
+    ignore(item_attrs.on_mouseenter(_ => (scope.emit)(SelectHighlight(index))))
+  }
+  @html.button(
+    id=id.unwrap_or(if index >= 0 { select_item_id(scope, index) } else { "" }),
+    class?,
+    title?,
+    type_="button",
+    disabled=option_disabled,
+    attrs=item_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTransition,
+        SelectItemStyle,
+        if active {
+          "--rui-menu-item-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-menu-item-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+        } else {
+          ""
+        },
+        ui_disabled_visual_style(option_disabled),
+      ],
+      style,
+    ),
+    [
+      @html.span(
+        style=["min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis"],
+        children,
+      ),
+      if selected {
+        @html.span(
+          attrs=@html.Attrs::build()
+            .aria_hidden("true")
+            .data_set("slot", "select-item-indicator"),
+          style=[
+            "position:absolute;inset-inline-end:0.5rem;display:inline-flex;width:1rem;height:1rem;align-items:center;justify-content:center",
+          ],
+          ui_check_icon(),
+        )
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+pub fn select_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).role("separator").data_set("slot", "select-separator"),
+    style=ui_styles(
+      [
+        "height:1px;margin:0.25rem -0.25rem;background:var(--rui-border,oklch(0.922 0 0));pointer-events:none",
+      ],
+      style,
+    ),
+    "",
+  )
+}
+
+///|
+fn select_scroll_button(
+  scope : SelectScope,
+  direction : Int,
+  slot : String,
+  label : String,
+  attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let button_attrs = ui_attrs(attrs)
+    .aria_label(label)
+    .data_set("slot", slot)
+    .tabindex(-1)
+    .on_click(_ => (scope.emit)(SelectMove(direction)))
+  @html.button(
+    type_="button",
+    attrs=button_attrs,
+    style=ui_styles(
+      [
+        "display:flex;width:100%;height:1.5rem;align-items:center;justify-content:center;border:0;background:var(--rui-popover,white);color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.75rem;cursor:default",
+      ],
+      style,
+    ),
+    if direction < 0 {
+      ui_chevron_up_icon()
+    } else {
+      ui_chevron_down_icon()
+    },
+  )
+}
+
+///|
+pub fn select_scroll_up_button(
+  scope~ : SelectScope,
+  label? : String = "Scroll up",
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  select_scroll_button(
+    scope, -1, "select-scroll-up-button", label, attrs, style,
+  )
+}
+
+///|
+pub fn select_scroll_down_button(
+  scope~ : SelectScope,
+  label? : String = "Scroll down",
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  select_scroll_button(
+    scope, 1, "select-scroll-down-button", label, attrs, style,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] select_content(
+  scope~ : SelectScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let resolved_id = id.unwrap_or("\{scope.id}-content")
+  scope.content_id.val = resolved_id
+  let content_attrs = popup_state_attrs(
+      attrs,
+      "select-content",
+      scope.model.open,
+    )
+    .popover("auto")
+    .role("listbox")
+    .tabindex(-1)
+    .aria_required(ui_bool(scope.required))
+    .aria_invalid(ui_bool(scope.invalid))
+    .data_set("trigger-id", scope.trigger_id.val)
+    .data_set("requested-side", popup_side_value(scope.side))
+    .data_set("requested-align", popup_align_value(scope.align))
+    .data_set("side", popup_side_value(scope.side))
+    .data_set("align", popup_align_value(scope.align))
+    .data_set("side-offset", "\{scope.side_offset}")
+    .data_set("align-offset", "\{scope.align_offset}")
+  @html.div(
+    id=resolved_id,
+    class?,
+    title?,
+    attrs=content_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        SelectContentStyle,
+        PopupTransition100Style,
+        popup_floating_anchor_style(
+          scope.trigger_id.val,
+          scope.side,
+          scope.align,
+          scope.side_offset,
+          scope.align_offset,
+        ),
+        popup_state_style(scope.model.open),
+      ],
+      style,
+    ),
+    @html.div(
+      attrs=@html.Attrs::build().data_set("slot", "select-viewport"),
+      style=["min-height:0;overflow-y:auto;padding:0.25rem"],
+      children,
+    ),
+  )
+}
+
+///|
+fn select_default_view(scope : SelectScope) -> @html.Html {
+  let items : Array[@html.Html] = []
+  for option in scope.options {
+    items.push(select_item(scope~, value=option.value, option.label))
+  }
+  @html.fragment([select_trigger(scope~), select_content(scope~, items)])
+}
+
+///|
+fn select_render(
+  scope : SelectScope,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  render : ((SelectScope) -> @html.Html)?,
+) -> @html.Html {
+  let body = if render is Some(render) {
+    // Compound renderers are pure. The discovery pass lets a custom Content
+    // id participate in Trigger's aria-controls even when Trigger is declared
+    // first, matching the two-pass Command catalog.
+    ignore(render(scope))
+    render(scope)
+  } else {
+    select_default_view(scope)
+  }
+  let hidden_control = if scope.name is Some(name) {
+    @html.input(
+      input_type=@html.Hidden,
+      name~,
+      value=scope.model.value.unwrap_or(""),
+      attrs=@html.Attrs::build()
+        .disabled(scope.disabled)
+        .data_set("slot", "select-hidden-input")
+        .aria_hidden("true"),
+    )
+  } else {
+    @html.nothing
+  }
+  @html.span(
+    id="\{scope.id}-root",
+    class?,
+    title?,
+    attrs=select_scope_root_attrs(scope, attrs),
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, SelectRootStyle],
+      style,
+    ),
+    [hidden_control, body],
+  )
+}
+
+///|
+#cfg(target="js")
+pub fn select(
+  id~ : String,
+  options~ : Array[SelectOption],
+  default_value? : String,
+  default_open? : Bool = false,
+  placeholder? : String = "Select an option",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  required? : Bool = false,
+  name? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  on_value_change? : @cmd.Emit[String],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render? : (SelectScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let selected = select_find_value(options, default_value)
+  let initial_value = if selected >= 0 {
+    Some(options[selected].value)
+  } else {
+    None
+  }
+  let initial_active = if selected >= 0 {
+    selected
+  } else {
+    select_first_enabled(options, false)
+  }
+  let initial : SelectModel = {
+    open: default_open && !disabled,
+    value: initial_value,
+    active: initial_active,
+    search: "",
+    search_generation: 0,
+  }
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        initial,
+        @cmd.batch([
+          ui_listbox_bind_sync_cmd(
+            id,
+            "select-content",
+            emit.map(value => SelectNativeChanged(value)),
+          ),
+          if initial.open {
+            select_popup_cmd(id, Some(true), None, "")
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(emit, message, current) => {
+      let base_scope : SelectScope = {
+        id,
+        options,
+        model: current,
+        placeholder,
+        disabled,
+        invalid,
+        required,
+        name,
+        side,
+        align,
+        side_offset,
+        align_offset,
+        emit,
+        content_id: Ref("\{id}-content"),
+        trigger_id: Ref("\{id}-trigger"),
+      }
+      match message {
+        SelectToggle =>
+          if disabled {
+            (current, @cmd.none)
+          } else {
+            let open = !current.open
+            let active = select_resolve_active(options, current)
+            let next = { ..current, open, active }
+            let next_scope = { ..base_scope, model: next }
+            (
+              next,
+              @cmd.batch([
+                select_open_commands(next_scope, open),
+                select_notify_bool(on_open_change, open),
+              ]),
+            )
+          }
+        SelectNativeChanged(open) =>
+          if current.open == open {
+            (current, @cmd.none)
+          } else if open {
+            let active = select_resolve_active(options, current)
+            (
+              { ..current, open: true, active },
+              @cmd.batch([
+                select_notify_bool(on_open_change, true),
+                if active >= 0 && active < options.length() {
+                  select_popup_cmd(
+                    id,
+                    None,
+                    Some("select-item"),
+                    options[active].value,
+                  )
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          } else {
+            (
+              { ..current, open: false },
+              select_notify_bool(on_open_change, false),
+            )
+          }
+        SelectMove(direction) => {
+          let active = if !current.open {
+            let selected = select_find_value(options, current.value)
+            if selected >= 0 {
+              selected
+            } else {
+              select_first_enabled(options, direction < 0)
+            }
+          } else {
+            select_next_enabled(options, current.active, direction)
+          }
+          let open = true
+          let next = { ..current, open, active }
+          (
+            next,
+            @cmd.batch([
+              if active >= 0 && active < options.length() {
+                select_popup_cmd(
+                  id,
+                  Some(true),
+                  Some("select-item"),
+                  options[active].value,
+                )
+              } else {
+                select_popup_cmd(id, Some(true), None, "")
+              },
+              if current.open {
+                @cmd.none
+              } else {
+                select_notify_bool(on_open_change, true)
+              },
+            ]),
+          )
+        }
+        SelectHighlight(index) =>
+          if !current.open ||
+            index < 0 ||
+            index >= options.length() ||
+            options[index].disabled {
+            (current, @cmd.none)
+          } else if current.active == index {
+            (current, @cmd.none)
+          } else {
+            ({ ..current, active: index }, @cmd.none)
+          }
+        SelectFirst => {
+          let active = select_first_enabled(options, false)
+          let opened = !current.open
+          (
+            { ..current, open: true, active },
+            @cmd.batch([
+              if active >= 0 && active < options.length() {
+                select_popup_cmd(
+                  id,
+                  Some(true),
+                  Some("select-item"),
+                  options[active].value,
+                )
+              } else {
+                select_popup_cmd(id, Some(true), None, "")
+              },
+              if opened {
+                select_notify_bool(on_open_change, true)
+              } else {
+                @cmd.none
+              },
+            ]),
+          )
+        }
+        SelectLast => {
+          let active = select_first_enabled(options, true)
+          let opened = !current.open
+          (
+            { ..current, open: true, active },
+            @cmd.batch([
+              if active >= 0 && active < options.length() {
+                select_popup_cmd(
+                  id,
+                  Some(true),
+                  Some("select-item"),
+                  options[active].value,
+                )
+              } else {
+                select_popup_cmd(id, Some(true), None, "")
+              },
+              if opened {
+                select_notify_bool(on_open_change, true)
+              } else {
+                @cmd.none
+              },
+            ]),
+          )
+        }
+        SelectChoose(requested) => {
+          let index = if requested < 0 { current.active } else { requested }
+          if index < 0 || index >= options.length() || options[index].disabled {
+            (current, @cmd.none)
+          } else {
+            let option = options[index]
+            let changed = current.value != Some(option.value)
+            (
+              {
+                ..current,
+                open: false,
+                value: Some(option.value),
+                active: index,
+              },
+              @cmd.batch([
+                select_popup_cmd(id, Some(false), Some("select-trigger"), ""),
+                select_notify_bool(on_open_change, false),
+                if changed {
+                  select_notify_value(on_value_change, option.value)
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        }
+        SelectClose =>
+          if current.open {
+            (
+              { ..current, open: false },
+              @cmd.batch([
+                select_popup_cmd(id, Some(false), Some("select-trigger"), ""),
+                select_notify_bool(on_open_change, false),
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        SelectDismiss =>
+          if current.open {
+            (
+              { ..current, open: false },
+              @cmd.batch([
+                select_popup_cmd(id, Some(false), None, ""),
+                select_notify_bool(on_open_change, false),
+              ]),
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        SelectTypeahead(key) => {
+          let search = select_typeahead_search(current.search, key)
+          let search_start = if current.open {
+            current.active
+          } else {
+            select_find_value(options, current.value)
+          }
+          let matched = select_typeahead_index(options, search_start, search)
+          let active = if matched >= 0 { matched } else { current.active }
+          let generation = current.search_generation + 1
+          if current.open {
+            (
+              { ..current, active, search, search_generation: generation },
+              @cmd.batch([
+                if matched >= 0 {
+                  select_popup_cmd(
+                    id,
+                    Some(true),
+                    Some("select-item"),
+                    options[matched].value,
+                  )
+                } else {
+                  @cmd.none
+                },
+                @cmd.delay(emit(SelectClearTypeahead(generation)), 700),
+              ]),
+            )
+          } else if matched >= 0 {
+            let option = options[matched]
+            let changed = current.value != Some(option.value)
+            (
+              {
+                ..current,
+                value: Some(option.value),
+                active: matched,
+                search,
+                search_generation: generation,
+              },
+              @cmd.batch([
+                if changed {
+                  select_notify_value(on_value_change, option.value)
+                } else {
+                  @cmd.none
+                },
+                @cmd.delay(emit(SelectClearTypeahead(generation)), 700),
+              ]),
+            )
+          } else {
+            (
+              { ..current, search, search_generation: generation },
+              @cmd.delay(emit(SelectClearTypeahead(generation)), 700),
+            )
+          }
+        }
+        SelectClearTypeahead(generation) =>
+          if generation == current.search_generation {
+            ({ ..current, search: "" }, @cmd.none)
+          } else {
+            (current, @cmd.none)
+          }
+      }
+    },
+  )
+  model.view(model => {
+    let scope : SelectScope = {
+      id,
+      options,
+      model,
+      placeholder,
+      disabled,
+      invalid,
+      required,
+      name,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      emit,
+      content_id: Ref("\{id}-content"),
+      trigger_id: Ref("\{id}-trigger"),
+    }
+    select_render(scope, class, title, attrs, style, render)
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn select(
+  id~ : String,
+  options~ : Array[SelectOption],
+  default_value? : String,
+  default_open? : Bool = false,
+  placeholder? : String = "Select an option",
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  required? : Bool = false,
+  name? : String,
+  side? : PopupSide = Bottom,
+  align? : PopupAlign = Start,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  on_value_change? : @cmd.Emit[String],
+  on_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  render? : (SelectScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_change, on_open_change))
+  let selected = select_find_value(options, default_value)
+  let model : SelectModel = {
+    open: default_open && !disabled,
+    value: if selected >= 0 {
+      Some(options[selected].value)
+    } else {
+      None
+    },
+    active: if selected >= 0 {
+      selected
+    } else {
+      select_first_enabled(options, false)
+    },
+    search: "",
+    search_generation: 0,
+  }
+  let scope : SelectScope = {
+    id,
+    options,
+    model,
+    placeholder,
+    disabled,
+    invalid,
+    required,
+    name,
+    side,
+    align,
+    side_offset,
+    align_offset,
+    emit: @cmd.Emit(_ => @cmd.none),
+    content_id: Ref("\{id}-content"),
+    trigger_id: Ref("\{id}-trigger"),
+  }
+  @rabbita.Val::constant(
+    select_render(scope, class, title, attrs, style, render),
+  )
+}

--- a/rui/select_combobox_test.mbt
+++ b/rui/select_combobox_test.mbt
@@ -1,0 +1,355 @@
+///|
+test "select owns incremental value and listbox state" {
+  let options = [
+    @rui.select_option(value="alpha", label="Alpha"),
+    @rui.select_option(value="beta", label="Beta"),
+    @rui.select_option(value="gamma", label="Gamma", disabled=true),
+  ]
+  let html = render_incremental(() => {
+    @rui.select(
+      id="project-select",
+      options~,
+      default_value="beta",
+      default_open=true,
+      name="project",
+      style=["max-width:20rem"],
+    )
+  })
+  assert_contains(html, "data-slot=\"select\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-value=\"beta\"")
+  assert_contains(html, "data-slot=\"select-hidden-input\"")
+  assert_contains(html, "name=\"project\"")
+  assert_contains(html, "value=\"beta\"")
+  assert_contains(html, "role=\"listbox\"")
+  assert_contains(html, "role=\"combobox\"")
+  assert_contains(
+    html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)))",
+  )
+  assert_contains(
+    html, "border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)))",
+  )
+  assert_contains(html, "aria-controls=\"project-select-content\"")
+  assert_contains(html, "id=\"project-select-content\"")
+  assert_contains(html, "role=\"option\"")
+  assert_contains(html, "aria-selected=\"true\"")
+  assert_contains(html, "aria-disabled=\"true\"")
+  assert_contains(html, "data-slot=\"select-item-indicator\"")
+  assert_contains(
+    html, "background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent))",
+  )
+  assert_contains(html, "--rui-menu-item-base-bg:var(--rui-accent")
+  assert_contains(html, "popover=\"auto\"")
+  assert_contains(html, "anchor-name:--rui-anchor_")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_contains(html, "position-area:bottom span-x-end")
+  assert_not_contains(html, "-10000px")
+  assert_contains(html, "max-width:20rem")
+}
+
+///|
+test "select compound API shares the opaque internal scope" {
+  let options = [
+    @rui.select_option(value="one", label="One"),
+    @rui.select_option(value="two", label="Two"),
+  ]
+  let html = render_incremental(() => {
+    @rui.select(
+      id="custom-select",
+      options~,
+      default_value="one",
+      default_open=true,
+      render=scope => {
+        @html.div([
+          @rui.select_trigger(scope~, style=["background:rebeccapurple"]),
+          @rui.select_content(scope~, id="numbers-popup", [
+            @rui.select_scroll_up_button(scope~),
+            @rui.select_group([
+              @rui.select_label("Numbers"),
+              @rui.select_item(scope~, value="one", "One"),
+              @rui.select_separator(),
+              @rui.select_item(scope~, value="two", "Two"),
+            ]),
+            @rui.select_scroll_down_button(scope~),
+          ]),
+        ])
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"select-trigger\"")
+  assert_contains(html, "data-slot=\"select-content\"")
+  assert_contains(html, "aria-controls=\"numbers-popup\"")
+  assert_contains(html, "id=\"numbers-popup\"")
+  assert_contains(html, "data-slot=\"select-group\"")
+  assert_contains(html, "data-slot=\"select-label\"")
+  assert_contains(html, "data-slot=\"select-separator\"")
+  assert_contains(html, "data-slot=\"select-scroll-up-button\"")
+  assert_contains(html, "data-slot=\"select-scroll-down-button\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "cursor:default")
+  assert_contains(html, "background:rebeccapurple")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+}
+
+///|
+test "combobox renders filtered-selection primitives from internal state" {
+  let options = [
+    @rui.combobox_option(value="moonbit", label="MoonBit"),
+    @rui.combobox_option(value="rabbita", label="Rabbita"),
+    @rui.combobox_option(value="vega", label="Vega", disabled=true),
+  ]
+  let html = render_incremental(() => {
+    @rui.combobox(
+      id="framework-combobox",
+      options~,
+      default_value="rabbita",
+      default_open=true,
+      name="framework",
+      invalid=true,
+    )
+  })
+  assert_contains(html, "data-slot=\"combobox\"")
+  assert_contains(html, "data-state=\"open\"")
+  assert_contains(html, "data-invalid=\"\"")
+  assert_contains(html, "data-slot=\"combobox-control\"")
+  assert_contains(
+    html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)))",
+  )
+  assert_contains(
+    html, "border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)))",
+  )
+  assert_contains(html, "data-slot=\"combobox-input\"")
+  assert_contains(html, "role=\"combobox\"")
+  assert_contains(html, "aria-expanded=\"true\"")
+  assert_contains(html, "aria-haspopup=\"listbox\"")
+  assert_contains(html, "aria-controls=\"framework-combobox-content\"")
+  assert_contains(html, "id=\"framework-combobox-input\"")
+  assert_contains(html, "id=\"framework-combobox-content\"")
+  assert_contains(html, "data-trigger-id=\"framework-combobox-control\"")
+  assert_contains(html, "anchor-name:--rui-anchor_")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_not_contains(html, "-10000px")
+  assert_not_contains(html, "aria-activedescendant")
+  assert_not_contains(html, "tabindex=\"0\"")
+  assert_contains(html, "value=\"Rabbita\"")
+  assert_contains(html, "data-slot=\"combobox-content\"")
+  assert_contains(html, "role=\"listbox\"")
+  assert_contains(html, "data-slot=\"combobox-item\"")
+  assert_contains(
+    html, "background:var(--rui-menu-item-bg,var(--rui-menu-item-base-bg,transparent))",
+  )
+  assert_contains(html, "aria-selected=\"true\"")
+  assert_contains(html, "data-slot=\"combobox-item-indicator\"")
+  assert_contains(html, "name=\"framework\"")
+  assert_contains(html, "value=\"rabbita\"")
+  assert_contains(html, "data-slot=\"combobox-clear\"")
+  assert_not_contains(html, "data-slot=\"combobox-trigger\"")
+  assert_contains(html, "data-size=\"icon-xs\"")
+  assert_contains(html, "tabindex=\"-1\"")
+}
+
+///|
+test "empty default combobox exposes one centered icon trigger" {
+  let html = render_incremental(() => {
+    @rui.combobox(id="empty-framework-combobox", options=[
+      @rui.combobox_option(value="moonbit", label="MoonBit"),
+      @rui.combobox_option(value="rabbita", label="Rabbita"),
+    ])
+  })
+  assert_not_contains(html, "data-slot=\"combobox-clear\"")
+  assert_contains(html, "data-slot=\"combobox-trigger\"")
+  assert_contains(html, "data-variant=\"ghost\"")
+  assert_contains(html, "data-size=\"icon-xs\"")
+  assert_contains(html, "aria-label=\"Toggle options\"")
+  assert_contains(html, "aria-haspopup=\"listbox\"")
+  assert_contains(html, "aria-expanded=\"false\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "width:1.5rem;height:1.5rem")
+  assert_contains(html, "data-slot=\"combobox-trigger-icon\"")
+  assert_contains(html, "viewBox=\"0 0 24 24\"")
+  assert_contains(html, "width=\"16\"")
+  assert_contains(html, "height=\"16\"")
+  assert_contains(html, "d=\"m6 9 6 6 6-6\"")
+}
+
+///|
+test "combobox input and trigger keep unique ids and anchor to the input" {
+  let options = [
+    @rui.combobox_option(value="alpha", label="Alpha"),
+    @rui.combobox_option(value="beta", label="Beta"),
+  ]
+  let html = render_incremental(() => {
+    @rui.combobox(id="compound-combobox", options~, default_open=true, render=scope => {
+      @html.fragment([
+        @rui.combobox_input(scope~, id="actual-combobox-input"),
+        @rui.combobox_trigger(
+          scope~,
+          id="actual-combobox-trigger",
+          aria_label="Toggle options",
+        ),
+        @rui.combobox_clear(scope~, id="actual-combobox-clear", style=[
+          "background:rebeccapurple",
+        ]),
+        @rui.combobox_content(
+          scope~,
+          id="actual-combobox-popup",
+          @rui.combobox_item(scope~, value="alpha", "Alpha"),
+        ),
+      ])
+    })
+  })
+  assert_contains(html, "id=\"actual-combobox-input\"")
+  assert_contains(html, "id=\"actual-combobox-trigger\"")
+  assert_contains(html, "id=\"actual-combobox-clear\"")
+  assert_contains(html, "data-slot=\"combobox-clear\"")
+  assert_contains(html, "data-variant=\"ghost\"")
+  assert_contains(html, "data-size=\"icon-xs\"")
+  assert_contains(
+    html, "background:var(--rui-button-bg,var(--rui-button-base-bg,transparent))",
+  )
+  assert_contains(html, "background:rebeccapurple")
+  assert_contains(html, "id=\"actual-combobox-popup\"")
+  assert_contains(html, "aria-controls=\"actual-combobox-popup\"")
+  assert_contains(html, "data-trigger-id=\"actual-combobox-input\"")
+  assert_contains(html, "position-anchor:--rui-anchor_")
+  assert_contains(html, "aria-label=\"Toggle options\"")
+  assert_contains(html, "tabindex=\"-1\"")
+  assert_contains(html, "data-slot=\"combobox-trigger-icon\"")
+  assert_contains(html, "display:inline-flex;width:1rem;height:1rem")
+  assert_contains(html, "line-height:0")
+  assert_not_contains(html, "id=\"compound-combobox-trigger\"")
+  assert_not_contains(html, "id=\"compound-combobox-input\"")
+}
+
+///|
+test "multiple combobox exposes chips and collection composition" {
+  let options = [
+    @rui.combobox_option(value="a", label="Alpha"),
+    @rui.combobox_option(value="b", label="Beta"),
+  ]
+  let html = render_incremental(() => {
+    @rui.combobox(
+      id="tags-combobox",
+      options~,
+      multiple=true,
+      default_values=["a", "b"],
+      render=scope => {
+        @html.div([
+          @rui.combobox_chips([
+            @rui.combobox_chip(scope~, value="a", "Alpha"),
+            @rui.combobox_chip(scope~, value="b", "Beta"),
+            @rui.combobox_chips_input(scope~, aria_label="Filter tags"),
+          ]),
+          @rui.combobox_content(
+            scope~,
+            id="tags-popup",
+            @rui.combobox_collection([
+              @rui.combobox_label("Tags"),
+              @rui.combobox_item(scope~, value="a", "Alpha"),
+              @rui.combobox_separator(),
+              @rui.combobox_item(scope~, value="b", "Beta"),
+            ]),
+          ),
+        ])
+      },
+    )
+  })
+  assert_contains(html, "data-multiple=\"true\"")
+  assert_contains(html, "aria-multiselectable=\"true\"")
+  assert_contains(html, "data-slot=\"combobox-chips\"")
+  assert_contains(html, "min-height:2.25rem")
+  assert_contains(
+    html, "border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))))",
+  )
+  assert_contains(
+    html, "background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)))",
+  )
+  assert_contains(
+    html, "box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)))",
+  )
+  assert_contains(html, "data-slot=\"combobox-chip\"")
+  assert_contains(html, "data-slot=\"combobox-chip-remove\"")
+  assert_contains(html, "data-variant=\"ghost\"")
+  assert_contains(html, "data-size=\"icon-xs\"")
+  assert_contains(
+    html, "background:var(--rui-button-bg,var(--rui-button-base-bg,transparent))",
+  )
+  assert_contains(html, "opacity:var(--rui-chip-remove-opacity,0.5)")
+  assert_contains(html, "data-slot=\"combobox-chip-input\"")
+  assert_contains(html, "aria-label=\"Filter tags\"")
+  assert_contains(html, "role=\"combobox\"")
+  assert_contains(html, "aria-expanded=\"false\"")
+  assert_not_contains(html, "aria-controls")
+  assert_not_contains(html, "aria-activedescendant")
+  assert_contains(html, "min-width:4rem")
+  assert_contains(html, "data-slot=\"combobox-collection\"")
+  assert_contains(html, "data-slot=\"combobox-label\"")
+  assert_contains(html, "data-slot=\"combobox-separator\"")
+  assert_contains(html, "id=\"tags-popup\"")
+}
+
+///|
+test "default multiple combobox uses chips as its only control surface" {
+  let html = render_incremental(() => {
+    @rui.combobox(
+      id="default-tags-combobox",
+      options=[
+        @rui.combobox_option(value="a", label="Alpha"),
+        @rui.combobox_option(value="b", label="Beta"),
+      ],
+      multiple=true,
+      default_values=["a"],
+    )
+  })
+  assert_contains(html, "data-slot=\"combobox-control\"")
+  assert_contains(
+    html, "data-slot=\"combobox-control\" id=\"default-tags-combobox-control\" style=\"box-sizing:border-box;display:flex;width:100%;min-width:0;",
+  )
+  assert_contains(html, "data-slot=\"combobox-chips\"")
+  assert_contains(html, "data-slot=\"combobox-clear\"")
+  assert_contains(html, "data-slot=\"combobox-chip-input\"")
+}
+
+///|
+test "closed select and disabled hidden controls stay out of focus and submission" {
+  let select_options = [
+    @rui.select_option(value="a", label="Alpha"),
+    @rui.select_option(value="b", label="Beta"),
+  ]
+  let select_html = render_incremental(() => {
+    @rui.select(
+      id="closed-select",
+      options=select_options,
+      default_value="a",
+      name="closed",
+      disabled=true,
+    )
+  })
+  assert_contains(select_html, "role=\"combobox\"")
+  assert_contains(select_html, "aria-expanded=\"false\"")
+  assert_not_contains(select_html, "aria-controls")
+  assert_not_contains(select_html, "tabindex=\"0\"")
+  assert_contains(select_html, "data-slot=\"select-hidden-input\"")
+  assert_contains(select_html, " disabled")
+
+  let combobox_options = [@rui.combobox_option(value="a", label="Alpha")]
+  let combobox_html = render_incremental(() => {
+    @rui.combobox(
+      id="disabled-combobox",
+      options=combobox_options,
+      default_value="a",
+      name="disabled-combobox",
+      disabled=true,
+    )
+  })
+  assert_contains(combobox_html, "value=\"Alpha\"")
+  assert_not_contains(combobox_html, "aria-controls")
+  assert_not_contains(combobox_html, "aria-activedescendant")
+  assert_contains(combobox_html, " disabled")
+}

--- a/rui/select_combobox_wbtest.mbt
+++ b/rui/select_combobox_wbtest.mbt
@@ -1,0 +1,515 @@
+///|
+test "select typeahead skips disabled options and cycles enabled matches" {
+  let options = [
+    select_option(value="aaron", label="Aaron", disabled=true),
+    select_option(value="apple", label="Apple"),
+    select_option(value="avocado", label="Avocado"),
+  ]
+  assert_eq(select_typeahead_index(options, -1, "a"), 1)
+  assert_eq(select_typeahead_index(options, 1, "a"), 2)
+  assert_eq(select_typeahead_index(options, 2, "z"), -1)
+  assert_eq(select_typeahead_search("", "A"), "a")
+  assert_eq(select_typeahead_search("a", "A"), "a")
+  assert_eq(select_typeahead_search("a", "p"), "ap")
+}
+
+///|
+test "combobox derives selected input and treats that label as an unfiltered query" {
+  let options = [
+    combobox_option(value="apple", label="Apple"),
+    combobox_option(value="banana", label="Banana"),
+  ]
+  assert_eq(combobox_selected_input_value(options, ["banana"], false), "Banana")
+  assert_eq(combobox_filter_query(options, ["banana"], false, "Banana"), "")
+  assert_eq(
+    combobox_filter_query(options, ["banana"], false, "Bananax"),
+    "Bananax",
+  )
+  assert_eq(combobox_selected_input_value(options, ["banana"], true), "")
+}
+
+///|
+test "combobox virtual navigation starts at an edge and skips disabled matches" {
+  let options = [
+    combobox_option(value="disabled", label="Disabled", disabled=true),
+    combobox_option(value="apple", label="Apple"),
+    combobox_option(value="banana", label="Banana"),
+  ]
+  assert_eq(combobox_next_match(options, "", -1, 1), 1)
+  assert_eq(combobox_next_match(options, "", -1, -1), 2)
+  assert_eq(combobox_next_match(options, "app", -1, 1), 1)
+  assert_eq(combobox_next_match(options, "missing", -1, 1), -1)
+}
+
+///|
+test "listbox native layer changes before focus restoration" {
+  let calls : Array[String] = []
+  ui_listbox_run_open_sequence(
+    () => calls.push("show-popover"),
+    Some(() => calls.push("focus-control")),
+  )
+  assert_eq(calls.length(), 2)
+  assert_eq(calls[0], "show-popover")
+  assert_eq(calls[1], "focus-control")
+
+  calls.clear()
+  ui_listbox_run_open_sequence(() => calls.push("hide-popover"), None)
+  assert_eq(calls.length(), 1)
+  assert_eq(calls[0], "hide-popover")
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_select_trigger_fixture(root_id : String) -> Unit =
+  #| rootId => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const trigger = {
+  #|     id: "caller-owned-trigger",
+  #|     dataset: { slot: "select-trigger" },
+  #|     getAttribute(name) {
+  #|       if (name === "id") return this.id
+  #|       if (name === "data-slot") return this.dataset.slot || ""
+  #|       return ""
+  #|     },
+  #|   }
+  #|   const content = {
+  #|     id: "caller-owned-content",
+  #|     dataset: {},
+  #|     setAttribute(name, value) {
+  #|       if (name === "data-trigger-id") this.dataset.triggerId = value
+  #|     },
+  #|   }
+  #|   const root = { querySelectorAll: () => [trigger, content] }
+  #|   globalThis.__ruiSelectTriggerFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     content,
+  #|   }
+  #|   globalThis.document = {
+  #|     getElementById: id => id === `${rootId}-root`
+  #|       ? root
+  #|       : id === content.id ? content : null,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_select_trigger_fixture_id() -> String =
+  #| () => globalThis.__ruiSelectTriggerFixture.content.dataset.triggerId || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_select_trigger_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSelectTriggerFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   delete globalThis.__ruiSelectTriggerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "select resolves a caller-owned trigger id from its component root" {
+  let root_id = "independent-select"
+  ffi_install_select_trigger_fixture(root_id)
+  sync_select_trigger_id(root_id, "caller-owned-content")
+  let trigger_id = ffi_select_trigger_fixture_id()
+  ffi_restore_select_trigger_fixture()
+  assert_eq(trigger_id, "caller-owned-trigger")
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_combobox_press_fixture(root_id : String) -> Unit =
+  #| rootId => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiComboboxPressFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     FocusEvent: globalThis.FocusEvent,
+  #|     hadFocusEvent: own("FocusEvent"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     listeners: {},
+  #|     dispatches: [],
+  #|     focuses: 0,
+  #|   }
+  #|   class FixtureFocusEvent {
+  #|     constructor() { this.relatedTarget = null }
+  #|   }
+  #|   class FixtureHTMLElement {
+  #|     constructor() { this.nodeType = 1 }
+  #|   }
+  #|   globalThis.FocusEvent = FixtureFocusEvent
+  #|   globalThis.HTMLElement = FixtureHTMLElement
+  #|   const root = new FixtureHTMLElement()
+  #|   root.dataset = { state: "open", slot: "combobox" }
+  #|   root.getAttribute = name => name === "data-state"
+  #|     ? root.dataset.state
+  #|     : name === "data-slot" ? root.dataset.slot : ""
+  #|   root.addEventListener = (type, listener) => {
+  #|     fixture.listeners[type] = listener
+  #|   }
+  #|   root.contains = target => target?.root === root
+  #|   const elements = {}
+  #|   const makeElement = slot => {
+  #|     const element = new FixtureHTMLElement()
+  #|     element.dataset = { slot }
+  #|     element.root = root
+  #|     element.getAttribute = name => name === "data-slot" ? slot : ""
+  #|     element.hasAttribute = () => false
+  #|     element.closest = selector => selector === '[data-slot="combobox"]'
+  #|       ? root
+  #|       : selector.includes(`[data-slot="${slot}"]`) ? element : null
+  #|     elements[slot] = element
+  #|     return element
+  #|   }
+  #|   const input = makeElement("combobox-input")
+  #|   makeElement("combobox-item")
+  #|   makeElement("combobox-trigger")
+  #|   makeElement("combobox-clear")
+  #|   input.focus = options => {
+  #|     if (options?.preventScroll) fixture.focuses += 1
+  #|   }
+  #|   root.querySelector = selector => selector.includes("combobox-input")
+  #|     ? input
+  #|     : null
+  #|   fixture.root = root
+  #|   fixture.elements = elements
+  #|   globalThis.document = {
+  #|     getElementById: id => id === `${rootId}-root` ? root : null,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_combobox_press_fixture(event_type : String) -> Unit =
+  #| eventType => {
+  #|   const fixture = globalThis.__ruiComboboxPressFixture
+  #|   fixture.listeners[eventType]?.(new FocusEvent())
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_press_event(slot : String) -> @dom.MouseEvent =
+  #| slot => {
+  #|   const fixture = globalThis.__ruiComboboxPressFixture
+  #|   return {
+  #|     currentTarget: fixture.root,
+  #|     target: fixture.elements[slot],
+  #|     defaultPrevented: false,
+  #|     preventDefault() { this.defaultPrevented = true },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_press_prevented(event : @dom.MouseEvent) -> Bool =
+  #| event => event.defaultPrevented
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_press_focuses() -> Int =
+  #| () => globalThis.__ruiComboboxPressFixture.focuses
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_keyboard_event(
+  key : String,
+  alt_key : Bool,
+  ctrl_key : Bool,
+  meta_key : Bool,
+  composing : Bool,
+) -> @dom.KeyboardEvent =
+  #| (key, altKey, ctrlKey, metaKey, isComposing) => ({
+  #|   key,
+  #|   altKey,
+  #|   ctrlKey,
+  #|   metaKey,
+  #|   isComposing,
+  #|   defaultPrevented: false,
+  #|   preventDefault() { this.defaultPrevented = true },
+  #| })
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_default_prevented(
+  event : @dom.KeyboardEvent,
+) -> Bool = "event => event.defaultPrevented"
+
+///|
+#cfg(target="js")
+fn combobox_key_test_result(
+  key : String,
+  multiple : Bool,
+  disabled : Bool,
+  query : String,
+  values : Array[String],
+  alt_key : Bool,
+  ctrl_key : Bool,
+  meta_key : Bool,
+  composing : Bool,
+) -> (Bool, Array[ComboboxMsg]) {
+  let messages : Array[ComboboxMsg] = []
+  let scope : ComboboxScope = {
+    id: "keyboard-combobox",
+    options: [],
+    model: { open: false, query, values, active: -1 },
+    multiple,
+    placeholder: "",
+    empty_text: "",
+    disabled,
+    invalid: false,
+    required: false,
+    name: None,
+    side: Bottom,
+    align: Start,
+    side_offset: 4,
+    align_offset: 0,
+    emit: @cmd.Emit(message => {
+      messages.push(message)
+      @cmd.none
+    }),
+    content_id: Ref("keyboard-combobox-content"),
+    anchor_id: Ref("keyboard-combobox-input"),
+    has_input: Ref(true),
+  }
+  let event = ffi_combobox_keyboard_event(
+    key, alt_key, ctrl_key, meta_key, composing,
+  )
+  ignore(combobox_input_keydown(scope, event))
+  (ffi_combobox_default_prevented(event), messages)
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_press_fixture_dispatches() -> Int =
+  #| () => globalThis.__ruiComboboxPressFixture.dispatches.length
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_press_fixture_last_dispatch() -> Int =
+  #| () => globalThis.__ruiComboboxPressFixture.dispatches.at(-1) ?? -1
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_combobox_press_fixture_record_dispatch(kind : Int) -> Unit =
+  #| kind => { globalThis.__ruiComboboxPressFixture.dispatches.push(kind) }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_combobox_press_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiComboboxPressFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadFocusEvent) globalThis.FocusEvent = fixture.FocusEvent
+  #|   else delete globalThis.FocusEvent
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiComboboxPressFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "combobox focusout binding dismisses an open root" {
+  let root_id = "press-combobox"
+  ffi_install_combobox_press_fixture(root_id)
+  bind_combobox_events(root_id, kind => {
+    ffi_combobox_press_fixture_record_dispatch(kind)
+  })
+  ffi_fire_combobox_press_fixture("focusout")
+  let dispatches = ffi_combobox_press_fixture_dispatches()
+  let last_dispatch = ffi_combobox_press_fixture_last_dispatch()
+  ffi_restore_combobox_press_fixture()
+
+  assert_eq(dispatches, 1)
+  assert_eq(last_dispatch, 7)
+}
+
+///|
+#cfg(target="js")
+test "combobox root handlers open after input release and preserve item press focus" {
+  let root_id = "press-combobox"
+  ffi_install_combobox_press_fixture(root_id)
+  let messages : Array[ComboboxMsg] = []
+  let scope : ComboboxScope = {
+    id: root_id,
+    options: [],
+    model: { open: false, query: "", values: [], active: -1 },
+    multiple: false,
+    placeholder: "",
+    empty_text: "",
+    disabled: false,
+    invalid: false,
+    required: false,
+    name: None,
+    side: Bottom,
+    align: Start,
+    side_offset: 4,
+    align_offset: 0,
+    emit: @cmd.Emit(message => {
+      messages.push(message)
+      @cmd.none
+    }),
+    content_id: Ref("press-combobox-content"),
+    anchor_id: Ref("press-combobox-input"),
+    has_input: Ref(true),
+  }
+  let input_click = ffi_combobox_press_event("combobox-input")
+  ignore(combobox_root_click(scope, input_click))
+  let input_click_prevented = ffi_combobox_press_prevented(input_click)
+  let item_press = ffi_combobox_press_event("combobox-item")
+  ignore(combobox_root_mousedown(item_press))
+  let item_press_prevented = ffi_combobox_press_prevented(item_press)
+  let trigger_press = ffi_combobox_press_event("combobox-trigger")
+  ignore(combobox_root_mousedown(trigger_press))
+  let trigger_press_prevented = ffi_combobox_press_prevented(trigger_press)
+  let focuses = ffi_combobox_press_focuses()
+  ffi_restore_combobox_press_fixture()
+
+  assert_false(input_click_prevented)
+  assert_eq(messages.length(), 1)
+  guard messages[0] is ComboboxOpen else {
+    fail("input release should request an open combobox")
+  }
+  assert_true(item_press_prevented)
+  assert_true(trigger_press_prevented)
+  assert_eq(focuses, 1)
+}
+
+///|
+#cfg(target="js")
+test "multiple combobox deletes the previous value only from an empty input" {
+  let (backspace_prevented, backspace_messages) = combobox_key_test_result(
+    "Backspace",
+    true,
+    false,
+    "",
+    ["alpha", "beta"],
+    false,
+    false,
+    false,
+    false,
+  )
+  assert_true(backspace_prevented)
+  guard backspace_messages.get(0) is Some(ComboboxRemove(value)) else {
+    fail("Backspace should remove the final selected value")
+  }
+  assert_eq(value, "beta")
+
+  let (delete_prevented, delete_messages) = combobox_key_test_result(
+    "Delete",
+    true,
+    false,
+    "",
+    ["alpha", "beta"],
+    false,
+    false,
+    false,
+    false,
+  )
+  assert_true(delete_prevented)
+  guard delete_messages.get(0) is Some(ComboboxRemove(value)) else {
+    fail("Delete should remove the final selected value")
+  }
+  assert_eq(value, "beta")
+
+  let rejected : Array[(Bool, Array[ComboboxMsg])] = [
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      false,
+      "query",
+      ["alpha"],
+      false,
+      false,
+      false,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      false,
+      false,
+      "",
+      ["alpha"],
+      false,
+      false,
+      false,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      false,
+      "",
+      [],
+      false,
+      false,
+      false,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      true,
+      "",
+      ["alpha"],
+      false,
+      false,
+      false,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      false,
+      "",
+      ["alpha"],
+      true,
+      false,
+      false,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      false,
+      "",
+      ["alpha"],
+      false,
+      true,
+      false,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      false,
+      "",
+      ["alpha"],
+      false,
+      false,
+      true,
+      false,
+    ),
+    combobox_key_test_result(
+      "Backspace",
+      true,
+      false,
+      "",
+      ["alpha"],
+      false,
+      false,
+      false,
+      true,
+    ),
+  ]
+  for result in rejected {
+    let (prevented, messages) = result
+    assert_false(prevented)
+    assert_eq(messages.length(), 0)
+  }
+}

--- a/rui/separator.mbt
+++ b/rui/separator.mbt
@@ -1,0 +1,69 @@
+///|
+pub(all) enum SeparatorOrientation {
+  Horizontal
+  Vertical
+} derive(Debug, Eq)
+
+///|
+const SeparatorBaseStyle : String = "display:block;flex-shrink:0;background:var(--rui-border,oklch(0.922 0 0))"
+
+///|
+const SeparatorHorizontalStyle : String = "width:100%;height:1px"
+
+///|
+const SeparatorVerticalStyle : String = "width:1px;height:100%;align-self:stretch"
+
+///|
+fn separator_orientation_value(orientation : SeparatorOrientation) -> String {
+  match orientation {
+    Horizontal => "horizontal"
+    Vertical => "vertical"
+  }
+}
+
+///|
+fn separator_orientation_style(orientation : SeparatorOrientation) -> String {
+  match orientation {
+    Horizontal => SeparatorHorizontalStyle
+    Vertical => SeparatorVerticalStyle
+  }
+}
+
+///|
+/// Render a decorative divider by default, matching shadcn/Radix semantics.
+/// Set `decorative=false` when the divider conveys document structure.
+pub fn separator(
+  orientation? : SeparatorOrientation = Horizontal,
+  decorative? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "separator",
+) -> @html.Html {
+  let orientation_value = separator_orientation_value(orientation)
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("orientation", orientation_value)
+  if decorative {
+    ignore(element_attrs.role("none"))
+  } else {
+    ignore(element_attrs.role("separator").aria_orientation(orientation_value))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        SeparatorBaseStyle,
+        separator_orientation_style(orientation),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    @html.nothing,
+  )
+}

--- a/rui/sheet.mbt
+++ b/rui/sheet.mbt
@@ -1,0 +1,418 @@
+///|
+/// Edge from which a [`sheet_content`] surface enters the viewport.
+pub(all) enum SheetSide {
+  SheetTop
+  SheetRight
+  SheetBottom
+  SheetLeft
+} derive(Debug, Eq)
+
+///|
+/// Explicit compound-component scope created by [`sheet`].
+struct SheetScope(DialogScope)
+
+///|
+const SheetPositionerStyle : String = "position:fixed;inset:0;z-index:51;display:flex;overflow:hidden;pointer-events:none"
+
+///|
+const SheetSurfaceStyle : String = "position:relative;display:flex;min-width:0;min-height:0;flex-direction:column;gap:1rem;overflow:auto;background:var(--rui-popover,var(--rui-background,oklch(1 0 0)));color:var(--rui-popover-foreground,var(--rui-foreground,oklch(0.145 0 0)));padding:1.5rem;box-shadow:0 16px 48px rgb(0 0 0 / 0.2);opacity:var(--rui-sheet-opacity,1);transform:var(--rui-sheet-transform,translate3d(0,0,0));will-change:opacity,transform;pointer-events:auto"
+
+///|
+const SheetCloseButtonStyle : String = "position:absolute;top:1rem;inset-inline-end:1rem;background:var(--rui-close-bg,var(--rui-button-bg,var(--rui-button-base-bg,transparent)));color:var(--rui-close-fg,var(--rui-button-fg,var(--rui-button-base-fg,currentColor)));box-shadow:var(--rui-close-shadow,var(--rui-button-shadow,var(--rui-button-base-shadow,none)));opacity:var(--rui-close-opacity,var(--rui-close-base-opacity,0.7))"
+
+///|
+fn sheet_side_value(side : SheetSide) -> String {
+  match side {
+    SheetTop => "top"
+    SheetRight => "right"
+    SheetBottom => "bottom"
+    SheetLeft => "left"
+  }
+}
+
+///|
+fn sheet_positioner_side_style(side : SheetSide) -> String {
+  match side {
+    SheetTop => "align-items:flex-start"
+    SheetRight => "justify-content:flex-end"
+    SheetBottom => "align-items:flex-end"
+    SheetLeft => "justify-content:flex-start"
+  }
+}
+
+///|
+fn sheet_surface_side_style(side : SheetSide) -> String {
+  match side {
+    SheetTop =>
+      "width:100%;max-height:85vh;border-bottom:1px solid var(--rui-border,oklch(0.922 0 0))"
+    SheetRight =>
+      "width:min(85vw,24rem);height:100%;border-left:1px solid var(--rui-border,oklch(0.922 0 0))"
+    SheetBottom =>
+      "width:100%;max-height:85vh;border-top:1px solid var(--rui-border,oklch(0.922 0 0))"
+    SheetLeft =>
+      "width:min(85vw,24rem);height:100%;border-right:1px solid var(--rui-border,oklch(0.922 0 0))"
+  }
+}
+
+///|
+fn sheet_closed_transform(side : SheetSide) -> String {
+  match side {
+    SheetTop => "translate3d(0,-2.5rem,0)"
+    SheetRight => "translate3d(2.5rem,0,0)"
+    SheetBottom => "translate3d(0,2.5rem,0)"
+    SheetLeft => "translate3d(-2.5rem,0,0)"
+  }
+}
+
+///|
+fn sheet_motion_style(side : SheetSide, open : Bool) -> String {
+  let closed_transform = sheet_closed_transform(side)
+  if open {
+    "--rui-sheet-closed-transform:\{closed_transform};--rui-sheet-opacity:1;--rui-sheet-transform:translate3d(0,0,0);animation:rui-sheet-enter 200ms ease-in-out"
+  } else {
+    "--rui-sheet-closed-transform:\{closed_transform};--rui-sheet-opacity:0;--rui-sheet-transform:\{closed_transform};animation:rui-sheet-exit 200ms ease-in-out;pointer-events:none"
+  }
+}
+
+///|
+fn sheet_close_icon(scope : DialogScope, label : String) -> @html.Html {
+  let close_attrs = @html.Attrs::build()
+    .data_set("rui-close-icon", "")
+    .data_set("state", dialog_state_value(scope.open))
+  dialog_control_button(
+    slot="sheet-close",
+    command=scope.close_command,
+    variant=Ghost,
+    size=IconSm,
+    disabled=false,
+    id=None,
+    class=None,
+    title=None,
+    aria_label=Some(label),
+    on_click=None,
+    attrs=Some(close_attrs),
+    style=[SheetCloseButtonStyle],
+    ui_x_icon(),
+  )
+}
+
+///|
+/// Create a stateful edge sheet backed by native dialog behavior. Modal sheets
+/// enter the browser top layer; `modal=false` leaves the page interactive. The
+/// returned value participates in Rabbita's incremental renderer.
+pub fn sheet(
+  id~ : String,
+  default_open? : Bool = false,
+  modal? : Bool = true,
+  close_on_escape? : Bool = true,
+  on_open_change? : @cmd.Emit[Bool],
+  on_close? : @cmd.Emit[String],
+  children : (SheetScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  dialog(
+    id~,
+    default_open~,
+    modal~,
+    close_on_escape~,
+    on_open_change?,
+    on_close?,
+    scope => children(SheetScope(scope)),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sheet_trigger(
+  scope : SheetScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let dialog_scope = scope.0
+  let trigger_attrs = dialog_state_attrs(
+      attrs,
+      "sheet-trigger",
+      dialog_scope.open,
+    )
+    .aria_haspopup("dialog")
+    .aria_controls(dialog_scope.id)
+    .aria_expanded(ui_bool(dialog_scope.open))
+  dialog_control_button(
+    slot="sheet-trigger",
+    command=dialog_scope.open_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(trigger_attrs),
+    style~,
+    children,
+  )
+}
+
+///|
+/// Render an edge-anchored sheet surface. Caller styles are appended after the
+/// built-in Vega recipe, so CSS variables or individual properties can be
+/// overridden without copying the component.
+pub fn[C : @html.IsChildren] sheet_content(
+  scope : SheetScope,
+  side? : SheetSide = SheetRight,
+  close_on_overlay? : Bool = true,
+  show_close? : Bool = true,
+  close_label? : String = "Close",
+  described? : Bool = true,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  native_attrs? : @html.Attrs,
+  native_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let dialog_scope = scope.0
+  let native_element_attrs = dialog_state_attrs(
+      native_attrs,
+      "sheet-native",
+      dialog_scope.open,
+    )
+    .data_set("modal", ui_bool(dialog_scope.modal))
+    .data_set("close-on-outside", ui_bool(close_on_overlay))
+    .data_set("close-on-escape", ui_bool(dialog_scope.close_on_escape))
+  if dialog_scope.modal {
+    ignore(native_element_attrs.aria_modal("true"))
+  }
+  if aria_label is Some(label) {
+    ignore(native_element_attrs.aria_label(label))
+  } else {
+    ignore(native_element_attrs.aria_labelledby(dialog_scope.title_id()))
+  }
+  if described {
+    ignore(native_element_attrs.aria_describedby(dialog_scope.description_id()))
+  }
+  let overlay_element_attrs = dialog_state_attrs(
+    overlay_attrs,
+    "sheet-overlay",
+    dialog_scope.open,
+  )
+  if close_on_overlay {
+    ignore(
+      overlay_element_attrs.on_click(_ => {
+        if ui_dialog_should_close_outside() {
+          dialog_scope.close_command
+        } else {
+          @cmd.none
+        }
+      }),
+    )
+  }
+  let content_attrs = dialog_state_attrs(
+    attrs,
+    "sheet-content",
+    dialog_scope.open,
+  ).data_set("side", sheet_side_value(side))
+  let positioner_attrs = dialog_state_attrs(
+    None,
+    "sheet-positioner",
+    dialog_scope.open,
+  ).data_set("side", sheet_side_value(side))
+  let content = @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        SheetSurfaceStyle,
+        sheet_surface_side_style(side),
+        sheet_motion_style(side, dialog_scope.open),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=content_attrs,
+    [
+      @html.div(style=[UiBoxSizing, "display:contents"], children),
+      if show_close {
+        sheet_close_icon(dialog_scope, close_label)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+  let open = dialog_scope.native_open
+  let on_close = dialog_scope.on_close
+  let on_cancel = dialog_scope.on_cancel
+  let closedby = if !dialog_scope.modal {
+    "none"
+  } else if close_on_overlay {
+    "any"
+  } else if dialog_scope.close_on_escape {
+    "closerequest"
+  } else {
+    "none"
+  }
+  @html.dialog(
+    style=ui_styles([UiBoxSizing, DialogNativeStyle], native_style),
+    id=dialog_scope.id,
+    open?,
+    closedby~,
+    on_close?,
+    on_cancel?,
+    attrs=native_element_attrs,
+    [
+      if dialog_scope.modal {
+        @html.div(
+          style=ui_styles(
+            [
+              UiBoxSizing,
+              DialogOverlayStyle,
+              dialog_overlay_motion_style(dialog_scope.open),
+            ],
+            overlay_style,
+          ),
+          attrs=overlay_element_attrs,
+          @html.nothing,
+        )
+      } else {
+        @html.nothing
+      },
+      @html.div(
+        style=[
+          UiBoxSizing,
+          SheetPositionerStyle,
+          sheet_positioner_side_style(side),
+        ],
+        attrs=positioner_attrs,
+        content,
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sheet_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DialogHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sheet-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sheet_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, DialogFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sheet-footer"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sheet_title(
+  scope : SheetScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.0.title_id())
+  @html.h2(
+    style=ui_styles([UiBoxSizing, DialogTitleStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sheet-title"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sheet_description(
+  scope : SheetScope,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_id = id.unwrap_or(scope.0.description_id())
+  @html.p(
+    style=ui_styles([UiBoxSizing, DialogDescriptionStyle], style),
+    id=element_id,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sheet-description"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sheet_close(
+  scope : SheetScope,
+  variant? : ButtonVariant = Outline,
+  size? : ButtonSize = Default,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  dialog_control_button(
+    slot="sheet-close",
+    command=scope.0.close_command,
+    variant~,
+    size~,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs~,
+    style~,
+    children,
+  )
+}

--- a/rui/sidebar.mbt
+++ b/rui/sidebar.mbt
@@ -1,0 +1,2878 @@
+///|
+pub(all) enum SidebarSide {
+  SidebarLeft
+  SidebarRight
+} derive(Debug, Eq)
+
+///|
+pub(all) enum SidebarVariant {
+  SidebarDefault
+  SidebarFloating
+  SidebarInset
+} derive(Debug, Eq)
+
+///|
+pub(all) enum SidebarCollapsible {
+  SidebarOffcanvas
+  SidebarIcon
+  SidebarFixed
+} derive(Debug, Eq)
+
+///|
+pub(all) enum SidebarMenuButtonSize {
+  SidebarMenuSm
+  SidebarMenuDefault
+  SidebarMenuLg
+} derive(Debug, Eq)
+
+///|
+pub(all) enum SidebarMenuButtonVariant {
+  SidebarMenuButtonDefault
+  SidebarMenuButtonOutline
+} derive(Debug, Eq)
+
+///|
+#cfg(target="js")
+priv struct SidebarState {
+  collapsed : Bool
+  mobile_open : Bool
+  desktop_width : Int?
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum SidebarMessage {
+  ToggleSidebarCollapsed
+  SetSidebarCollapsed(Bool)
+  ToggleSidebarMobile
+  SetSidebarMobile(Bool)
+  CommitSidebarWidth(Int)
+}
+
+///|
+/// Explicit state and commands shared by every part inside
+/// [`sidebar_provider`].
+struct SidebarScope {
+  collapsed : Bool
+  mobile_open : Bool
+  desktop_width : Int?
+  toggle_collapsed : @cmd.Cmd
+  expand : @cmd.Cmd
+  collapse : @cmd.Cmd
+  toggle_mobile : @cmd.Cmd
+  open_mobile : @cmd.Cmd
+  close_mobile : @cmd.Cmd
+  commit_width : @cmd.Emit[Int]
+}
+
+///|
+const SidebarProviderStyle : String = "position:relative;display:flex;width:100%;min-height:100svh;align-items:stretch;background:var(--rui-sidebar-wrapper-background,var(--rui-background,oklch(1 0 0)));color:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const SidebarShellStyle : String = "position:relative;min-width:0;align-self:stretch;flex:none;transition:width 200ms linear"
+
+///|
+const SidebarBaseStyle : String = "position:relative;display:flex;min-width:0;flex-direction:column;flex-shrink:0;overflow:visible;background:var(--rui-sidebar,oklch(0.985 0 0));color:var(--rui-sidebar-foreground,var(--rui-foreground,oklch(0.145 0 0)));transition:width 200ms linear,transform 200ms linear"
+
+///|
+const SidebarDesktopStyle : String = "position:absolute;top:0;bottom:0;z-index:10"
+
+///|
+const SidebarMobileLayerStyle : String = "position:fixed;inset:0;width:auto;height:auto;max-width:none;max-height:none;margin:0;border:0;padding:0;background:transparent;color:inherit;overflow:visible;pointer-events:none;transition:display 200ms,overlay 200ms;transition-behavior:allow-discrete"
+
+///|
+const SidebarMobileStyle : String = "position:fixed;top:0;bottom:0;z-index:1;width:min(var(--rui-sidebar-width-mobile,18rem),calc(100vw - 2rem));max-width:100vw;margin:0;border-block:0;padding:0;overflow:hidden;pointer-events:auto;outline:none;box-shadow:0 16px 48px rgb(0 0 0 / 0.22);transition:transform 200ms ease-in-out,opacity 200ms ease-in-out"
+
+///|
+const SidebarOverlayStyle : String = "position:fixed;inset:0;z-index:0;background:rgb(0 0 0 / 0.5);opacity:var(--rui-sidebar-overlay-opacity,0);visibility:var(--rui-sidebar-overlay-visibility,hidden);pointer-events:var(--rui-sidebar-overlay-pointer-events,none);transition:opacity 200ms ease,visibility 0s linear var(--rui-sidebar-overlay-visibility-delay,200ms)"
+
+///|
+const SidebarOverlayOpenStyle : String = "--rui-sidebar-overlay-opacity:1;--rui-sidebar-overlay-visibility:visible;--rui-sidebar-overlay-pointer-events:auto;--rui-sidebar-overlay-visibility-delay:0s"
+
+///|
+const SidebarOverlayClosedStyle : String = "--rui-sidebar-overlay-opacity:0;--rui-sidebar-overlay-visibility:hidden;--rui-sidebar-overlay-pointer-events:auto;--rui-sidebar-overlay-visibility-delay:200ms"
+
+///|
+const SidebarHeaderFooterStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.5rem;padding:0.5rem;overflow:hidden"
+
+///|
+const SidebarContentStyle : String = "display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;gap:0.5rem;overflow-x:hidden;overflow-y:var(--rui-sidebar-content-overflow-y,auto);scrollbar-width:none"
+
+///|
+const SidebarGroupStyle : String = "position:relative;display:flex;min-width:0;flex-direction:column;padding:0.5rem"
+
+///|
+const SidebarGroupLabelStyle : String = "display:flex;height:2rem;min-width:0;align-items:center;margin-block-start:var(--rui-sidebar-group-label-local-margin,var(--rui-sidebar-group-label-margin,0));padding-inline:0.5rem;color:var(--rui-sidebar-label-fg,var(--rui-sidebar-label-base-fg,color-mix(in oklab,var(--rui-sidebar-foreground,var(--rui-foreground,oklch(0.145 0 0))) 70%,transparent)));font-size:0.75rem;line-height:1rem;font-weight:500;white-space:nowrap;opacity:var(--rui-sidebar-group-label-local-opacity,var(--rui-sidebar-group-label-opacity,1));overflow:hidden;pointer-events:var(--rui-sidebar-group-label-local-pointer-events,var(--rui-sidebar-group-label-pointer-events,auto));transition:margin 200ms linear,opacity 150ms ease"
+
+///|
+const SidebarGroupActionStyle : String = "position:absolute;top:0.875rem;inset-inline-end:0.75rem;z-index:2;display:var(--rui-sidebar-group-action-display,inline-flex)"
+
+///|
+const SidebarActionSurfaceStyle : String = "border-color:var(--rui-sidebar-action-border,var(--rui-button-border,var(--rui-button-base-border,transparent)));background:var(--rui-sidebar-action-bg,var(--rui-button-bg,var(--rui-button-base-bg,transparent)));color:var(--rui-sidebar-action-fg,var(--rui-sidebar-foreground,inherit));box-shadow:var(--rui-sidebar-action-shadow,var(--rui-button-shadow,var(--rui-button-base-shadow,none)))"
+
+///|
+const SidebarActionSizeStyle : String = "width:1.25rem;height:1.25rem;--rui-button-icon-size:1rem;--rui-button-padding-inline:0"
+
+///|
+const SidebarGroupContentStyle : String = "min-width:0;width:100%;font-size:0.875rem;line-height:1.25rem"
+
+///|
+const SidebarMenuStyle : String = "display:flex;min-width:0;width:100%;flex-direction:column;gap:0.25rem;margin:0;padding:0;list-style:none"
+
+///|
+const SidebarMenuItemStyle : String = "position:relative;display:block;min-width:0"
+
+///|
+const SidebarMenuButtonStyle : String = "display:flex;width:var(--rui-sidebar-item-collapse-width,100%);min-width:0;align-items:center;justify-content:var(--rui-sidebar-item-justify-content,flex-start);gap:var(--rui-sidebar-item-collapse-gap,0.5rem);border:1px solid transparent;border-color:var(--rui-sidebar-item-border,var(--rui-sidebar-item-base-border,transparent));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);margin:0;padding-inline-start:0.5rem;padding-inline-end:var(--rui-sidebar-item-local-padding-end,var(--rui-sidebar-item-padding-end,0.5rem));background:var(--rui-sidebar-item-bg,var(--rui-sidebar-item-base-bg,transparent));color:var(--rui-sidebar-item-fg,var(--rui-sidebar-item-base-fg,inherit));box-shadow:var(--rui-sidebar-item-shadow,var(--rui-sidebar-item-base-shadow,none));font-size:var(--rui-sidebar-item-collapse-font-size,var(--rui-sidebar-item-base-font-size,0.875rem));line-height:1.25rem;font-weight:var(--rui-sidebar-item-font-weight,var(--rui-sidebar-item-base-font-weight,400));text-align:start;text-decoration:none;white-space:nowrap;cursor:pointer;outline-offset:2px;overflow:hidden;appearance:none;-webkit-appearance:none;transition:width 200ms linear,height 200ms linear,gap 200ms linear,padding 200ms linear,font-size 150ms ease,color 150ms ease,background-color 150ms ease,border-color 150ms ease,box-shadow 150ms ease"
+
+///|
+const SidebarMenuButtonActiveStyle : String = "--rui-sidebar-item-base-bg:var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)));--rui-sidebar-item-base-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,var(--rui-foreground,oklch(0.145 0 0))));--rui-sidebar-item-base-font-weight:500"
+
+///|
+const SidebarMenuButtonOutlineStyle : String = "--rui-sidebar-item-base-bg:var(--rui-background,oklch(1 0 0));--rui-sidebar-item-base-shadow:0 0 0 1px var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)))"
+
+///|
+const SidebarMenuActionStyle : String = "position:absolute;top:var(--rui-sidebar-menu-action-top,0.375rem);inset-inline-end:0.25rem;z-index:2;display:var(--rui-sidebar-menu-action-display,inline-flex);opacity:var(--rui-sidebar-action-opacity,var(--rui-sidebar-action-base-opacity,1));transform:translateY(var(--rui-sidebar-action-press-offset,0))"
+
+///|
+const SidebarMenuActionHoverStyle : String = "--rui-sidebar-action-base-opacity:0"
+
+///|
+const SidebarRailStyle : String = "position:absolute;top:0;bottom:0;left:var(--rui-sidebar-rail-left,auto);right:var(--rui-sidebar-rail-right,-0.5rem);z-index:4;width:1rem;height:auto;border:0;border-radius:0;margin:0;padding:0;background:transparent;color:inherit;box-shadow:none;cursor:var(--rui-sidebar-rail-cursor,col-resize);touch-action:none;user-select:none"
+
+///|
+const SidebarRailLineStyle : String = "position:absolute;top:0;bottom:0;left:var(--rui-sidebar-rail-line-left,50%);display:block;width:2px;background:var(--rui-sidebar-rail-line-bg,transparent);transition:background-color 150ms ease;pointer-events:none"
+
+///|
+const SidebarMenuBadgeStyle : String = "position:absolute;top:var(--rui-sidebar-menu-badge-top,0.375rem);inset-inline-end:var(--rui-sidebar-badge-local-end,var(--rui-sidebar-badge-end,0.5rem));display:var(--rui-sidebar-menu-badge-display,flex);min-width:1.25rem;height:1.25rem;align-items:center;justify-content:center;border-radius:0.25rem;padding-inline:0.25rem;color:var(--rui-sidebar-badge-fg,var(--rui-sidebar-badge-base-fg,inherit));font-size:0.75rem;line-height:1rem;font-variant-numeric:tabular-nums;pointer-events:none"
+
+///|
+const SidebarMenuSubStyle : String = "display:var(--rui-sidebar-menu-sub-display,flex);min-width:0;flex-direction:column;gap:0.125rem;margin-block:0.25rem;margin-inline:0.875rem;padding-block:0.25rem;padding-inline:0.625rem;border-inline-start:1px solid var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)));list-style:none"
+
+///|
+const SidebarMenuSubButtonStyle : String = "display:flex;width:100%;min-width:0;height:1.75rem;align-items:center;gap:0.5rem;border:0;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);padding-inline:0.5rem;background:var(--rui-sidebar-item-bg,var(--rui-sidebar-item-base-bg,transparent));color:var(--rui-sidebar-item-fg,var(--rui-sidebar-item-base-fg,inherit));box-shadow:var(--rui-sidebar-item-shadow,var(--rui-sidebar-item-base-shadow,none));font-size:0.8125rem;line-height:1rem;font-weight:var(--rui-sidebar-item-font-weight,var(--rui-sidebar-item-base-font-weight,400));text-align:start;text-decoration:none;white-space:nowrap;overflow:hidden;cursor:pointer;outline-offset:2px"
+
+///|
+const SidebarInsetStyle : String = "position:relative;display:flex;min-width:0;flex:1;flex-direction:column;background:var(--rui-background,oklch(1 0 0));transition:margin 200ms linear,border-radius 200ms linear,box-shadow 200ms linear"
+
+///|
+fn sidebar_side_value(side : SidebarSide) -> String {
+  match side {
+    SidebarLeft => "left"
+    SidebarRight => "right"
+  }
+}
+
+///|
+fn sidebar_variant_value(variant : SidebarVariant) -> String {
+  match variant {
+    SidebarDefault => "sidebar"
+    SidebarFloating => "floating"
+    SidebarInset => "inset"
+  }
+}
+
+///|
+fn sidebar_collapsible_value(collapsible : SidebarCollapsible) -> String {
+  match collapsible {
+    SidebarOffcanvas => "offcanvas"
+    SidebarIcon => "icon"
+    SidebarFixed => "none"
+  }
+}
+
+///|
+fn sidebar_state_value(collapsed : Bool) -> String {
+  if collapsed {
+    "collapsed"
+  } else {
+    "expanded"
+  }
+}
+
+///|
+#cfg(target="js")
+priv struct SidebarPointerState {
+  rail : @dom.Element
+  root : @dom.Element
+  sidebar : @dom.Element
+  shell : @dom.Element
+  pointer_id : Int
+  right : Bool
+  gutter : Int
+  start_x : Int
+  start_width : Double
+  min : Double
+  max : Double
+  mut width : Double
+  mut active : Bool
+  was_collapsed : Bool
+  original_current_width : String
+  original_sidebar_width : String
+  original_transition : String
+  original_shell_width : String
+  original_shell_transition : String
+  original_user_select : String
+  original_cursor : String
+  mut captured : Bool
+  mut suppress_click : @dom.Listener?
+  mut lost_pointer_capture : @dom.Listener?
+}
+
+///|
+#cfg(target="js")
+let sidebar_pointer_states : Array[SidebarPointerState] = []
+
+///|
+#cfg(target="js")
+fn sidebar_pointer_state(rail : @dom.Element) -> SidebarPointerState? {
+  for state in sidebar_pointer_states {
+    if state.rail.is_same_node(rail.as_node()) {
+      return Some(state)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn sidebar_remove_pointer_state(rail : @dom.Element) -> Unit {
+  for index, state in sidebar_pointer_states {
+    if state.rail.is_same_node(rail.as_node()) {
+      ignore(sidebar_pointer_states.remove(index))
+      return
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_restore_style_property(
+  style : @dom.CSSStyleDeclaration,
+  name : String,
+  value : String,
+) -> Unit {
+  if value == "" {
+    ignore(style.remove_property(name))
+  } else {
+    style.set_property(name, value)
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_remove_click_suppression(state : SidebarPointerState) -> Unit {
+  if state.suppress_click is Some(listener) {
+    state.rail.remove_event_listener_with_options(
+      "click",
+      listener,
+      capture=true,
+    )
+    state.suppress_click = None
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_install_click_suppression(state : SidebarPointerState) -> Unit {
+  if state.suppress_click is Some(_) {
+    return
+  }
+  let listener : @dom.Listener = event => {
+    event.prevent_default()
+    event.stop_immediate_propagation()
+    event.stop_propagation()
+    sidebar_remove_click_suppression(state)
+  }
+  state.suppress_click = Some(listener)
+  state.rail.add_event_listener_with_options("click", listener, capture=true)
+}
+
+///|
+#cfg(target="js")
+fn sidebar_release_pointer_state(
+  state : SidebarPointerState,
+  committed : Bool,
+) -> Unit {
+  let dragged = state.active
+  guard state.root.to_html_element() is Some(root) else {
+    sidebar_remove_pointer_state(state.rail)
+    return
+  }
+  guard state.sidebar.to_html_element() is Some(sidebar) else {
+    sidebar_remove_pointer_state(state.rail)
+    return
+  }
+  guard state.shell.to_html_element() is Some(shell) else {
+    sidebar_remove_pointer_state(state.rail)
+    return
+  }
+  let root_style = root.get_style()
+  let sidebar_style = sidebar.get_style()
+  let shell_style = shell.get_style()
+  if committed && dragged {
+    sidebar_restore_style_property(
+      sidebar_style,
+      "transition",
+      state.original_transition,
+    )
+    sidebar_restore_style_property(
+      shell_style,
+      "transition",
+      state.original_shell_transition,
+    )
+    sidebar_restore_style_property(
+      root_style,
+      "user-select",
+      state.original_user_select,
+    )
+    sidebar_restore_style_property(root_style, "cursor", state.original_cursor)
+    if !state.was_collapsed {
+      sidebar_restore_style_property(
+        sidebar_style,
+        "width",
+        state.original_sidebar_width,
+      )
+      sidebar_restore_style_property(
+        shell_style,
+        "width",
+        state.original_shell_width,
+      )
+    }
+  } else {
+    sidebar_restore_style_property(
+      root_style,
+      "--rui-sidebar-current-width",
+      state.original_current_width,
+    )
+    sidebar_restore_style_property(
+      sidebar_style,
+      "width",
+      state.original_sidebar_width,
+    )
+    sidebar_restore_style_property(
+      sidebar_style,
+      "transition",
+      state.original_transition,
+    )
+    sidebar_restore_style_property(
+      shell_style,
+      "width",
+      state.original_shell_width,
+    )
+    sidebar_restore_style_property(
+      shell_style,
+      "transition",
+      state.original_shell_transition,
+    )
+    sidebar_restore_style_property(
+      root_style,
+      "user-select",
+      state.original_user_select,
+    )
+    sidebar_restore_style_property(root_style, "cursor", state.original_cursor)
+  }
+  state.root.remove_attribute("data-resizing")
+  state.sidebar.remove_attribute("data-resizing")
+  state.rail.remove_attribute("data-resizing")
+  if state.lost_pointer_capture is Some(listener) {
+    state.rail.remove_event_listener("lostpointercapture", listener)
+    state.lost_pointer_capture = None
+  }
+  sidebar_remove_pointer_state(state.rail)
+  if state.captured {
+    state.captured = false
+    if state.rail.has_pointer_capture(state.pointer_id) {
+      state.rail.release_pointer_capture(state.pointer_id)
+    }
+  }
+  if committed && dragged {
+    ignore(
+      @dom.window().set_timeout(
+        () => sidebar_remove_click_suppression(state),
+        0,
+      ),
+    )
+  } else {
+    sidebar_remove_click_suppression(state)
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_pointer_start(
+  event : @dom.MouseEvent,
+  min_width : Int,
+  max_width : Int,
+) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  if pointer.get_default_prevented() ||
+    !pointer.get_is_primary() ||
+    (pointer.get_pointer_type() == "mouse" && pointer.get_button() != 0) {
+    return false
+  }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(rail) else { return false }
+  guard rail.closest("[data-slot=\"sidebar-wrapper\"]") is Some(root) else {
+    return false
+  }
+  guard rail.closest("[data-slot=\"sidebar\"]") is Some(sidebar) else {
+    return false
+  }
+  guard sidebar.closest("[data-slot=\"sidebar-shell\"]") is Some(shell) else {
+    return false
+  }
+  if sidebar.get_attribute("data-mobile").unwrap_or("") == "true" ||
+    sidebar.get_attribute("data-state").unwrap_or("") == "collapsed" {
+    return false
+  }
+  if sidebar_pointer_state(rail) is Some(previous) {
+    sidebar_release_pointer_state(previous, false)
+  }
+  guard root.to_html_element() is Some(root_html) else { return false }
+  guard sidebar.to_html_element() is Some(sidebar_html) else { return false }
+  guard shell.to_html_element() is Some(shell_html) else { return false }
+  let gutter = if shell.get_attribute("data-variant").unwrap_or("") == "sidebar" {
+    0
+  } else {
+    16
+  }
+  let min = min_width.max(1).to_double()
+  let available = root.get_bounding_client_rect().get_width() - 52.0
+  if available < min {
+    return false
+  }
+  let max = max_width.max(min_width.max(1)).to_double().min(available).max(min)
+  let start_width = (sidebar.get_bounding_client_rect().get_width() +
+  gutter.to_double()).clamp(min~, max~)
+  let root_style = root_html.get_style()
+  let sidebar_style = sidebar_html.get_style()
+  let shell_style = shell_html.get_style()
+  let state : SidebarPointerState = {
+    rail,
+    root,
+    sidebar,
+    shell,
+    pointer_id: pointer.get_pointer_id(),
+    right: sidebar.get_attribute("data-side").unwrap_or("") == "right",
+    gutter,
+    start_x: pointer.get_client_x(),
+    start_width,
+    min,
+    max,
+    width: start_width,
+    active: false,
+    was_collapsed: false,
+    original_current_width: root_style.get_property_value(
+      "--rui-sidebar-current-width",
+    ),
+    original_sidebar_width: sidebar_style.get_property_value("width"),
+    original_transition: sidebar_style.get_property_value("transition"),
+    original_shell_width: shell_style.get_property_value("width"),
+    original_shell_transition: shell_style.get_property_value("transition"),
+    original_user_select: root_style.get_property_value("user-select"),
+    original_cursor: root_style.get_property_value("cursor"),
+    captured: false,
+    suppress_click: None,
+    lost_pointer_capture: None,
+  }
+  let lost_pointer_capture : @dom.Listener = lost => {
+    if lost.to_pointer_event() is Some(lost_pointer) &&
+      lost_pointer.get_pointer_id() == state.pointer_id &&
+      sidebar_pointer_state(state.rail) is Some(_) {
+      sidebar_release_pointer_state(state, false)
+    }
+  }
+  state.lost_pointer_capture = Some(lost_pointer_capture)
+  rail.add_event_listener("lostpointercapture", lost_pointer_capture)
+  sidebar_pointer_states.push(state)
+  rail.set_pointer_capture(state.pointer_id)
+  if rail.has_pointer_capture(state.pointer_id) {
+    state.captured = true
+    true
+  } else {
+    sidebar_release_pointer_state(state, false)
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_pointer_move(event : @dom.MouseEvent) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(rail) else { return false }
+  guard sidebar_pointer_state(rail) is Some(state) else { return false }
+  guard state.pointer_id == pointer.get_pointer_id() else { return false }
+  guard state.root.to_html_element() is Some(root) else { return false }
+  guard state.sidebar.to_html_element() is Some(sidebar) else { return false }
+  guard state.shell.to_html_element() is Some(shell) else { return false }
+  let physical_delta = pointer.get_client_x() - state.start_x
+  if !state.active {
+    if physical_delta.abs() < 4 {
+      return false
+    }
+    state.active = true
+    sidebar_install_click_suppression(state)
+    state.root.set_attribute("data-resizing", "true")
+    state.sidebar.set_attribute("data-resizing", "true")
+    state.rail.set_attribute("data-resizing", "true")
+    root.get_style().set_property("user-select", "none")
+    root.get_style().set_property("cursor", "col-resize")
+  }
+  let delta = if state.right { -physical_delta } else { physical_delta }
+  state.width = (state.start_width + delta.to_double()).clamp(
+    min=state.min,
+    max=state.max,
+  )
+  let rounded_width = state.width.round().to_int().max(1)
+  root
+  .get_style()
+  .set_property("--rui-sidebar-current-width", "\{rounded_width}px")
+  sidebar.get_style().set_property("transition", "none")
+  sidebar
+  .get_style()
+  .set_property("width", "\{(rounded_width - state.gutter).max(1)}px")
+  shell.get_style().set_property("transition", "none")
+  shell.get_style().set_property("width", "\{rounded_width}px")
+  true
+}
+
+///|
+#cfg(target="js")
+fn sidebar_pointer_end(event : @dom.MouseEvent) -> Int {
+  guard event.to_pointer_event() is Some(pointer) else { return 0 }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return 0
+  }
+  guard current_target.to_element() is Some(rail) else { return 0 }
+  guard sidebar_pointer_state(rail) is Some(state) else { return 0 }
+  guard state.pointer_id == pointer.get_pointer_id() else { return 0 }
+  let width = if state.active { state.width.round().to_int().max(1) } else { 0 }
+  sidebar_release_pointer_state(state, state.active)
+  width
+}
+
+///|
+#cfg(target="js")
+fn sidebar_pointer_cancel(event : @dom.MouseEvent) -> Unit {
+  guard event.to_pointer_event() is Some(pointer) else { return }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return
+  }
+  guard current_target.to_element() is Some(rail) else { return }
+  guard sidebar_pointer_state(rail) is Some(state) else { return }
+  guard state.pointer_id == pointer.get_pointer_id() else { return }
+  sidebar_release_pointer_state(state, false)
+}
+
+///|
+fn sidebar_side_style(side : SidebarSide) -> String {
+  match side {
+    SidebarLeft =>
+      "--rui-sidebar-rail-left:auto;--rui-sidebar-rail-right:-0.5rem;--rui-sidebar-rail-line-left:50%;border-right:1px solid var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)))"
+    SidebarRight =>
+      "--rui-sidebar-rail-left:-0.5rem;--rui-sidebar-rail-right:auto;--rui-sidebar-rail-line-left:50%;border-left:1px solid var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)))"
+  }
+}
+
+///|
+fn sidebar_shell_side_style(side : SidebarSide) -> String {
+  match side {
+    SidebarLeft => "order:0"
+    SidebarRight => "order:1"
+  }
+}
+
+///|
+fn sidebar_mobile_side_style(side : SidebarSide) -> String {
+  match side {
+    SidebarLeft => "left:0"
+    SidebarRight => "right:0"
+  }
+}
+
+///|
+fn sidebar_mobile_state_style(side : SidebarSide, open : Bool) -> String {
+  if open {
+    "transform:translateX(0);opacity:1"
+  } else {
+    match side {
+      SidebarLeft => "transform:translateX(-100%);opacity:0"
+      SidebarRight => "transform:translateX(100%);opacity:0"
+    }
+  }
+}
+
+///|
+fn sidebar_variant_style(variant : SidebarVariant) -> String {
+  match variant {
+    SidebarDefault => ""
+    SidebarFloating =>
+      "border:1px solid var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)));border-radius:var(--rui-radius,0.625rem);box-shadow:0 1px 3px rgb(0 0 0 / 0.08)"
+    SidebarInset => "border:0;border-radius:0;box-shadow:none"
+  }
+}
+
+///|
+fn sidebar_desktop_position_style(
+  side : SidebarSide,
+  variant : SidebarVariant,
+) -> String {
+  if variant is SidebarDefault {
+    match side {
+      SidebarLeft => "left:0"
+      SidebarRight => "right:0"
+    }
+  } else {
+    match side {
+      SidebarLeft => "top:0.5rem;bottom:0.5rem;left:0.5rem"
+      SidebarRight => "top:0.5rem;bottom:0.5rem;right:0.5rem"
+    }
+  }
+}
+
+///|
+fn sidebar_desktop_surface_width_style(
+  collapsed : Bool,
+  collapsible : SidebarCollapsible,
+  variant : SidebarVariant,
+) -> String {
+  if collapsed && collapsible is SidebarIcon {
+    "width:var(--rui-sidebar-width-icon,3rem)"
+  } else if variant is SidebarDefault {
+    "width:var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))"
+  } else {
+    "width:calc(var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem)) - 1rem)"
+  }
+}
+
+///|
+fn sidebar_desktop_state_style(
+  side : SidebarSide,
+  collapsed : Bool,
+  collapsible : SidebarCollapsible,
+  variant : SidebarVariant,
+) -> String {
+  if collapsed && collapsible is SidebarOffcanvas {
+    if variant is SidebarDefault {
+      match side {
+        SidebarLeft => "transform:translateX(-100%)"
+        SidebarRight => "transform:translateX(100%)"
+      }
+    } else {
+      match side {
+        SidebarLeft => "transform:translateX(calc(-100% - 0.5rem))"
+        SidebarRight => "transform:translateX(calc(100% + 0.5rem))"
+      }
+    }
+  } else {
+    "transform:translateX(0)"
+  }
+}
+
+///|
+fn sidebar_shell_width_style(
+  collapsed : Bool,
+  collapsible : SidebarCollapsible,
+  variant : SidebarVariant,
+) -> String {
+  if collapsed && collapsible is SidebarOffcanvas {
+    "width:0px"
+  } else if collapsed && collapsible is SidebarIcon {
+    if variant is SidebarDefault {
+      "width:var(--rui-sidebar-width-icon,3rem)"
+    } else {
+      "width:calc(var(--rui-sidebar-width-icon,3rem) + 1rem)"
+    }
+  } else {
+    "width:var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))"
+  }
+}
+
+///|
+fn sidebar_descendant_state_style(
+  collapsed : Bool,
+  collapsible : SidebarCollapsible,
+  mobile : Bool,
+  side : SidebarSide,
+) -> String {
+  if mobile {
+    "--rui-sidebar-group-label-margin:0;--rui-sidebar-group-label-opacity:1;--rui-sidebar-group-label-pointer-events:auto;--rui-sidebar-group-action-display:inline-flex;--rui-sidebar-menu-action-display:inline-flex;--rui-sidebar-menu-badge-display:flex;--rui-sidebar-menu-sub-display:flex;--rui-sidebar-input-display:block;--rui-sidebar-content-overflow-y:auto;--rui-sidebar-item-collapse-width:100%;--rui-sidebar-item-collapse-height:var(--rui-sidebar-item-base-height,2rem);--rui-sidebar-item-collapse-gap:0.5rem;--rui-sidebar-item-collapse-font-size:var(--rui-sidebar-item-base-font-size,0.875rem);--rui-sidebar-item-justify-content:flex-start"
+  } else if collapsed && collapsible is SidebarIcon {
+    "--rui-sidebar-group-label-margin:-2rem;--rui-sidebar-group-label-opacity:0;--rui-sidebar-group-label-pointer-events:none;--rui-sidebar-group-action-display:none;--rui-sidebar-menu-action-display:none;--rui-sidebar-menu-badge-display:none;--rui-sidebar-menu-sub-display:none;--rui-sidebar-input-display:none;--rui-sidebar-content-overflow-y:hidden;--rui-sidebar-item-collapse-width:2rem;--rui-sidebar-item-collapse-height:2rem;--rui-sidebar-item-collapse-gap:0;--rui-sidebar-item-collapse-font-size:0;--rui-sidebar-item-justify-content:center;--rui-sidebar-item-local-padding-end:0.5rem;--rui-sidebar-badge-local-end:0.5rem;--rui-sidebar-skeleton-text-display:none;--rui-sidebar-rail-cursor:pointer"
+  } else if collapsed && collapsible is SidebarOffcanvas {
+    match side {
+      SidebarLeft =>
+        "--rui-sidebar-rail-cursor:pointer;--rui-sidebar-rail-left:auto;--rui-sidebar-rail-right:-1rem;--rui-sidebar-rail-line-left:0%"
+      SidebarRight =>
+        "--rui-sidebar-rail-cursor:pointer;--rui-sidebar-rail-left:-1rem;--rui-sidebar-rail-right:auto;--rui-sidebar-rail-line-left:100%"
+    }
+  } else {
+    ""
+  }
+}
+
+///|
+#cfg(target="js")
+const SidebarFocusableSelector : String = "a[href]:not([aria-disabled=\"true\"]):not([tabindex=\"-1\"]),button:not(:disabled):not([aria-disabled=\"true\"]):not([tabindex=\"-1\"]),input:not(:disabled):not([aria-disabled=\"true\"]):not([tabindex=\"-1\"]),select:not(:disabled):not([aria-disabled=\"true\"]):not([tabindex=\"-1\"]),textarea:not(:disabled):not([aria-disabled=\"true\"]):not([tabindex=\"-1\"]),[tabindex]:not([tabindex=\"-1\"]):not(:disabled):not([disabled]):not([aria-disabled=\"true\"])"
+
+///|
+#cfg(target="js")
+priv struct SidebarModalRecord {
+  node : @dom.Element
+  had_inert : Bool
+  inert_value : String
+  had_aria_hidden : Bool
+  aria_hidden : String
+}
+
+///|
+#cfg(target="js")
+priv struct SidebarModalState {
+  root : @dom.Element
+  records : Array[SidebarModalRecord]
+  observer : @dom.MutationObserver?
+}
+
+///|
+#cfg(target="js")
+priv struct SidebarDesktopCollapseFocus {
+  active : @dom.Element
+  sidebar : @dom.Element
+  wrapper : @dom.Element?
+}
+
+///|
+#cfg(target="js")
+priv struct SidebarMobileLayerBinding {
+  layer : @dom.Element
+  mut close_timer : Int?
+}
+
+///|
+#cfg(target="js")
+let sidebar_restore_trigger : Ref[@dom.Element?] = Ref(None)
+
+///|
+#cfg(target="js")
+let sidebar_modal_state : Ref[SidebarModalState?] = Ref(None)
+
+///|
+#cfg(target="js")
+let sidebar_desktop_collapse_focus : Ref[SidebarDesktopCollapseFocus?] = Ref(
+  None,
+)
+
+///|
+#cfg(target="js")
+let sidebar_focus_bound_documents : Array[@dom.Document] = []
+
+///|
+#cfg(target="js")
+let sidebar_mobile_layer_bindings : Array[SidebarMobileLayerBinding] = []
+
+///|
+#cfg(target="js")
+fn sidebar_document_elements(selector : String) -> Array[@dom.Element] {
+  let elements : Array[@dom.Element] = []
+  if !ui_has_document() {
+    return elements
+  }
+  let nodes = @dom.document().query_selector_all(selector)
+  for index in 0..<nodes.get_length().to_int() {
+    if nodes.item(index.to_double()).to_option() is Some(node) &&
+      node.to_element() is Some(element) {
+      elements.push(element)
+    }
+  }
+  elements
+}
+
+///|
+#cfg(target="js")
+fn sidebar_element_is_visible(element : @dom.Element) -> Bool {
+  if element.get_client_rects().length() == 0 ||
+    element.closest("[inert]") is Some(_) ||
+    !ui_element_is_enabled(element) {
+    return false
+  }
+  if ui_has_window() {
+    let style = @dom.window().get_computed_style(element)
+    style.get_property_value("display") != "none" &&
+    style.get_property_value("visibility") != "hidden"
+  } else {
+    true
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_focusable_elements(root : @dom.Element) -> Array[@dom.Element] {
+  root
+  .query_selector_all(SidebarFocusableSelector)
+  .filter(sidebar_element_is_visible)
+}
+
+///|
+#cfg(target="js")
+fn sidebar_focus_edge(root : @dom.Element, last : Bool) -> Unit {
+  let items = sidebar_focusable_elements(root)
+  let target = if items.length() == 0 {
+    root
+  } else if last {
+    items[items.length() - 1]
+  } else {
+    items[0]
+  }
+  ui_focus_element_without_scroll(target)
+  if target.is_same_node(root.as_node()) && ui_has_window() {
+    ignore(
+      @dom.window().request_animation_frame(_ => {
+        if !root.get_is_connected() ||
+          root.get_attribute("data-mobile-state").unwrap_or("") != "open" ||
+          !ui_has_document() {
+          return
+        }
+        let document = @dom.document()
+        guard document.get_active_element() is Some(active) &&
+          active.is_same_node(root.as_node()) else {
+          return
+        }
+        let refreshed = sidebar_focusable_elements(root)
+        if refreshed.length() > 0 {
+          ui_focus_element_without_scroll(
+            if last {
+              refreshed[refreshed.length() - 1]
+            } else {
+              refreshed[0]
+            },
+          )
+        }
+      }),
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_trap_focus(event : @dom.KeyboardEvent) -> Bool {
+  if event.key() != "Tab" ||
+    event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() {
+    return false
+  }
+  guard event.current_target().to_option() is Some(current) &&
+    current.to_element() is Some(root) else {
+    return false
+  }
+  if root.get_attribute("aria-hidden").unwrap_or("") == "true" {
+    return false
+  }
+  let items = sidebar_focusable_elements(root)
+  if items.length() == 0 {
+    ui_focus_element_without_scroll(root)
+    return true
+  }
+  let active = if ui_has_document() {
+    @dom.document().get_active_element()
+  } else {
+    None
+  }
+  let mut active_index = -1
+  if active is Some(active) {
+    for index, item in items {
+      if item.is_same_node(active.as_node()) {
+        active_index = index
+      }
+    }
+  }
+  let next_index = if event.shift_key() {
+    if active_index <= 0 {
+      items.length() - 1
+    } else {
+      active_index - 1
+    }
+  } else if active_index < 0 || active_index == items.length() - 1 {
+    0
+  } else {
+    active_index + 1
+  }
+  ui_focus_element_without_scroll(items[next_index])
+  true
+}
+
+///|
+#cfg(target="js")
+fn sidebar_bind_mobile_dismiss(attrs : @html.Attrs, command : @cmd.Cmd) -> Unit {
+  ignore(
+    attrs.on_keydown(event => {
+      if event.key() == "Escape" {
+        event.prevent_default()
+        command
+      } else if sidebar_trap_focus(event) {
+        event.prevent_default()
+        @cmd.none
+      } else {
+        @cmd.none
+      }
+    }),
+  )
+}
+
+///|
+#cfg(target="js")
+fn sidebar_current_mobile_root() -> @dom.Element? {
+  let roots = sidebar_document_elements(
+    "[data-slot=\"sidebar\"][data-mobile=\"true\"][data-mobile-state=\"open\"]",
+  ).filter(root => {
+    !root.has_attribute("hidden") &&
+    root.get_attribute("aria-hidden").unwrap_or("") != "true"
+  })
+  roots.get(roots.length() - 1)
+}
+
+///|
+#cfg(target="js")
+fn sidebar_release_modal() -> Unit {
+  guard sidebar_modal_state.val is Some(state) else { return }
+  if state.observer is Some(observer) {
+    observer.disconnect()
+  }
+  let mut index = state.records.length() - 1
+  while index >= 0 {
+    let record = state.records[index]
+    if record.had_inert {
+      record.node.set_attribute("inert", record.inert_value)
+    } else {
+      record.node.remove_attribute("inert")
+    }
+    if record.had_aria_hidden {
+      record.node.set_attribute("aria-hidden", record.aria_hidden)
+    } else {
+      record.node.remove_attribute("aria-hidden")
+    }
+    index -= 1
+  }
+  sidebar_modal_state.val = None
+}
+
+///|
+#cfg(target="js")
+fn sidebar_contain_background(root : @dom.Element) -> Unit {
+  if sidebar_modal_state.val is Some(state) &&
+    state.root.is_same_node(root.as_node()) {
+    return
+  }
+  sidebar_release_modal()
+  let records : Array[SidebarModalRecord] = []
+  let body = if ui_has_document() { @dom.document().get_body() } else { None }
+  let mut node = root
+  let mut complete = false
+  while !complete {
+    if node.get_parent_element() is Some(parent) {
+      for sibling in parent.get_children() {
+        if !sibling.is_same_node(node.as_node()) &&
+          sibling.get_attribute("data-slot").unwrap_or("") != "sidebar-overlay" {
+          records.push({
+            node: sibling,
+            had_inert: sibling.has_attribute("inert"),
+            inert_value: sibling.get_attribute("inert").unwrap_or(""),
+            had_aria_hidden: sibling.has_attribute("aria-hidden"),
+            aria_hidden: sibling.get_attribute("aria-hidden").unwrap_or(""),
+          })
+          sibling.set_attribute("inert", "")
+          sibling.set_attribute("aria-hidden", "true")
+        }
+      }
+      node = parent
+      complete = body is Some(body) && node.is_same_node(body.as_node())
+    } else {
+      complete = true
+    }
+  }
+  let observer = @dom.MutationObserver::new((_, _) => {
+    if !root.get_is_connected() ||
+      root.has_attribute("hidden") ||
+      root.get_attribute("aria-hidden").unwrap_or("") == "true" ||
+      root.get_attribute("data-mobile-state").unwrap_or("") != "open" {
+      sidebar_release_modal()
+    }
+  })
+  if ui_has_document() &&
+    @dom.document().get_document_element() is Some(document_element) {
+    observer.observe(
+      document_element.as_node(),
+      attributes=true,
+      child_list=true,
+      subtree=true,
+      attribute_filter=["data-mobile-state", "aria-hidden", "hidden"],
+    )
+  }
+  sidebar_modal_state.val = Some({ root, records, observer: Some(observer) })
+}
+
+///|
+#cfg(target="js")
+fn sidebar_document_is_bound(document : @dom.Document) -> Bool {
+  for bound in sidebar_focus_bound_documents {
+    if bound.to_node().is_same_node(document.to_node()) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+#cfg(target="js")
+fn sidebar_bind_focus_document(document : @dom.Document) -> Unit {
+  if sidebar_document_is_bound(document) {
+    return
+  }
+  sidebar_focus_bound_documents.push(document)
+  document.add_event_listener_with_options(
+    "focusin",
+    event => {
+      if sidebar_current_mobile_root() is Some(root) {
+        if !ui_element_contains_target(root, event.target()) {
+          sidebar_focus_edge(root, false)
+        }
+      } else {
+        sidebar_release_modal()
+      }
+    },
+    capture=true,
+  )
+  document.add_event_listener_with_options(
+    "keydown",
+    event => {
+      guard event.to_keyboard_event() is Some(keyboard) else { return }
+      guard sidebar_current_mobile_root() is Some(root) else {
+        sidebar_release_modal()
+        return
+      }
+      if keyboard.get_default_prevented() {
+        return
+      }
+      let active_outside = document.get_active_element() is Some(active) &&
+        !root.contains(active.as_node())
+      if keyboard.key() == "Tab" && active_outside {
+        keyboard.prevent_default()
+        sidebar_focus_edge(root, keyboard.shift_key())
+      } else if keyboard.key() == "Escape" &&
+        !ui_element_contains_target(root, keyboard.target()) {
+        keyboard.prevent_default()
+        if ui_has_window() {
+          // Re-dispatch the same typed event once the document dispatch completes.
+          @dom.window().queue_microtask(() => {
+            if root.get_is_connected() &&
+              root.get_attribute("data-mobile-state").unwrap_or("") == "open" {
+              root.dispatch_event(keyboard.as_event())
+            }
+          })
+        }
+      }
+    },
+    capture=true,
+  )
+}
+
+///|
+#cfg(target="js")
+fn sidebar_capture_active_restore_target(
+  document : @dom.Document,
+  root : @dom.Element,
+) -> Unit {
+  if sidebar_restore_trigger.val is Some(_) {
+    return
+  }
+  guard document.get_active_element() is Some(active) else { return }
+  if root.contains(active.as_node()) || active.to_html_element() is None {
+    return
+  }
+  if document.get_body() is Some(body) && active.is_same_node(body.as_node()) {
+    return
+  }
+  if document.get_document_element() is Some(document_element) &&
+    active.is_same_node(document_element.as_node()) {
+    return
+  }
+  sidebar_restore_trigger.val = Some(active)
+}
+
+///|
+#cfg(target="js")
+fn sidebar_focus_open() -> Bool {
+  if !ui_has_document() {
+    return false
+  }
+  let document = @dom.document()
+  sidebar_bind_focus_document(document)
+  guard sidebar_current_mobile_root() is Some(root) else { return false }
+  sidebar_capture_active_restore_target(document, root)
+  sidebar_contain_background(root)
+  if document.get_active_element() is None ||
+    (
+      document.get_active_element() is Some(active) &&
+      !root.contains(active.as_node())
+    ) {
+    sidebar_focus_edge(root, false)
+  }
+  document.get_active_element() is Some(active) &&
+  (root.contains(active.as_node()) || active.is_same_node(root.as_node()))
+}
+
+///|
+#cfg(target="js")
+fn sidebar_bind_mobile_focus(attrs : @html.Attrs, open : Bool) -> Unit {
+  if open {
+    ignore(
+      attrs.on_focus(_ => {
+        ignore(sidebar_focus_open())
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_bind_mobile_focus(attrs : @html.Attrs, open : Bool) -> Unit {
+  ignore((attrs, open))
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_bind_mobile_dismiss(attrs : @html.Attrs, command : @cmd.Cmd) -> Unit {
+  ignore((attrs, command))
+}
+
+///|
+#cfg(target="js")
+fn sidebar_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  if disabled {
+    ignore(
+      attrs.on_click(event => {
+        event.prevent_default()
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_bind_disabled_link(attrs : @html.Attrs, disabled : Bool) -> Unit {
+  ignore((attrs, disabled))
+}
+
+///|
+#cfg(target="js")
+fn sidebar_capture_restore_trigger(event : @dom.MouseEvent) -> Unit {
+  if event.current_target().to_option() is Some(current) &&
+    current.to_element() is Some(trigger) &&
+    trigger.to_html_element() is Some(_) {
+    sidebar_restore_trigger.val = Some(trigger)
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_bind_restore_trigger(attrs : @html.Attrs, enabled : Bool) -> Unit {
+  if enabled {
+    ignore(
+      attrs.on_click(event => {
+        sidebar_capture_restore_trigger(event)
+        @cmd.none
+      }),
+    )
+  }
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_bind_restore_trigger(attrs : @html.Attrs, enabled : Bool) -> Unit {
+  ignore((attrs, enabled))
+}
+
+///|
+#cfg(target="js")
+fn sidebar_restore_captured_trigger() -> Unit {
+  sidebar_release_modal()
+  let trigger = sidebar_restore_trigger.val
+  sidebar_restore_trigger.val = None
+  guard trigger is Some(trigger) else { return }
+  if trigger.get_is_connected() &&
+    ui_element_is_enabled(trigger) &&
+    trigger.closest("[inert],[hidden],[aria-hidden=\"true\"]") is None {
+    ui_focus_element_without_scroll(trigger)
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_mobile_layer_binding(
+  layer : @dom.Element,
+) -> SidebarMobileLayerBinding? {
+  for binding in sidebar_mobile_layer_bindings {
+    if binding.layer.is_same_node(layer.as_node()) {
+      return Some(binding)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn sidebar_prune_mobile_layer_bindings() -> Unit {
+  let mut index = 0
+  while index < sidebar_mobile_layer_bindings.length() {
+    let binding = sidebar_mobile_layer_bindings[index]
+    if binding.layer.get_is_connected() {
+      index += 1
+    } else {
+      if binding.close_timer is Some(timer) && ui_has_window() {
+        @dom.window().clear_timeout(timer)
+      }
+      ignore(sidebar_mobile_layer_bindings.remove(index))
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_finish_mobile_layer_close(
+  binding : SidebarMobileLayerBinding,
+) -> Unit {
+  binding.close_timer = None
+  if binding.layer.get_attribute("data-state").unwrap_or("") == "open" {
+    return
+  }
+  if binding.layer.to_html_element() is Some(layer) &&
+    binding.layer.matches(":popover-open") {
+    layer.hide_popover()
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_sync_mobile_layers() -> Unit {
+  if !ui_has_document() {
+    return
+  }
+  sidebar_prune_mobile_layer_bindings()
+  let layers = sidebar_document_elements(
+    "[data-slot=\"sidebar-mobile-layer\"][popover]",
+  )
+  for layer in layers {
+    let binding = if sidebar_mobile_layer_binding(layer) is Some(binding) {
+      binding
+    } else {
+      let binding : SidebarMobileLayerBinding = { layer, close_timer: None }
+      sidebar_mobile_layer_bindings.push(binding)
+      binding
+    }
+    let requested = layer.get_attribute("data-state").unwrap_or("") == "open"
+    let native_open = layer.matches(":popover-open")
+    if requested {
+      if binding.close_timer is Some(timer) {
+        if ui_has_window() {
+          @dom.window().clear_timeout(timer)
+        }
+        binding.close_timer = None
+      }
+      if !native_open && layer.to_html_element() is Some(html) {
+        html.show_popover()
+      }
+    } else if native_open && binding.close_timer is None {
+      if ui_has_window() {
+        binding.close_timer = Some(
+          @dom.window().set_timeout(
+            () => sidebar_finish_mobile_layer_close(binding),
+            200,
+          ),
+        )
+      } else {
+        sidebar_finish_mobile_layer_close(binding)
+      }
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_mobile_effect_cmd(open : Bool, restore_on_close : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    sidebar_sync_mobile_layers()
+    if open {
+      ignore(sidebar_focus_open())
+    } else if restore_on_close && !sidebar_focus_open() {
+      sidebar_restore_captured_trigger()
+    }
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_mobile_effect_cmd(open : Bool, restore_on_close : Bool) -> @cmd.Cmd {
+  ignore((open, restore_on_close))
+  @cmd.none
+}
+
+///|
+#cfg(target="js")
+fn sidebar_capture_desktop_collapse_focus() -> Unit {
+  sidebar_desktop_collapse_focus.val = None
+  if !ui_has_document() {
+    return
+  }
+  guard @dom.document().get_active_element() is Some(active) else { return }
+  guard active.closest("[data-slot=\"sidebar\"][data-mobile=\"false\"]")
+    is Some(sidebar) else {
+    return
+  }
+  if active.get_attribute("data-slot").unwrap_or("") == "sidebar-rail" {
+    return
+  }
+  sidebar_desktop_collapse_focus.val = Some({
+    active,
+    sidebar,
+    wrapper: sidebar.closest("[data-slot=\"sidebar-wrapper\"]"),
+  })
+}
+
+///|
+#cfg(target="js")
+fn sidebar_restore_desktop_collapse_focus() -> Unit {
+  let captured = sidebar_desktop_collapse_focus.val
+  sidebar_desktop_collapse_focus.val = None
+  guard captured is Some(state) else { return }
+  if !ui_has_document() ||
+    !state.sidebar.get_is_connected() ||
+    state.sidebar.get_attribute("data-state").unwrap_or("") != "collapsed" {
+    return
+  }
+  let document = @dom.document()
+  guard document.get_active_element() is Some(current) else { return }
+  let active_still_current = current.is_same_node(state.active.as_node())
+  let body_is_current = document.get_body() is Some(body) &&
+    current.is_same_node(body.as_node())
+  if !active_still_current && !body_is_current {
+    return
+  }
+  let hidden = !state.active.get_is_connected() ||
+    state.sidebar.get_attribute("data-collapsible").unwrap_or("") == "offcanvas" ||
+    state.active.get_client_rects().length() == 0 ||
+    (
+      ui_has_window() &&
+      (
+        @dom.window()
+        .get_computed_style(state.active)
+        .get_property_value("display") ==
+        "none" ||
+        @dom.window()
+        .get_computed_style(state.active)
+        .get_property_value("visibility") ==
+        "hidden"
+      )
+    )
+  if !hidden {
+    return
+  }
+  let trigger = if state.wrapper is Some(wrapper) {
+    wrapper.query_selector(
+      "[data-slot=\"sidebar-trigger\"][aria-expanded=\"false\"]:not(:disabled):not([aria-disabled=\"true\"])",
+    )
+  } else {
+    None
+  }
+  let target = if trigger is Some(trigger) {
+    Some(trigger)
+  } else {
+    state.sidebar.query_selector("[data-slot=\"sidebar-rail\"]")
+  }
+  if target is Some(target) {
+    ui_focus_element_without_scroll(target)
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_desktop_collapse_focus_cmd() -> @cmd.Cmd {
+  @cmd.batch([
+    @cmd.custom_cmd(kind=@cmd.Immediately, _ => {
+      sidebar_capture_desktop_collapse_focus()
+    }),
+    @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+      sidebar_restore_desktop_collapse_focus()
+    }),
+  ])
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_desktop_collapse_focus_cmd() -> @cmd.Cmd {
+  @cmd.none
+}
+
+///|
+fn sidebar_mobile_change_cmd(
+  notify : @cmd.Emit[Bool]?,
+  open : Bool,
+) -> @cmd.Cmd {
+  @cmd.batch([
+    sidebar_emit_bool(notify, open),
+    sidebar_mobile_effect_cmd(open, true),
+  ])
+}
+
+///|
+fn sidebar_provider_width_style(width : Int?) -> String {
+  match width {
+    Some(width) => "--rui-sidebar-current-width:\{width}px"
+    None => ""
+  }
+}
+
+///|
+fn sidebar_menu_size_value(size : SidebarMenuButtonSize) -> String {
+  match size {
+    SidebarMenuSm => "sm"
+    SidebarMenuDefault => "default"
+    SidebarMenuLg => "lg"
+  }
+}
+
+///|
+fn sidebar_menu_variant_value(variant : SidebarMenuButtonVariant) -> String {
+  match variant {
+    SidebarMenuButtonDefault => "default"
+    SidebarMenuButtonOutline => "outline"
+  }
+}
+
+///|
+fn sidebar_menu_variant_style(variant : SidebarMenuButtonVariant) -> String {
+  match variant {
+    SidebarMenuButtonDefault => ""
+    SidebarMenuButtonOutline => SidebarMenuButtonOutlineStyle
+  }
+}
+
+///|
+fn sidebar_menu_size_style(size : SidebarMenuButtonSize) -> String {
+  match size {
+    SidebarMenuSm =>
+      "height:var(--rui-sidebar-item-collapse-height,1.75rem);--rui-sidebar-item-base-height:1.75rem;--rui-sidebar-item-base-font-size:0.75rem"
+    SidebarMenuDefault =>
+      "height:var(--rui-sidebar-item-collapse-height,2rem);--rui-sidebar-item-base-height:2rem;--rui-sidebar-item-base-font-size:0.875rem"
+    SidebarMenuLg =>
+      "height:var(--rui-sidebar-item-collapse-height,3rem);--rui-sidebar-item-base-height:3rem;--rui-sidebar-item-base-font-size:0.875rem"
+  }
+}
+
+///|
+fn sidebar_emit_bool(emit : @cmd.Emit[Bool]?, value : Bool) -> @cmd.Cmd {
+  if emit is Some(notify) {
+    notify(value)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn sidebar_scope(
+  state : SidebarState,
+  emit : @cmd.Emit[SidebarMessage],
+) -> SidebarScope {
+  {
+    collapsed: state.collapsed,
+    mobile_open: state.mobile_open,
+    desktop_width: state.desktop_width,
+    toggle_collapsed: emit(ToggleSidebarCollapsed),
+    expand: emit(SetSidebarCollapsed(false)),
+    collapse: emit(SetSidebarCollapsed(true)),
+    toggle_mobile: emit(ToggleSidebarMobile),
+    open_mobile: emit(SetSidebarMobile(true)),
+    close_mobile: emit(SetSidebarMobile(false)),
+    commit_width: emit.map(width => CommitSidebarWidth(width)),
+  }
+}
+
+///|
+fn sidebar_provider_view(
+  scope : SidebarScope,
+  id : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (SidebarScope) -> @html.Html,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar-wrapper")
+    .data_set("state", sidebar_state_value(scope.collapsed))
+    .data_set("mobile", if scope.mobile_open { "open" } else { "closed" })
+    .data_set(
+      "width",
+      match scope.desktop_width {
+        Some(width) => "\{width}"
+        None => "auto"
+      },
+    )
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        SidebarProviderStyle,
+        sidebar_provider_width_style(scope.desktop_width),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children(scope),
+  )
+}
+
+///|
+/// Own desktop-collapse and mobile-open state for a complete sidebar tree.
+/// The native fallback renders the requested initial state as a constant value.
+#cfg(target="js")
+pub fn sidebar_provider(
+  default_collapsed? : Bool = false,
+  default_mobile_open? : Bool = false,
+  on_collapsed_change? : @cmd.Emit[Bool],
+  on_mobile_open_change? : @cmd.Emit[Bool],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (SidebarScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let initial : SidebarState = {
+    collapsed: default_collapsed,
+    mobile_open: default_mobile_open,
+    desktop_width: None,
+  }
+  let (state, emit) = @rabbita.create_state_with_init(
+    init=fn(_) {
+      (
+        initial,
+        if default_mobile_open {
+          sidebar_mobile_effect_cmd(true, false)
+        } else {
+          @cmd.none
+        },
+      )
+    },
+    update=fn(_, msg, state) {
+      match msg {
+        ToggleSidebarCollapsed => {
+          let next = !state.collapsed
+          (
+            { ..state, collapsed: next },
+            @cmd.batch([
+              sidebar_emit_bool(on_collapsed_change, next),
+              if next {
+                sidebar_desktop_collapse_focus_cmd()
+              } else {
+                @cmd.none
+              },
+            ]),
+          )
+        }
+        SetSidebarCollapsed(next) =>
+          if next == state.collapsed {
+            (state, @cmd.none)
+          } else {
+            (
+              { ..state, collapsed: next },
+              @cmd.batch([
+                sidebar_emit_bool(on_collapsed_change, next),
+                if next {
+                  sidebar_desktop_collapse_focus_cmd()
+                } else {
+                  @cmd.none
+                },
+              ]),
+            )
+          }
+        ToggleSidebarMobile => {
+          let next = !state.mobile_open
+          (
+            { ..state, mobile_open: next },
+            sidebar_mobile_change_cmd(on_mobile_open_change, next),
+          )
+        }
+        SetSidebarMobile(next) =>
+          if next == state.mobile_open {
+            (state, @cmd.none)
+          } else {
+            (
+              { ..state, mobile_open: next },
+              sidebar_mobile_change_cmd(on_mobile_open_change, next),
+            )
+          }
+        CommitSidebarWidth(width) => {
+          let next = { ..state, collapsed: false, desktop_width: Some(width) }
+          if next == state {
+            (state, @cmd.none)
+          } else {
+            (
+              next,
+              if state.collapsed {
+                sidebar_emit_bool(on_collapsed_change, false)
+              } else {
+                @cmd.none
+              },
+            )
+          }
+        }
+      }
+    },
+  )
+  state.view(state => {
+    sidebar_provider_view(
+      sidebar_scope(state, emit),
+      id,
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn sidebar_provider(
+  default_collapsed? : Bool = false,
+  default_mobile_open? : Bool = false,
+  on_collapsed_change? : @cmd.Emit[Bool],
+  on_mobile_open_change? : @cmd.Emit[Bool],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (SidebarScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_collapsed_change, on_mobile_open_change))
+  let scope : SidebarScope = {
+    collapsed: default_collapsed,
+    mobile_open: default_mobile_open,
+    desktop_width: None,
+    toggle_collapsed: @cmd.none,
+    expand: @cmd.none,
+    collapse: @cmd.none,
+    toggle_mobile: @cmd.none,
+    open_mobile: @cmd.none,
+    close_mobile: @cmd.none,
+    commit_width: @cmd.Emit(_ => @cmd.none),
+  }
+  @rabbita.Val::constant(
+    sidebar_provider_view(scope, id, class, title, attrs, style, children),
+  )
+}
+
+///|
+pub fn sidebar_is_collapsed(scope : SidebarScope) -> Bool {
+  scope.collapsed
+}
+
+///|
+pub fn sidebar_is_mobile_open(scope : SidebarScope) -> Bool {
+  scope.mobile_open
+}
+
+///|
+/// Commands for applications that need custom controls instead of the default
+/// trigger and rail.
+pub fn sidebar_expand(scope : SidebarScope) -> @cmd.Cmd {
+  scope.expand
+}
+
+///|
+pub fn sidebar_collapse(scope : SidebarScope) -> @cmd.Cmd {
+  scope.collapse
+}
+
+///|
+pub fn sidebar_open_mobile(scope : SidebarScope) -> @cmd.Cmd {
+  scope.open_mobile
+}
+
+///|
+pub fn sidebar_close_mobile(scope : SidebarScope) -> @cmd.Cmd {
+  scope.close_mobile
+}
+
+///|
+/// Render either the desktop sidebar or its explicit mobile sheet form.
+/// `mobile=true` is intentional: inline styles have no hidden stylesheet or
+/// breakpoint registration, so applications choose when to switch forms.
+pub fn[C : @html.IsChildren] sidebar(
+  scope : SidebarScope,
+  side? : SidebarSide = SidebarLeft,
+  variant? : SidebarVariant = SidebarDefault,
+  collapsible? : SidebarCollapsible = SidebarOffcanvas,
+  mobile? : Bool = false,
+  aria_label? : String = "Sidebar",
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool = false,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  overlay_attrs? : @html.Attrs,
+  overlay_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let collapsed = if mobile || collapsible == SidebarFixed {
+    false
+  } else {
+    scope.collapsed
+  }
+  let is_hidden = hidden
+  let mobile_open = scope.mobile_open && !is_hidden
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar")
+    .data_set("side", sidebar_side_value(side))
+    .data_set("variant", sidebar_variant_value(variant))
+    .data_set("collapsible", sidebar_collapsible_value(collapsible))
+    .data_set("state", sidebar_state_value(collapsed))
+    .data_set("mobile", ui_bool(mobile))
+    .data_set("mobile-state", if mobile_open { "open" } else { "closed" })
+    .aria_label(aria_label)
+  if mobile {
+    ignore(
+      element_attrs
+      .role("dialog")
+      .aria_modal("true")
+      .aria_hidden(ui_bool(!mobile_open))
+      .inert(!mobile_open)
+      .autofocus(mobile_open)
+      .tabindex(-1),
+    )
+    sidebar_bind_mobile_dismiss(element_attrs, scope.close_mobile)
+    sidebar_bind_mobile_focus(element_attrs, mobile_open)
+  }
+  let surface = @html.aside(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        SidebarBaseStyle,
+        if mobile {
+          SidebarMobileStyle
+        } else {
+          SidebarDesktopStyle
+        },
+        if mobile {
+          sidebar_mobile_side_style(side)
+        } else {
+          ""
+        },
+        if mobile {
+          sidebar_mobile_state_style(side, mobile_open)
+        } else {
+          ""
+        },
+        sidebar_side_style(side),
+        if mobile {
+          ""
+        } else {
+          sidebar_variant_style(variant)
+        },
+        if mobile {
+          ""
+        } else {
+          sidebar_desktop_position_style(side, variant)
+        },
+        if mobile {
+          ""
+        } else {
+          sidebar_desktop_surface_width_style(collapsed, collapsible, variant)
+        },
+        if mobile {
+          ""
+        } else {
+          sidebar_desktop_state_style(side, collapsed, collapsible, variant)
+        },
+        sidebar_descendant_state_style(collapsed, collapsible, mobile, side),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden=is_hidden,
+    attrs=element_attrs,
+    children,
+  )
+  if mobile {
+    let backdrop_attrs = ui_attrs(overlay_attrs)
+      .data_set("slot", "sidebar-overlay")
+      .data_set("state", if mobile_open { "open" } else { "closed" })
+      .aria_hidden("true")
+    ignore(backdrop_attrs.on_click(_ => scope.close_mobile))
+    let layer_attrs = @html.Attrs::build()
+      .data_set("slot", "sidebar-mobile-layer")
+      .data_set("state", if mobile_open { "open" } else { "closed" })
+      .popover("manual")
+    @html.div(
+      style=[UiBoxSizing, UiFontSans, SidebarMobileLayerStyle],
+      attrs=layer_attrs,
+      [
+        @html.div(
+          style=ui_styles(
+            [
+              UiBoxSizing,
+              SidebarOverlayStyle,
+              if mobile_open {
+                SidebarOverlayOpenStyle
+              } else {
+                SidebarOverlayClosedStyle
+              },
+            ],
+            overlay_style,
+          ),
+          attrs=backdrop_attrs,
+          @html.nothing,
+        ),
+        surface,
+      ],
+    )
+  } else {
+    let shell_attrs = @html.Attrs::build()
+      .data_set("slot", "sidebar-shell")
+      .data_set("side", sidebar_side_value(side))
+      .data_set("variant", sidebar_variant_value(variant))
+      .data_set("collapsible", sidebar_collapsible_value(collapsible))
+      .data_set("state", sidebar_state_value(collapsed))
+    @html.div(
+      style=[
+        UiBoxSizing,
+        SidebarShellStyle,
+        sidebar_shell_side_style(side),
+        sidebar_shell_width_style(collapsed, collapsible, variant),
+      ],
+      hidden=is_hidden,
+      attrs=shell_attrs,
+      surface,
+    )
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_trigger(
+  scope : SidebarScope,
+  mobile? : Bool = false,
+  controls? : String,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String = "Toggle sidebar",
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let expanded = if mobile { scope.mobile_open } else { !scope.collapsed }
+  let trigger_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar-trigger")
+    .data_set("state", if expanded { "open" } else { "closed" })
+    .aria_expanded(ui_bool(expanded))
+  if controls is Some(value) {
+    ignore(trigger_attrs.aria_controls(value))
+  }
+  sidebar_bind_restore_trigger(
+    trigger_attrs,
+    mobile && !scope.mobile_open && !disabled,
+  )
+  dialog_control_button(
+    slot="sidebar-trigger",
+    command=if mobile { scope.toggle_mobile } else { scope.toggle_collapsed },
+    variant=Ghost,
+    size=IconSm,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label=Some(aria_label),
+    on_click~,
+    attrs=Some(trigger_attrs),
+    style=ui_styles(
+      ["width:1.75rem;height:1.75rem;--rui-button-base-shadow:0 0 #0000"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+#cfg(target="js")
+fn sidebar_bind_resize_attrs(
+  attrs : @html.Attrs,
+  scope : SidebarScope,
+  min_width : Int,
+  max_width : Int,
+) -> Unit {
+  ignore(
+    attrs
+    .on_pointerdown(event => {
+      ignore(sidebar_pointer_start(event, min_width, max_width))
+      @cmd.none
+    })
+    .on_pointermove(event => {
+      if sidebar_pointer_move(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    })
+    .on_pointerup(event => {
+      let width = sidebar_pointer_end(event)
+      if width > 0 {
+        event.prevent_default()
+        (scope.commit_width)(width)
+      } else {
+        @cmd.none
+      }
+    })
+    .on_pointercancel(event => {
+      sidebar_pointer_cancel(event)
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn sidebar_bind_resize_attrs(
+  attrs : @html.Attrs,
+  scope : SidebarScope,
+  min_width : Int,
+  max_width : Int,
+) -> Unit {
+  ignore((attrs, scope, min_width, max_width))
+}
+
+///|
+/// Render the desktop edge control for toggling and pointer resizing.
+/// Placement and resize direction are derived from the nearest sidebar.
+pub fn sidebar_rail(
+  scope : SidebarScope,
+  min_width? : Int = 160,
+  max_width? : Int = 512,
+  id? : String,
+  class? : String,
+  title? : String = "Toggle sidebar",
+  aria_label? : String = "Toggle sidebar",
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let line_edge = "transform:translateX(-50%)"
+  let rail_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar-rail")
+    .data_set("min-width", "\{min_width}")
+    .data_set("max-width", "\{max_width}")
+    .aria_expanded(ui_bool(!scope.collapsed))
+    .tabindex(-1)
+  ignore(
+    rail_attrs.on_click(_ => {
+      @cmd.batch([
+        match on_click {
+          Some(command) => command
+          None => @cmd.none
+        },
+        scope.toggle_collapsed,
+      ])
+    }),
+  )
+  sidebar_bind_resize_attrs(rail_attrs, scope, min_width, max_width)
+  dialog_control_button(
+    slot="sidebar-rail",
+    command=@cmd.none,
+    variant=Ghost,
+    size=IconXs,
+    disabled=false,
+    id~,
+    class~,
+    title=Some(title),
+    aria_label=Some(aria_label),
+    on_click=None,
+    attrs=Some(rail_attrs),
+    style=ui_styles([SidebarRailStyle], style),
+    @html.span(
+      attrs=@html.Attrs::build()
+        .data_set("slot", "sidebar-rail-line")
+        .aria_hidden("true"),
+      style=[SidebarRailLineStyle, line_edge],
+      @html.nothing,
+    ),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, SidebarHeaderFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, SidebarHeaderFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-footer"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, SidebarContentStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-content"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_group(
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("slot", "sidebar-group")
+  if aria_label is Some(label) {
+    ignore(element_attrs.role("group").aria_label(label))
+  }
+  @html.div(
+    style=ui_styles([UiBoxSizing, SidebarGroupStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_group_label(
+  scope? : SidebarScope,
+  hide_when_collapsed? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  // The owning sidebar knows whether its collapse mode actually hides labels.
+  // Rely on that inherited custom property so SidebarFixed never hides a label
+  // merely because the provider also drives a different collapsed sidebar.
+  ignore(scope)
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        SidebarGroupLabelStyle,
+        if hide_when_collapsed {
+          ""
+        } else {
+          "--rui-sidebar-group-label-local-margin:0;--rui-sidebar-group-label-local-opacity:1;--rui-sidebar-group-label-local-pointer-events:auto"
+        },
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "sidebar-group-label")
+      .data_set("state", if hide_when_collapsed { "auto" } else { "visible" }),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_group_action(
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  dialog_control_button(
+    slot="sidebar-group-action",
+    command=@cmd.none,
+    variant=Ghost,
+    size=IconXs,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs~,
+    style=ui_styles(
+      [
+        SidebarGroupActionStyle,
+        SidebarActionSurfaceStyle,
+        SidebarActionSizeStyle,
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_group_content(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, SidebarGroupContentStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-group-content"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.ul(
+    style=ui_styles([UiBoxSizing, SidebarMenuStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-menu"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu_item(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.li(
+    style=ui_styles([UiBoxSizing, SidebarMenuItemStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-menu-item"),
+    children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] render_sidebar_menu_button(
+  href : String?,
+  is_active : Bool,
+  variant : SidebarMenuButtonVariant,
+  size : SidebarMenuButtonSize,
+  disabled : Bool,
+  aria_label : String?,
+  target : @html.Target,
+  rel : String?,
+  download : String?,
+  on_click : @cmd.Cmd?,
+  id : String?,
+  class_ : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar-menu-button")
+    .data_set("variant", sidebar_menu_variant_value(variant))
+    .data_set("size", sidebar_menu_size_value(size))
+    .data_set("active", ui_bool(is_active))
+    .data_set("state", if is_active { "active" } else { "inactive" })
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if is_active && href is Some(_) {
+    ignore(element_attrs.aria_current("page"))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  sidebar_bind_disabled_link(element_attrs, disabled && href is Some(_))
+  let styles = ui_styles(
+    [
+      UiBoxSizing,
+      UiFontSans,
+      UiTextRendering,
+      UiTransition,
+      SidebarMenuButtonStyle,
+      sidebar_menu_variant_style(variant),
+      sidebar_menu_size_style(size),
+      if is_active {
+        SidebarMenuButtonActiveStyle
+      } else {
+        ""
+      },
+      ui_disabled_style(disabled),
+    ],
+    style,
+  )
+  match href {
+    Some(href) =>
+      @html.a(
+        style=styles,
+        id?,
+        class?=class_,
+        title?,
+        href~,
+        target~,
+        rel?,
+        download?,
+        attrs=element_attrs,
+        children,
+      )
+    None =>
+      @html.button(
+        style=styles,
+        id?,
+        class?=class_,
+        title?,
+        type_="button",
+        disabled~,
+        attrs=element_attrs,
+        children,
+      )
+  }
+}
+
+///|
+/// Render a native button, or a native anchor when `href` is supplied.
+pub fn[C : @html.IsChildren] sidebar_menu_button(
+  href? : String,
+  is_active? : Bool = false,
+  variant? : SidebarMenuButtonVariant = SidebarMenuButtonDefault,
+  size? : SidebarMenuButtonSize = SidebarMenuDefault,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  render_sidebar_menu_button(
+    href, is_active, variant, size, disabled, aria_label, target, rel, download,
+    on_click, id, class, title, attrs, style, children,
+  )
+}
+
+///|
+fn[C : @html.IsChildren] render_sidebar_menu_button_with_tooltip(
+  id : String,
+  tooltip : String,
+  open : Bool,
+  href : String?,
+  is_active : Bool,
+  variant : SidebarMenuButtonVariant,
+  size : SidebarMenuButtonSize,
+  disabled : Bool,
+  aria_label : String?,
+  target : @html.Target,
+  rel : String?,
+  download : String?,
+  on_click : @cmd.Cmd?,
+  class_ : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  tooltip_side : PopupSide,
+  tooltip_align : PopupAlign,
+  tooltip_side_offset : Int,
+  tooltip_align_offset : Int,
+  tooltip_show_arrow : Bool,
+  tooltip_attrs : @html.Attrs?,
+  tooltip_style : Array[String],
+  children : C,
+) -> @html.Html {
+  let content_id = id + "-tooltip"
+  let trigger_attrs = ui_attrs(attrs)
+    .data_set("tooltip-root", "")
+    .data_set("tooltip-state", if open { "open" } else { "closed" })
+    .data_set("close-on-click", "true")
+    .data_set("hoverable", "true")
+    .data_set("sidebar-collapsed-only", "true")
+  if open {
+    ignore(trigger_attrs.aria_describedby(content_id))
+  }
+  let content_attrs = ui_attrs(tooltip_attrs).data_set("tooltip-owner-id", id)
+  @html.fragment([
+    render_sidebar_menu_button(
+      href,
+      is_active,
+      variant,
+      size,
+      disabled,
+      aria_label,
+      target,
+      rel,
+      download,
+      on_click,
+      Some(id),
+      class_,
+      title,
+      Some(trigger_attrs),
+      style,
+      children,
+    ),
+    tooltip_content(
+      id=content_id,
+      trigger_id=id,
+      open~,
+      side=tooltip_side,
+      align=tooltip_align,
+      side_offset=tooltip_side_offset,
+      align_offset=tooltip_align_offset,
+      show_arrow=tooltip_show_arrow,
+      attrs=content_attrs,
+      style=tooltip_style,
+      tooltip,
+    ),
+  ])
+}
+
+///|
+/// Render a sidebar menu button with a tooltip that is active only while its
+/// desktop icon sidebar is collapsed.
+///
+/// The tooltip reuses the button or anchor as its trigger, so this API never
+/// nests interactive elements. Expanded, off-canvas, fixed, and mobile
+/// sidebars suppress the tooltip automatically.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] sidebar_menu_button_with_tooltip(
+  id~ : String,
+  tooltip~ : String,
+  href? : String,
+  is_active? : Bool = false,
+  variant? : SidebarMenuButtonVariant = SidebarMenuButtonDefault,
+  size? : SidebarMenuButtonSize = SidebarMenuDefault,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  on_click? : @cmd.Cmd,
+  on_tooltip_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  tooltip_side? : PopupSide = Right,
+  tooltip_align? : PopupAlign = Center,
+  tooltip_side_offset? : Int = 4,
+  tooltip_align_offset? : Int = 0,
+  tooltip_show_arrow? : Bool = true,
+  tooltip_attrs? : @html.Attrs,
+  tooltip_style? : Array[String] = [],
+  children : C,
+) -> @rabbita.Val[@html.Html] {
+  let content_id = id + "-tooltip"
+  let initial_model : TooltipModel = {
+    open: false,
+    trigger_hovered: false,
+    trigger_focused: false,
+    content_hovered: false,
+    generation: 0,
+  }
+  let (model, _) = @rabbita.create_state_with_init(
+    init=emit => {
+      let sync = emit.map(value => TooltipNativeChanged(value))
+      (
+        initial_model,
+        @cmd.batch([
+          floating_bind_sync_cmd(content_id, sync),
+          tooltip_bind_trigger_events_cmd(content_id, id, id, emit),
+        ]),
+      )
+    },
+    update=(emit, msg, current) => {
+      tooltip_update(
+        content_id, true, on_tooltip_open_change, emit, msg, current,
+      )
+    },
+  )
+  model.view(model => {
+    render_sidebar_menu_button_with_tooltip(
+      id,
+      tooltip,
+      model.open,
+      href,
+      is_active,
+      variant,
+      size,
+      disabled,
+      aria_label,
+      target,
+      rel,
+      download,
+      on_click,
+      class,
+      title,
+      attrs,
+      style,
+      tooltip_side,
+      tooltip_align,
+      tooltip_side_offset,
+      tooltip_align_offset,
+      tooltip_show_arrow,
+      tooltip_attrs,
+      tooltip_style,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] sidebar_menu_button_with_tooltip(
+  id~ : String,
+  tooltip~ : String,
+  href? : String,
+  is_active? : Bool = false,
+  variant? : SidebarMenuButtonVariant = SidebarMenuButtonDefault,
+  size? : SidebarMenuButtonSize = SidebarMenuDefault,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  on_click? : @cmd.Cmd,
+  on_tooltip_open_change? : @cmd.Emit[Bool],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  tooltip_side? : PopupSide = Right,
+  tooltip_align? : PopupAlign = Center,
+  tooltip_side_offset? : Int = 4,
+  tooltip_align_offset? : Int = 0,
+  tooltip_show_arrow? : Bool = true,
+  tooltip_attrs? : @html.Attrs,
+  tooltip_style? : Array[String] = [],
+  children : C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_tooltip_open_change)
+  @rabbita.Val::constant(
+    render_sidebar_menu_button_with_tooltip(
+      id, tooltip, false, href, is_active, variant, size, disabled, aria_label, target,
+      rel, download, on_click, class, title, attrs, style, tooltip_side, tooltip_align,
+      tooltip_side_offset, tooltip_align_offset, tooltip_show_arrow, tooltip_attrs,
+      tooltip_style, children,
+    ),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu_action(
+  show_on_hover? : Bool = false,
+  disabled? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar-menu-action")
+    .data_set("show-on-hover", ui_bool(show_on_hover))
+  dialog_control_button(
+    slot="sidebar-menu-action",
+    command=@cmd.none,
+    variant=Ghost,
+    size=IconXs,
+    disabled~,
+    id~,
+    class~,
+    title~,
+    aria_label~,
+    on_click~,
+    attrs=Some(element_attrs),
+    style=ui_styles(
+      [
+        SidebarMenuActionStyle,
+        SidebarActionSurfaceStyle,
+        SidebarActionSizeStyle,
+        if show_on_hover {
+          SidebarMenuActionHoverStyle
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu_badge(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.span(
+    style=ui_styles([UiBoxSizing, SidebarMenuBadgeStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-menu-badge"),
+    children,
+  )
+}
+
+///|
+pub fn sidebar_menu_skeleton(
+  show_icon? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "display:flex;height:2rem;align-items:center;gap:0.5rem;padding-inline:0.5rem;border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem)",
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "sidebar-menu-skeleton")
+      .data_set("icon", ui_bool(show_icon))
+      .aria_hidden("true"),
+    [
+      if show_icon {
+        skeleton(
+          attrs=@html.Attrs::build().data_set("sidebar-skeleton-part", "icon"),
+          style=["width:1rem;height:1rem;flex-shrink:0;border-radius:0.25rem"],
+        )
+      } else {
+        @html.nothing
+      },
+      skeleton(
+        attrs=@html.Attrs::build().data_set("sidebar-skeleton-part", "text"),
+        style=[
+          "display:var(--rui-sidebar-skeleton-text-display,block);height:0.75rem;width:70%;border-radius:0.25rem",
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu_sub(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.ul(
+    style=ui_styles([UiBoxSizing, SidebarMenuSubStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-menu-sub"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu_sub_item(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.li(
+    style=ui_styles([UiBoxSizing, SidebarMenuItemStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-menu-sub-item"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_menu_sub_button(
+  href? : String,
+  is_active? : Bool = false,
+  disabled? : Bool = false,
+  aria_label? : String,
+  target? : @html.Target = Self,
+  rel? : String,
+  download? : String,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "sidebar-menu-sub-button")
+    .data_set("active", ui_bool(is_active))
+    .data_set("state", if is_active { "active" } else { "inactive" })
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if is_active && href is Some(_) {
+    ignore(element_attrs.aria_current("page"))
+  }
+  if disabled {
+    ignore(
+      element_attrs.aria_disabled("true").data_set("disabled", "").tabindex(-1),
+    )
+  } else if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  sidebar_bind_disabled_link(element_attrs, disabled && href is Some(_))
+  let styles = ui_styles(
+    [
+      UiBoxSizing,
+      UiFontSans,
+      UiTransition,
+      SidebarMenuSubButtonStyle,
+      if is_active {
+        SidebarMenuButtonActiveStyle
+      } else {
+        ""
+      },
+      ui_disabled_style(disabled),
+    ],
+    style,
+  )
+  match href {
+    Some(href) =>
+      @html.a(
+        style=styles,
+        id?,
+        class?,
+        title?,
+        href~,
+        target~,
+        rel?,
+        download?,
+        attrs=element_attrs,
+        children,
+      )
+    None =>
+      @html.button(
+        style=styles,
+        id?,
+        class?,
+        title?,
+        type_="button",
+        disabled~,
+        attrs=element_attrs,
+        children,
+      )
+  }
+}
+
+///|
+pub fn sidebar_separator(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        "width:auto;height:1px;flex-shrink:0;margin-inline:0.5rem;background:var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)))",
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "sidebar-separator")
+      .role("separator")
+      .aria_orientation("horizontal"),
+    @html.nothing,
+  )
+}
+
+///|
+pub fn sidebar_input(
+  name? : String,
+  value? : String,
+  placeholder? : String,
+  auto_complete? : @html.AutoComplete,
+  id? : String,
+  class? : String,
+  title? : String,
+  disabled? : Bool = false,
+  aria_label? : String,
+  on_change? : @cmd.Emit[String],
+  on_input? : @cmd.Emit[String],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("slot", "sidebar-input")
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  if disabled {
+    ignore(element_attrs.disabled(true).data_set("disabled", ""))
+  }
+  @html.input(
+    input_type=@html.Text,
+    name?,
+    value?,
+    placeholder?,
+    auto_complete?,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        InputBaseStyle,
+        "height:2rem;--rui-control-base-shadow:0 0 #0000;background:var(--rui-background,oklch(1 0 0));font-size:0.875rem;line-height:1.25rem",
+        "display:var(--rui-sidebar-input-display,block)",
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    on_change?,
+    on_input?,
+    attrs=element_attrs,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] sidebar_inset(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles([UiBoxSizing, SidebarInsetStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "sidebar-inset").role("main"),
+    children,
+  )
+}

--- a/rui/sidebar_menu_button_test.mbt
+++ b/rui/sidebar_menu_button_test.mbt
@@ -1,0 +1,102 @@
+///|
+#cfg(target="js")
+extern "js" fn install_sidebar_menu_button_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_sidebar_menu_button_value(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_sidebar_menu_button_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_sidebar_menu_button_value(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+test "sidebar menu button variants preserve native button and anchor semantics" {
+  let default_button = render(
+    @rui.sidebar_menu_button(id="default-menu-button", "Overview"),
+  )
+  assert_contains(default_button, "<button")
+  assert_contains(default_button, "type=\"button\"")
+  assert_contains(default_button, "data-slot=\"sidebar-menu-button\"")
+  assert_contains(default_button, "data-variant=\"default\"")
+  assert_not_contains(
+    default_button, "--rui-sidebar-item-base-shadow:0 0 0 1px",
+  )
+
+  let outline_anchor = render(
+    @rui.sidebar_menu_button(
+      href="/projects",
+      is_active=true,
+      variant=@rui.SidebarMenuButtonOutline,
+      "Projects",
+    ),
+  )
+  assert_contains(outline_anchor, "<a")
+  assert_contains(outline_anchor, "href=\"/projects\"")
+  assert_contains(outline_anchor, "aria-current=\"page\"")
+  assert_contains(outline_anchor, "data-variant=\"outline\"")
+  assert_contains(
+    outline_anchor, "--rui-sidebar-item-base-bg:var(--rui-background,oklch(1 0 0))",
+  )
+  assert_contains(
+    outline_anchor, "--rui-sidebar-item-base-shadow:0 0 0 1px var(--rui-sidebar-border",
+  )
+}
+
+///|
+test "sidebar tooltip reuses its anchor trigger without an interactive wrapper" {
+  let html = render_sidebar_menu_button_value(() => {
+    @rui.sidebar_menu_button_with_tooltip(
+      id="projects-link",
+      tooltip="Projects",
+      href="/projects",
+      variant=@rui.SidebarMenuButtonOutline,
+      tooltip_side=@rui.Right,
+      "Projects",
+    )
+  })
+  assert_contains(html, "<a")
+  assert_contains(html, "id=\"projects-link\"")
+  assert_contains(html, "href=\"/projects\"")
+  assert_contains(html, "data-slot=\"sidebar-menu-button\"")
+  assert_contains(html, "data-tooltip-root=\"\"")
+  assert_contains(html, "data-sidebar-collapsed-only=\"true\"")
+  assert_contains(html, "id=\"projects-link-tooltip\"")
+  assert_contains(html, "data-slot=\"tooltip-content\"")
+  assert_contains(html, "data-tooltip-owner-id=\"projects-link\"")
+  assert_contains(html, "data-state=\"closed\"")
+  assert_not_contains(html, "<button")
+  assert_not_contains(html, "aria-describedby=\"projects-link-tooltip\"")
+  assert_not_contains(html, "projects-link-tooltip-root")
+}
+
+///|
+test "sidebar tooltip reuses its button trigger without nesting buttons" {
+  let html = render_sidebar_menu_button_value(() => {
+    @rui.sidebar_menu_button_with_tooltip(
+      id="settings-button",
+      tooltip="Settings",
+      "Settings",
+    )
+  })
+  assert_eq(html.split("<button").count(), 2)
+  assert_contains(html, "id=\"settings-button\"")
+  assert_contains(html, "id=\"settings-button-tooltip\"")
+}

--- a/rui/sidebar_pointer_wbtest.mbt
+++ b/rui/sidebar_pointer_wbtest.mbt
@@ -1,0 +1,403 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_pointer_fixture(
+  side : String,
+  collapsed : Bool,
+  start_width : Int,
+  preferred_width : Int,
+  root_width : Int,
+) -> Unit =
+  #| (side, collapsed, startWidth, preferredWidth, rootWidth) => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const style = entries => {
+  #|     const values = new Map(entries)
+  #|     return {
+  #|       getPropertyValue: name => values.get(name) || "",
+  #|       setProperty: (name, value) => { values.set(name, String(value)) },
+  #|       removeProperty: name => {
+  #|         const value = values.get(name) || ""
+  #|         values.delete(name)
+  #|         return value
+  #|       },
+  #|     }
+  #|   }
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture = {
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own("PointerEvent"),
+  #|     captures: 0,
+  #|     releases: 0,
+  #|     prevented: 0,
+  #|     stopped: 0,
+  #|     listeners: {},
+  #|     clicks: 0,
+  #|     timeouts: [],
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class PointerEvent {
+  #|     constructor(init) {
+  #|       Object.assign(this, init)
+  #|       this.defaultPrevented = init.defaultPrevented ?? false
+  #|     }
+  #|     preventDefault() {
+  #|       this.defaultPrevented = true
+  #|       fixture.prevented += 1
+  #|     }
+  #|   }
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement, PointerEvent })
+  #|   const dataName = name => name.replace(/^data-/, "").replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+  #|   const dataMethods = element => Object.assign(element, {
+  #|     getAttribute(name) { return this.dataset[dataName(name)] ?? "" },
+  #|     setAttribute(name, value) { this.dataset[dataName(name)] = String(value) },
+  #|     removeAttribute(name) { delete this.dataset[dataName(name)] },
+  #|   })
+  #|   const root = dataMethods(new HTMLElement())
+  #|   Object.assign(root, {
+  #|     dataset: { slot: "sidebar-wrapper" },
+  #|     style: style([]),
+  #|     getBoundingClientRect: () => ({ width: rootWidth }),
+  #|   })
+  #|   const sidebarStyle = style([[
+  #|     "width",
+  #|     collapsed
+  #|       ? "var(--rui-sidebar-width-icon,3rem)"
+  #|       : "var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  #|   ], ["transition", "width 200ms ease,transform 200ms ease"]])
+  #|   const shellStyle = style([
+  #|     ["width", "var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))"],
+  #|     ["transition", "width 200ms linear"],
+  #|   ])
+  #|   const shell = dataMethods(new HTMLElement())
+  #|   Object.assign(shell, {
+  #|     dataset: { slot: "sidebar-shell", variant: "sidebar" },
+  #|     style: shellStyle,
+  #|   })
+  #|   const sidebar = dataMethods(new HTMLElement())
+  #|   Object.assign(sidebar, {
+  #|     dataset: {
+  #|       state: collapsed ? "collapsed" : "expanded",
+  #|       mobile: "false",
+  #|       side,
+  #|     },
+  #|     style: sidebarStyle,
+  #|     getBoundingClientRect: () => {
+  #|       const width = sidebarStyle.getPropertyValue("width")
+  #|       if (/^-?\d+(?:\.\d+)?px$/.test(width)) return { width: Number.parseFloat(width) }
+  #|       if (width.includes("--rui-sidebar-current-width")) return { width: preferredWidth }
+  #|       return { width: startWidth }
+  #|     },
+  #|     closest: selector => selector.includes("sidebar-shell") ? shell : null,
+  #|   })
+  #|   const rail = dataMethods(new HTMLElement())
+  #|   Object.assign(rail, {
+  #|     dataset: {},
+  #|     closest: selector => selector.includes("sidebar-wrapper")
+  #|       ? root
+  #|       : selector.includes("sidebar-shell") ? shell
+  #|       : selector.includes('data-slot="sidebar"') ? sidebar : null,
+  #|     addEventListener: (type, callback) => { fixture.listeners[type] = callback },
+  #|     removeEventListener: (type, callback) => {
+  #|       if (fixture.listeners[type] === callback) delete fixture.listeners[type]
+  #|     },
+  #|     setPointerCapture(pointerId) {
+  #|       this.__capturedPointerId = pointerId
+  #|       fixture.captures += 1
+  #|     },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId !== pointerId) return
+  #|       delete this.__capturedPointerId
+  #|       fixture.releases += 1
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|     click: () => { fixture.clicks += 1 },
+  #|   })
+  #|   fixture.root = root
+  #|   fixture.sidebar = sidebar
+  #|   fixture.shell = shell
+  #|   fixture.rail = rail
+  #|   globalThis.window = {
+  #|     setTimeout(callback) {
+  #|       fixture.timeouts.push(callback)
+  #|       return fixture.timeouts.length
+  #|     },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_pointer_fixture_event(
+  client_x : Int,
+  pointer_id : Int,
+) -> @dom.MouseEvent =
+  #| (clientX, pointerId) => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   return new PointerEvent({
+  #|     currentTarget: fixture.rail,
+  #|     target: fixture.rail,
+  #|     clientX,
+  #|     clientY: 100,
+  #|     pointerId,
+  #|     pointerType: "mouse",
+  #|     button: 0,
+  #|     isPrimary: true,
+  #|     defaultPrevented: false,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_pointer_fixture_variant(variant : String) -> Unit =
+  #| variant => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   if (fixture?.shell?.dataset) fixture.shell.dataset.variant = variant
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_pointer_fixture_property(kind : Int) -> String =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   if (kind === 0) return fixture.root.style.getPropertyValue("--rui-sidebar-current-width")
+  #|   if (kind === 1) return fixture.sidebar.style.getPropertyValue("width")
+  #|   if (kind === 2) return fixture.sidebar.style.getPropertyValue("transition")
+  #|   if (kind === 3) return fixture.root.style.getPropertyValue("user-select")
+  #|   if (kind === 4) return fixture.shell.style.getPropertyValue("width")
+  #|   if (kind === 5) return fixture.shell.style.getPropertyValue("transition")
+  #|   return fixture.root.style.getPropertyValue("cursor")
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_pointer_fixture_count(kind : Int) -> Int =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   if (kind === 0) return fixture.captures
+  #|   if (kind === 1) return fixture.releases
+  #|   if (kind === 2) return fixture.prevented
+  #|   if (kind === 3) return fixture.stopped
+  #|   if (kind === 4) return fixture.clicks
+  #|   return 0
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_pointer_fixture_click() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   const listener = fixture.listeners.click
+  #|   if (!listener) return false
+  #|   const event = {
+  #|     defaultPrevented: false,
+  #|     preventDefault() { this.defaultPrevented = true },
+  #|     stopImmediatePropagation() { fixture.stopped += 1 },
+  #|     stopPropagation() { fixture.stopped += 1 },
+  #|   }
+  #|   listener(event)
+  #|   return event.defaultPrevented
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_pointer_fixture_lost(pointer_id : Int) -> Unit =
+  #| pointerId => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   delete fixture.rail.__capturedPointerId
+  #|   fixture.listeners.lostpointercapture?.(new PointerEvent({
+  #|     pointerId,
+  #|     currentTarget: fixture.rail,
+  #|     target: fixture.rail,
+  #|   }))
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarPointerFixture
+  #|   if (!fixture) return
+  #|   for (const callback of fixture.timeouts) callback()
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiSidebarPointerFixture
+  #|   delete globalThis.__ruiSidebarDispatchingCommitClick
+  #| }
+
+///|
+#cfg(target="js")
+test "sidebar rail resizes left and suppresses the synthetic toggle click" {
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 640)
+  let down = ffi_sidebar_pointer_fixture_event(100, 7)
+  let move_event = ffi_sidebar_pointer_fixture_event(160, 7)
+  let up = ffi_sidebar_pointer_fixture_event(160, 7)
+  assert_true(sidebar_pointer_start(down, 160, 512))
+  assert_true(sidebar_pointer_move(move_event))
+  assert_eq(ffi_sidebar_pointer_fixture_property(0), "300px")
+  assert_eq(ffi_sidebar_pointer_fixture_property(1), "300px")
+  assert_eq(ffi_sidebar_pointer_fixture_property(4), "300px")
+  assert_eq(ffi_sidebar_pointer_fixture_property(5), "none")
+  assert_eq(ffi_sidebar_pointer_fixture_property(6), "col-resize")
+  assert_eq(sidebar_pointer_end(up), 300)
+  assert_eq(ffi_sidebar_pointer_fixture_count(0), 1)
+  assert_eq(ffi_sidebar_pointer_fixture_count(1), 1)
+  assert_true(ffi_sidebar_pointer_fixture_click())
+  assert_eq(ffi_sidebar_pointer_fixture_count(3), 2)
+  assert_eq(
+    ffi_sidebar_pointer_fixture_property(4),
+    "var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  )
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "sidebar rail reverses right-side delta and clamps both bounds" {
+  ffi_install_sidebar_pointer_fixture("right", false, 240, 240, 640)
+  let down = ffi_sidebar_pointer_fixture_event(300, 11)
+  assert_true(sidebar_pointer_start(down, 160, 400))
+  assert_true(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(360, 11)))
+  assert_eq(
+    sidebar_pointer_end(ffi_sidebar_pointer_fixture_event(360, 11)),
+    180,
+  )
+  ffi_restore_sidebar_pointer_fixture()
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 640)
+  assert_true(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 12), 160, 400),
+  )
+  assert_true(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(700, 12)))
+  assert_eq(
+    sidebar_pointer_end(ffi_sidebar_pointer_fixture_event(700, 12)),
+    400,
+  )
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "sidebar rail preserves clicks below threshold and restores cancellation" {
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 640)
+  assert_true(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 20), 160, 512),
+  )
+  assert_false(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(103, 20)))
+  assert_eq(sidebar_pointer_end(ffi_sidebar_pointer_fixture_event(103, 20)), 0)
+  assert_false(ffi_sidebar_pointer_fixture_click())
+  ffi_restore_sidebar_pointer_fixture()
+  ffi_install_sidebar_pointer_fixture("left", true, 48, 240, 640)
+  assert_false(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 21), 160, 512),
+  )
+  assert_false(ffi_sidebar_pointer_fixture_click())
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "sidebar rail lost pointer capture cancels an in-flight preview" {
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 640)
+  assert_true(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 31), 160, 512),
+  )
+  assert_true(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(180, 31)))
+  ffi_sidebar_pointer_fixture_lost(31)
+  assert_eq(ffi_sidebar_pointer_fixture_property(0), "")
+  assert_eq(
+    ffi_sidebar_pointer_fixture_property(1),
+    "var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  )
+  assert_eq(ffi_sidebar_pointer_fixture_count(1), 0)
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "sidebar pointer cancel rolls back an active preview" {
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 640)
+  assert_true(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 37), 160, 512),
+  )
+  assert_true(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(180, 37)))
+  sidebar_pointer_cancel(ffi_sidebar_pointer_fixture_event(180, 37))
+  assert_eq(ffi_sidebar_pointer_fixture_property(0), "")
+  assert_eq(
+    ffi_sidebar_pointer_fixture_property(1),
+    "var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  )
+  assert_eq(ffi_sidebar_pointer_fixture_count(1), 1)
+  assert_false(ffi_sidebar_pointer_fixture_click())
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "sidebar pointer capture commits a drag that ends outside the rail" {
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 640)
+  assert_true(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 41), 160, 512),
+  )
+  assert_true(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(900, 41)))
+  assert_eq(ffi_sidebar_pointer_fixture_property(0), "512px")
+  assert_eq(
+    sidebar_pointer_end(ffi_sidebar_pointer_fixture_event(900, 41)),
+    512,
+  )
+  assert_eq(ffi_sidebar_pointer_fixture_count(4), 0)
+  assert_eq(ffi_sidebar_pointer_fixture_count(0), 1)
+  assert_eq(ffi_sidebar_pointer_fixture_count(1), 1)
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "floating sidebar resizes one total-width token without double-counting its gutter" {
+  ffi_install_sidebar_pointer_fixture("left", false, 224, 224, 640)
+  ffi_sidebar_pointer_fixture_variant("floating")
+  assert_true(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 47), 160, 512),
+  )
+  assert_true(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(160, 47)))
+  assert_eq(ffi_sidebar_pointer_fixture_property(0), "300px")
+  assert_eq(ffi_sidebar_pointer_fixture_property(1), "284px")
+  assert_eq(ffi_sidebar_pointer_fixture_property(4), "300px")
+  assert_eq(
+    sidebar_pointer_end(ffi_sidebar_pointer_fixture_event(160, 47)),
+    300,
+  )
+  ffi_restore_sidebar_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "sidebar rail refuses resize when the root cannot honor its minimum" {
+  ffi_install_sidebar_pointer_fixture("left", false, 240, 240, 40)
+  assert_false(
+    sidebar_pointer_start(ffi_sidebar_pointer_fixture_event(100, 51), 160, 512),
+  )
+  assert_false(sidebar_pointer_move(ffi_sidebar_pointer_fixture_event(180, 51)))
+  assert_eq(ffi_sidebar_pointer_fixture_property(0), "")
+  assert_eq(
+    ffi_sidebar_pointer_fixture_property(1),
+    "var(--rui-sidebar-current-width,var(--rui-sidebar-width,16rem))",
+  )
+  assert_eq(ffi_sidebar_pointer_fixture_count(0), 0)
+  ffi_restore_sidebar_pointer_fixture()
+}

--- a/rui/sidebar_tooltip_wbtest.mbt
+++ b/rui/sidebar_tooltip_wbtest.mbt
@@ -1,0 +1,421 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_tooltip_fixture(
+  content_id : String,
+  trigger_id : String,
+) -> Unit =
+  #| (contentId, triggerId) => {
+  #|   const keys = [
+  #|     "window", "document", "EventTarget", "Node", "Element",
+  #|     "HTMLElement", "HTMLDialogElement", "Document", "Window", "Event",
+  #|     "MouseEvent", "KeyboardEvent", "FocusEvent", "ToggleEvent",
+  #|     "MutationObserver",
+  #|   ]
+  #|   const globals = new Map(keys.map(key => [key, {
+  #|     had: Object.prototype.hasOwnProperty.call(globalThis, key),
+  #|     value: globalThis[key],
+  #|   }]))
+  #|   class FakeEventTarget {
+  #|     constructor() { this.listeners = new Map() }
+  #|     addEventListener(type, callback, options = {}) {
+  #|       const listeners = this.listeners.get(type) ?? []
+  #|       listeners.push({ callback, once: Boolean(options?.once) })
+  #|       this.listeners.set(type, listeners)
+  #|     }
+  #|     removeEventListener(type, callback) {
+  #|       this.listeners.set(
+  #|         type,
+  #|         (this.listeners.get(type) ?? []).filter(item => item.callback !== callback),
+  #|       )
+  #|     }
+  #|     dispatchEvent(event) {
+  #|       if (!(event instanceof FakeEvent)) throw new TypeError("Event required")
+  #|       if (!event.target) event.target = this
+  #|       event.currentTarget = this
+  #|       const listeners = [...(this.listeners.get(event.type) ?? [])]
+  #|       for (const item of listeners) {
+  #|         item.callback(event)
+  #|         if (item.once) this.removeEventListener(event.type, item.callback)
+  #|         if (event.immediatePropagationStopped) break
+  #|       }
+  #|       event.currentTarget = null
+  #|       return !event.defaultPrevented
+  #|     }
+  #|   }
+  #|   class FakeNode extends FakeEventTarget {
+  #|     constructor(nodeType) {
+  #|       super()
+  #|       this.nodeType = nodeType
+  #|       this.parentNode = null
+  #|       this.isConnected = true
+  #|     }
+  #|     contains(node) {
+  #|       for (let current = node; current; current = current.parentNode) {
+  #|         if (current === this) return true
+  #|       }
+  #|       return false
+  #|     }
+  #|   }
+  #|   class FakeStyle {
+  #|     constructor() { this.values = new Map() }
+  #|     getPropertyValue(name) { return this.values.get(name) ?? "" }
+  #|     setProperty(name, value) { this.values.set(name, String(value)) }
+  #|     removeProperty(name) {
+  #|       const previous = this.getPropertyValue(name)
+  #|       this.values.delete(name)
+  #|       return previous
+  #|     }
+  #|   }
+  #|   class FakeElement extends FakeNode {
+  #|     constructor(id, attributes = {}) {
+  #|       super(1)
+  #|       this.id = id
+  #|       this.attributes = new Map()
+  #|       this.children = []
+  #|       this.parentElement = null
+  #|       this.style = new FakeStyle()
+  #|       this.focusVisible = true
+  #|       for (const [name, value] of Object.entries(attributes)) {
+  #|         this.setAttribute(name, value)
+  #|       }
+  #|     }
+  #|     setAttribute(name, value) { this.attributes.set(name, String(value)) }
+  #|     getAttribute(name) {
+  #|       if (name === "id") return this.id
+  #|       return this.attributes.get(name) ?? ""
+  #|     }
+  #|     hasAttribute(name) { return this.attributes.has(name) }
+  #|     removeAttribute(name) { this.attributes.delete(name) }
+  #|     append(child) {
+  #|       child.parentNode = this
+  #|       child.parentElement = this
+  #|       this.children.push(child)
+  #|     }
+  #|     matches(selector) {
+  #|       if (selector === ":focus-visible") return this.focusVisible
+  #|       if (selector === ":popover-open") return Boolean(this.popoverOpen)
+  #|       const slot = selector.match(/^\[data-slot="([^"]+)"\]$/)?.[1]
+  #|       return slot ? this.getAttribute("data-slot") === slot : false
+  #|     }
+  #|     closest(selector) {
+  #|       for (let current = this; current; current = current.parentElement) {
+  #|         if (current.matches(selector)) return current
+  #|       }
+  #|       return null
+  #|     }
+  #|     querySelectorAll(selector) {
+  #|       const result = []
+  #|       const visit = element => {
+  #|         for (const child of element.children) {
+  #|           if (child.matches(selector)) result.push(child)
+  #|           visit(child)
+  #|         }
+  #|       }
+  #|       visit(this)
+  #|       return result
+  #|     }
+  #|     querySelector(selector) { return this.querySelectorAll(selector)[0] ?? null }
+  #|   }
+  #|   class FakeHTMLElement extends FakeElement {
+  #|     constructor(id, attributes = {}) {
+  #|       super(id, attributes)
+  #|       this.popover = null
+  #|       this.popoverOpen = false
+  #|     }
+  #|     focus() {}
+  #|     showPopover() {
+  #|       if (this.popoverOpen) return
+  #|       this.popoverOpen = true
+  #|       this.dispatchEvent(new FakeToggleEvent("toggle", {
+  #|         oldState: "closed", newState: "open",
+  #|       }))
+  #|     }
+  #|     hidePopover() {
+  #|       if (!this.popoverOpen) return
+  #|       this.popoverOpen = false
+  #|       this.dispatchEvent(new FakeToggleEvent("toggle", {
+  #|         oldState: "open", newState: "closed",
+  #|       }))
+  #|     }
+  #|   }
+  #|   class FakeHTMLDialogElement extends FakeHTMLElement {}
+  #|   class FakeEvent {
+  #|     constructor(type, init = {}) {
+  #|       this.type = type
+  #|       this.cancelable = Boolean(init.cancelable)
+  #|       this.defaultPrevented = false
+  #|       this.propagationStopped = false
+  #|       this.immediatePropagationStopped = false
+  #|       this.target = init.target ?? null
+  #|       this.currentTarget = null
+  #|       this.timeStamp = 0
+  #|     }
+  #|     preventDefault() { if (this.cancelable) this.defaultPrevented = true }
+  #|     stopPropagation() { this.propagationStopped = true }
+  #|     stopImmediatePropagation() {
+  #|       this.immediatePropagationStopped = true
+  #|       this.propagationStopped = true
+  #|     }
+  #|     composedPath() { return this.target ? [this.target] : [] }
+  #|   }
+  #|   class FakeMouseEvent extends FakeEvent {}
+  #|   class FakeKeyboardEvent extends FakeEvent {
+  #|     constructor(type, init = {}) { super(type, init); this.key = init.key ?? "" }
+  #|   }
+  #|   class FakeFocusEvent extends FakeEvent {
+  #|     constructor(type, init = {}) {
+  #|       super(type, init)
+  #|       this.relatedTarget = init.relatedTarget ?? null
+  #|     }
+  #|   }
+  #|   class FakeToggleEvent extends FakeEvent {
+  #|     constructor(type, init = {}) {
+  #|       super(type, init)
+  #|       this.oldState = init.oldState ?? "closed"
+  #|       this.newState = init.newState ?? "closed"
+  #|     }
+  #|   }
+  #|   class FakeDocument extends FakeNode {
+  #|     constructor() {
+  #|       super(9)
+  #|       this.body = new FakeHTMLElement("body")
+  #|       this.documentElement = new FakeHTMLElement("html")
+  #|       this.activeElement = this.body
+  #|     }
+  #|     getElementById(value) {
+  #|       if (value === contentId) return popup
+  #|       if (value === triggerId) return trigger
+  #|       if (value === "sidebar") return sidebar
+  #|       return null
+  #|     }
+  #|   }
+  #|   class FakeWindow extends FakeEventTarget {
+  #|     constructor() { super(); this.performance = { now: () => 0 } }
+  #|     requestAnimationFrame(callback) { callback(0); return 1 }
+  #|     queueMicrotask(callback) { callback() }
+  #|     getComputedStyle(element) { return element.style }
+  #|   }
+  #|   let fixture
+  #|   class FakeMutationObserver {
+  #|     constructor(callback) { fixture.observer = callback }
+  #|     observe() {}
+  #|     disconnect() {}
+  #|   }
+  #|   const sidebar = new FakeHTMLElement("sidebar", {
+  #|     "data-slot": "sidebar",
+  #|     "data-collapsible": "icon",
+  #|     "data-state": "expanded",
+  #|     "data-mobile": "false",
+  #|   })
+  #|   const trigger = new FakeHTMLElement(triggerId, {
+  #|     "data-sidebar-collapsed-only": "true",
+  #|     "data-close-on-click": "true",
+  #|     "data-hoverable": "true",
+  #|   })
+  #|   const popup = new FakeHTMLElement(contentId, {
+  #|     "data-slot": "tooltip-content",
+  #|     "data-trigger-id": triggerId,
+  #|     "data-tooltip-owner-id": triggerId,
+  #|     "data-restore-focus": "false",
+  #|   })
+  #|   popup.popover = "manual"
+  #|   sidebar.append(trigger)
+  #|   const document = new FakeDocument()
+  #|   const window = new FakeWindow()
+  #|   window.document = document
+  #|   fixture = globalThis.__ruiSidebarTooltipFixture = {
+  #|     globals, contentId, triggerId, sidebar, trigger, popup,
+  #|     observer: null, escapeEvent: null,
+  #|   }
+  #|   Object.assign(globalThis, {
+  #|     window, document, EventTarget: FakeEventTarget, Node: FakeNode,
+  #|     Element: FakeElement, HTMLElement: FakeHTMLElement,
+  #|     HTMLDialogElement: FakeHTMLDialogElement, Document: FakeDocument,
+  #|     Window: FakeWindow, Event: FakeEvent, MouseEvent: FakeMouseEvent,
+  #|     KeyboardEvent: FakeKeyboardEvent, FocusEvent: FakeFocusEvent,
+  #|     ToggleEvent: FakeToggleEvent, MutationObserver: FakeMutationObserver,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_tooltip_fixture_set_context(
+  collapsed : Bool,
+  mobile : Bool,
+  icon : Bool,
+) -> Unit =
+  #| (collapsed, mobile, icon) => {
+  #|   const sidebar = globalThis.__ruiSidebarTooltipFixture.sidebar
+  #|   sidebar.setAttribute("data-state", collapsed ? "collapsed" : "expanded")
+  #|   sidebar.setAttribute("data-mobile", mobile ? "true" : "false")
+  #|   sidebar.setAttribute("data-collapsible", icon ? "icon" : "offcanvas")
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_tooltip_fixture_set_disabled(
+  disabled : Bool,
+) -> Unit =
+  #| disabled => {
+  #|   const trigger = globalThis.__ruiSidebarTooltipFixture.trigger
+  #|   if (disabled) trigger.setAttribute("aria-disabled", "true")
+  #|   else trigger.removeAttribute("aria-disabled")
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_tooltip_fixture_fire(type_ : String) -> Unit =
+  #| type => {
+  #|   const fixture = globalThis.__ruiSidebarTooltipFixture
+  #|   const event = type === "focus"
+  #|     ? new FocusEvent(type)
+  #|     : new MouseEvent(type)
+  #|   fixture.trigger.dispatchEvent(event)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_tooltip_fixture_fire_observer() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarTooltipFixture
+  #|   fixture.observer?.([], null)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_tooltip_fixture_fire_escape() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarTooltipFixture
+  #|   fixture.escapeEvent = new KeyboardEvent("keydown", {
+  #|     key: "Escape", cancelable: true,
+  #|   })
+  #|   document.dispatchEvent(fixture.escapeEvent)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_tooltip_fixture_escape_handled() -> Bool =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarTooltipFixture
+  #|   return Boolean(
+  #|     fixture.escapeEvent?.defaultPrevented &&
+  #|     fixture.escapeEvent?.propagationStopped,
+  #|   )
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_tooltip_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarTooltipFixture
+  #|   if (!fixture) return
+  #|   fixture.sidebar.isConnected = false
+  #|   fixture.trigger.isConnected = false
+  #|   fixture.popup.isConnected = false
+  #|   for (const [key, saved] of fixture.globals) {
+  #|     if (saved.had) globalThis[key] = saved.value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   delete globalThis.__ruiSidebarTooltipFixture
+  #| }
+
+///|
+#cfg(target="js")
+fn reset_sidebar_tooltip_bindings(id : String) -> Unit {
+  if tooltip_event_bindings.get(id) is Some(binding) &&
+    binding.sidebar_observer.val is Some(observer) {
+    observer.disconnect()
+  }
+  ignore(tooltip_event_bindings.remove(id))
+  if floating_live_layer(id) is Some(_) {
+    ignore(set_floating_open(id, false))
+  }
+  floating_stop(id)
+  ignore(floating_layers.remove(id))
+  floating_update_stack(id, false)
+}
+
+///|
+#cfg(target="js")
+test "sidebar tooltip opens only for collapsed desktop icons and handles Escape" {
+  let kind = Ref(-1)
+  let wait = Ref(-1)
+  ffi_install_sidebar_tooltip_fixture(
+    "sidebar-projects-tooltip", "sidebar-projects",
+  )
+  assert_true(
+    bind_tooltip_events_for_trigger(
+      "sidebar-projects-tooltip",
+      "sidebar-projects",
+      "sidebar-projects",
+      (next_kind, next_wait) => {
+        kind.val = next_kind
+        wait.val = next_wait
+      },
+    ),
+  )
+  assert_eq(kind.val, 9)
+
+  ffi_sidebar_tooltip_fixture_set_context(true, false, true)
+  kind.val = -1
+  ffi_sidebar_tooltip_fixture_fire("mouseenter")
+  assert_eq(kind.val, 0)
+  assert_eq(wait.val, 0)
+  kind.val = -1
+  ffi_sidebar_tooltip_fixture_fire("focus")
+  assert_eq(kind.val, 2)
+
+  ffi_sidebar_tooltip_fixture_set_context(false, false, true)
+  kind.val = -1
+  ffi_sidebar_tooltip_fixture_fire("mouseenter")
+  ffi_sidebar_tooltip_fixture_fire("focus")
+  assert_eq(kind.val, -1)
+  ffi_sidebar_tooltip_fixture_set_context(true, true, true)
+  ffi_sidebar_tooltip_fixture_fire("mouseenter")
+  ffi_sidebar_tooltip_fixture_fire("focus")
+  assert_eq(kind.val, -1)
+  ffi_sidebar_tooltip_fixture_set_context(true, false, false)
+  ffi_sidebar_tooltip_fixture_fire("mouseenter")
+  ffi_sidebar_tooltip_fixture_fire("focus")
+  assert_eq(kind.val, -1)
+
+  ffi_sidebar_tooltip_fixture_set_context(true, false, true)
+  ffi_sidebar_tooltip_fixture_set_disabled(true)
+  ffi_sidebar_tooltip_fixture_fire("mouseenter")
+  ffi_sidebar_tooltip_fixture_fire("focus")
+  assert_eq(kind.val, -1)
+  ffi_sidebar_tooltip_fixture_set_disabled(false)
+
+  bind_floating_sync("sidebar-projects-tooltip", _ => ())
+  assert_true(set_floating_open("sidebar-projects-tooltip", true))
+  ffi_sidebar_tooltip_fixture_fire_escape()
+  assert_eq(kind.val, 7)
+  assert_true(ffi_sidebar_tooltip_fixture_escape_handled())
+
+  ffi_sidebar_tooltip_fixture_set_context(false, false, true)
+  kind.val = -1
+  ffi_sidebar_tooltip_fixture_fire_observer()
+  let closed_kind = kind.val
+  reset_sidebar_tooltip_bindings("sidebar-projects-tooltip")
+  ffi_restore_sidebar_tooltip_fixture()
+  assert_eq(closed_kind, 9)
+}
+
+///|
+test "sidebar outline variant keeps its shadcn hover and active ring" {
+  assert_true(
+    UiInteractionCss.contains(
+      "[data-slot=\"sidebar-menu-button\"][data-variant=\"outline\"]:not(:disabled):not([aria-disabled=\"true\"]):hover",
+    ),
+  )
+  assert_true(
+    UiInteractionCss.contains(
+      "[data-slot=\"sidebar-menu-button\"][data-variant=\"outline\"]:where(:active,[data-active=\"true\"])",
+    ),
+  )
+  assert_true(
+    UiInteractionCss.contains(
+      "--rui-sidebar-item-shadow:0 0 0 1px var(--rui-sidebar-accent",
+    ),
+  )
+}

--- a/rui/sidebar_wbtest.mbt
+++ b/rui/sidebar_wbtest.mbt
@@ -1,0 +1,747 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_focus_fixture(
+  mode : Int,
+) -> @dom.KeyboardEvent =
+  #| mode => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiSidebarFocusFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     getComputedStyle: globalThis.getComputedStyle,
+  #|     hadGetComputedStyle: own("getComputedStyle"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     focused: -1,
+  #|   }
+  #|   globalThis.HTMLElement = class FakeHTMLElement {
+  #|     static [Symbol.hasInstance](value) { return value?.nodeType === 1 }
+  #|   }
+  #|   const makeItem = index => ({
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     isSameNode(other) { return this === other },
+  #|     hasAttribute: () => false,
+  #|     getAttribute: () => null,
+  #|     closest: () => null,
+  #|     getClientRects: () => [{}],
+  #|     focus: () => { fixture.focused = index },
+  #|   })
+  #|   const disabledLink = makeItem(6)
+  #|   const enabledLink = makeItem(7)
+  #|   const excludedButton = makeItem(8)
+  #|   const excludedInput = makeItem(9)
+  #|   const excludedSelect = makeItem(10)
+  #|   const excludedTextarea = makeItem(11)
+  #|   const enabledNativeControl = makeItem(12)
+  #|   const items = mode === 3 ? []
+  #|     : mode === 6 ? [disabledLink, enabledLink]
+  #|     : mode === 7
+  #|       ? [
+  #|           excludedButton,
+  #|           excludedInput,
+  #|           excludedSelect,
+  #|           excludedTextarea,
+  #|           enabledNativeControl,
+  #|         ]
+  #|     : [makeItem(0), makeItem(1)]
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     isSameNode(other) { return this === other },
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "aria-hidden" && mode === 4 ? "true" : null,
+  #|     querySelectorAll: selector => {
+  #|       fixture.selector = selector
+  #|       if (mode === 6
+  #|         && selector.includes('a[href]:not([aria-disabled="true"]):not([tabindex="-1"])')) {
+  #|         return [enabledLink]
+  #|       }
+  #|       if (mode === 7
+  #|         && selector.includes('button:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')
+  #|         && selector.includes('input:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')
+  #|         && selector.includes('select:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')
+  #|         && selector.includes('textarea:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')) {
+  #|         return [enabledNativeControl]
+  #|       }
+  #|       return items
+  #|     },
+  #|     contains: node => items.includes(node),
+  #|     focus: () => { fixture.focused = 2 },
+  #|   }
+  #|   fixture.root = root
+  #|   fixture.items = items
+  #|   globalThis.document = {
+  #|     activeElement: mode === 0 || mode === 7
+  #|       ? items[items.length - 1]
+  #|       : mode === 1 || mode === 2 ? items[0] : null,
+  #|   }
+  #|   globalThis.getComputedStyle = () => ({ visibility: "visible" })
+  #|   return {
+  #|     key: mode === 5 ? "Escape" : "Tab",
+  #|     shiftKey: mode === 1,
+  #|     altKey: false,
+  #|     ctrlKey: false,
+  #|     metaKey: false,
+  #|     currentTarget: root,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_focus_fixture_focused() -> Int =
+  #| () => globalThis.__ruiSidebarFocusFixture?.focused ?? -1
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarFocusFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadGetComputedStyle) globalThis.getComputedStyle = fixture.getComputedStyle
+  #|   else delete globalThis.getComputedStyle
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiSidebarFocusFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_restore_fixture(
+  blocked : Bool,
+) -> @dom.MouseEvent =
+  #| blocked => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiSidebarRestoreFixture = {
+  #|     previous: globalThis.__ruiSidebarRestoreTrigger,
+  #|     hadPrevious: own("__ruiSidebarRestoreTrigger"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     focused: 0,
+  #|   }
+  #|   globalThis.HTMLElement = class FakeHTMLElement {
+  #|     static [Symbol.hasInstance](value) { return value?.nodeType === 1 }
+  #|   }
+  #|   const trigger = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     isSameNode(other) { return this === other },
+  #|     disabled: false,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: () => null,
+  #|     closest: () => blocked ? {} : null,
+  #|     focus: () => { fixture.focused += 1 },
+  #|   }
+  #|   fixture.trigger = trigger
+  #|   return { currentTarget: trigger }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_restore_fixture_focused() -> Int =
+  #| () => globalThis.__ruiSidebarRestoreFixture?.focused ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_restore_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarRestoreFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadPrevious) globalThis.__ruiSidebarRestoreTrigger = fixture.previous
+  #|   else delete globalThis.__ruiSidebarRestoreTrigger
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiSidebarRestoreFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_open_focus_fixture(
+  exclude_native_tabstops : Bool,
+) -> Unit =
+  #| excludeNativeTabstops => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const listeners = {}
+  #|   let fixture
+  #|   const oldNode = globalThis.Node
+  #|   const oldHTMLElement = globalThis.HTMLElement
+  #|   const oldKeyboardEvent = globalThis.KeyboardEvent
+  #|   const oldMutationObserver = globalThis.MutationObserver
+  #|   const hadMutationObserver = own("MutationObserver")
+  #|   globalThis.Node = class FakeNode {
+  #|     static [Symbol.hasInstance](value) { return value?.nodeType != null }
+  #|   }
+  #|   globalThis.HTMLElement = class FakeHTMLElement {
+  #|     static [Symbol.hasInstance](value) { return value?.nodeType === 1 }
+  #|   }
+  #|   globalThis.KeyboardEvent = class FakeKeyboardEvent {
+  #|     static [Symbol.hasInstance](value) { return typeof value?.key === "string" }
+  #|   }
+  #|   globalThis.MutationObserver = class FakeMutationObserver {
+  #|     observe() {}
+  #|     disconnect() {}
+  #|   }
+  #|   const outside = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     isSameNode(other) { return this === other },
+  #|     disabled: false,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: () => null,
+  #|     closest: () => null,
+  #|     focus: () => {
+  #|       fixture.focused = 3
+  #|       globalThis.document.activeElement = outside
+  #|     },
+  #|   }
+  #|   fixture = globalThis.__ruiSidebarOpenFocusFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     Node: oldNode,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: oldHTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     KeyboardEvent: oldKeyboardEvent,
+  #|     hadKeyboardEvent: own("KeyboardEvent"),
+  #|     MutationObserver: oldMutationObserver,
+  #|     hadMutationObserver,
+  #|     computed: globalThis.getComputedStyle,
+  #|     hadComputed: own("getComputedStyle"),
+  #|     listeners,
+  #|     focused: -1,
+  #|     outside,
+  #|     restoreTrigger: globalThis.__ruiSidebarRestoreTrigger,
+  #|     hadRestoreTrigger: own("__ruiSidebarRestoreTrigger"),
+  #|   }
+  #|   const makeItem = index => {
+  #|     const item = {
+  #|       nodeType: 1,
+  #|       isConnected: true,
+  #|       isSameNode(other) { return this === other },
+  #|       hasAttribute: () => false,
+  #|       getAttribute: () => null,
+  #|       closest: () => null,
+  #|       getClientRects: () => [{}],
+  #|       focus: () => {
+  #|         fixture.focused = index
+  #|         globalThis.document.activeElement = item
+  #|       },
+  #|     }
+  #|     return item
+  #|   }
+  #|   const enabledNativeControl = makeItem(7)
+  #|   const excludedNativeControls = [
+  #|     makeItem(3),
+  #|     makeItem(4),
+  #|     makeItem(5),
+  #|     makeItem(6),
+  #|   ]
+  #|   const items = excludeNativeTabstops
+  #|     ? [...excludedNativeControls, enabledNativeControl]
+  #|     : [makeItem(0), makeItem(1)]
+  #|   const root = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     isSameNode(other) { return this === other },
+  #|     hidden: false,
+  #|     hasAttribute: () => false,
+  #|     getAttribute: name => name === "data-mobile-state" ? "open" : null,
+  #|     parentElement: null,
+  #|     querySelectorAll: selector => {
+  #|       if (excludeNativeTabstops
+  #|         && selector.includes('button:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')
+  #|         && selector.includes('input:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')
+  #|         && selector.includes('select:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')
+  #|         && selector.includes('textarea:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"])')) {
+  #|         return [enabledNativeControl]
+  #|       }
+  #|       return items
+  #|     },
+  #|     contains: node => node === root || items.includes(node),
+  #|     focus: () => {
+  #|       fixture.focused = 2
+  #|       globalThis.document.activeElement = root
+  #|     },
+  #|     dispatchEvent: () => true,
+  #|   }
+  #|   fixture.root = root
+  #|   fixture.items = items
+  #|   const body = {
+  #|     nodeType: 1,
+  #|     isSameNode(other) { return this === other },
+  #|   }
+  #|   const documentElement = {
+  #|     nodeType: 1,
+  #|     isSameNode(other) { return this === other },
+  #|   }
+  #|   const roots = [root]
+  #|   roots.item = index => roots[index] ?? null
+  #|   globalThis.document = {
+  #|     nodeType: 9,
+  #|     isSameNode(other) { return this === other },
+  #|     activeElement: outside,
+  #|     body,
+  #|     documentElement,
+  #|     querySelectorAll: () => roots,
+  #|     addEventListener: (type, callback) => { listeners[type] = callback },
+  #|   }
+  #|   globalThis.getComputedStyle = () => ({ display: "block", visibility: "visible" })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_open_focus_fixture_focused() -> Int =
+  #| () => globalThis.__ruiSidebarOpenFocusFixture?.focused ?? -1
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_sidebar_outside_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarOpenFocusFixture
+  #|   globalThis.document.activeElement = fixture.outside
+  #|   fixture.listeners.focusin?.({ target: fixture.outside })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_sidebar_outside_tab_fixture(shift : Bool) -> Bool =
+  #| shift => {
+  #|   const fixture = globalThis.__ruiSidebarOpenFocusFixture
+  #|   globalThis.document.activeElement = fixture.outside
+  #|   const event = {
+  #|     key: "Tab",
+  #|     shiftKey: shift,
+  #|     defaultPrevented: false,
+  #|     preventDefault() { this.defaultPrevented = true },
+  #|   }
+  #|   fixture.listeners.keydown?.(event)
+  #|   return event.defaultPrevented
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_open_focus_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarOpenFocusFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadComputed) globalThis.getComputedStyle = fixture.computed
+  #|   else delete globalThis.getComputedStyle
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadKeyboardEvent) globalThis.KeyboardEvent = fixture.KeyboardEvent
+  #|   else delete globalThis.KeyboardEvent
+  #|   if (fixture.hadMutationObserver) {
+  #|     globalThis.MutationObserver = fixture.MutationObserver
+  #|   } else {
+  #|     delete globalThis.MutationObserver
+  #|   }
+  #|   if (fixture.hadRestoreTrigger) {
+  #|     globalThis.__ruiSidebarRestoreTrigger = fixture.restoreTrigger
+  #|   } else {
+  #|     delete globalThis.__ruiSidebarRestoreTrigger
+  #|   }
+  #|   delete globalThis.__ruiSidebarOpenFocusFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_mobile_layer_fixture(mode : Int) -> Unit =
+  #| mode => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiSidebarMobileLayerFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     setTimeout: globalThis.setTimeout,
+  #|     hadSetTimeout: own("setTimeout"),
+  #|     clearTimeout: globalThis.clearTimeout,
+  #|     hadClearTimeout: own("clearTimeout"),
+  #|     shows: 0,
+  #|     hides: 0,
+  #|     queries: 0,
+  #|     layers: [],
+  #|     nextTimer: 1,
+  #|     timers: new Map(),
+  #|   }
+  #|   globalThis.window = globalThis
+  #|   globalThis.HTMLElement = class FakeHTMLElement {
+  #|     static [Symbol.hasInstance](value) { return value?.nodeType === 1 }
+  #|   }
+  #|   globalThis.setTimeout = callback => {
+  #|     const timer = fixture.nextTimer++
+  #|     fixture.timers.set(timer, callback)
+  #|     return timer
+  #|   }
+  #|   globalThis.clearTimeout = timer => { fixture.timers.delete(timer) }
+  #|   const makeLayer = (requestedOpen, nativeOpen) => {
+  #|     const layer = {
+  #|       nodeType: 1,
+  #|       isConnected: true,
+  #|       isSameNode(other) { return this === other },
+  #|       dataset: { state: requestedOpen ? "open" : "closed" },
+  #|       getAttribute: name => name === "data-state" ? layer.dataset.state : null,
+  #|       nativeOpen,
+  #|       matches: selector => selector === ":popover-open" && layer.nativeOpen,
+  #|       showPopover: () => {
+  #|         fixture.shows += 1
+  #|         layer.nativeOpen = true
+  #|       },
+  #|       hidePopover: () => {
+  #|         fixture.hides += 1
+  #|         layer.nativeOpen = false
+  #|       },
+  #|     }
+  #|     return layer
+  #|   }
+  #|   fixture.layers = mode === 0
+  #|     ? [makeLayer(true, false)]
+  #|     : mode === 1
+  #|       ? [makeLayer(false, true)]
+  #|       : [
+  #|           makeLayer(true, false),
+  #|           makeLayer(false, true),
+  #|           makeLayer(true, true),
+  #|           makeLayer(false, false),
+  #|         ]
+  #|   fixture.layers.item = index => fixture.layers[index] ?? null
+  #|   globalThis.document = {
+  #|     querySelectorAll: selector => {
+  #|       fixture.queries += 1
+  #|       return selector === '[data-slot="sidebar-mobile-layer"][popover]'
+  #|         ? fixture.layers
+  #|         : []
+  #|     },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_mobile_layer_fixture_flush() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarMobileLayerFixture
+  #|   const callbacks = [...fixture.timers.values()]
+  #|   fixture.timers.clear()
+  #|   for (const callback of callbacks) callback()
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_mobile_layer_fixture_request_open() -> Unit =
+  #| () => {
+  #|   globalThis.__ruiSidebarMobileLayerFixture.layers[0].dataset.state = "open"
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_mobile_layer_fixture_count(kind : Int) -> Int =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiSidebarMobileLayerFixture
+  #|   if (kind === 0) return fixture.shows
+  #|   if (kind === 1) return fixture.hides
+  #|   if (kind === 2) return fixture.layers.filter(layer => layer.nativeOpen).length
+  #|   if (kind === 3) {
+  #|     return fixture.layers.filter(layer => layer.__ruiSidebarLayerOpen).length
+  #|   }
+  #|   return fixture.queries
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_mobile_layer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarMobileLayerFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadSetTimeout) globalThis.setTimeout = fixture.setTimeout
+  #|   else delete globalThis.setTimeout
+  #|   if (fixture.hadClearTimeout) globalThis.clearTimeout = fixture.clearTimeout
+  #|   else delete globalThis.clearTimeout
+  #|   for (const layer of fixture.layers) layer.isConnected = false
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiSidebarMobileLayerFixture
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_sidebar_desktop_collapse_fixture() -> Unit =
+  #| () => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const fixture = globalThis.__ruiSidebarDesktopCollapseFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     state: "expanded",
+  #|     focused: 0,
+  #|   }
+  #|   delete globalThis.window
+  #|   globalThis.HTMLElement = class FakeHTMLElement {
+  #|     static [Symbol.hasInstance](value) { return value?.nodeType === 1 }
+  #|   }
+  #|   const trigger = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     focus: () => {
+  #|       fixture.focused += 1
+  #|       globalThis.document.activeElement = trigger
+  #|     },
+  #|   }
+  #|   const wrapper = {
+  #|     nodeType: 1,
+  #|     querySelector: selector => selector.includes("sidebar-trigger")
+  #|       ? trigger
+  #|       : null,
+  #|   }
+  #|   const sidebar = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     getAttribute: name => name === "data-state"
+  #|       ? fixture.state
+  #|       : name === "data-collapsible" ? "icon" : null,
+  #|     closest: selector => selector.includes("sidebar-wrapper")
+  #|       ? wrapper
+  #|       : null,
+  #|     querySelector: () => null,
+  #|   }
+  #|   const active = {
+  #|     nodeType: 1,
+  #|     isConnected: true,
+  #|     isSameNode(other) { return this === other },
+  #|     getAttribute: name => name === "data-slot" ? "sidebar-menu-button" : null,
+  #|     getClientRects: () => [],
+  #|     closest: selector => selector.includes('data-mobile="false"')
+  #|       ? sidebar
+  #|       : null,
+  #|   }
+  #|   const body = {
+  #|     nodeType: 1,
+  #|     isSameNode(other) { return this === other },
+  #|   }
+  #|   fixture.sidebar = sidebar
+  #|   fixture.active = active
+  #|   globalThis.document = { activeElement: active, body }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_desktop_collapse_fixture_collapse() -> Unit =
+  #| () => { globalThis.__ruiSidebarDesktopCollapseFixture.state = "collapsed" }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_desktop_collapse_fixture_replace_focus() -> Unit =
+  #| () => {
+  #|   globalThis.document.activeElement = {
+  #|     nodeType: 1,
+  #|     isSameNode(other) { return this === other },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_sidebar_desktop_collapse_fixture_focused() -> Int =
+  #| () => globalThis.__ruiSidebarDesktopCollapseFixture?.focused ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_sidebar_desktop_collapse_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSidebarDesktopCollapseFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   delete globalThis.__ruiSidebarDesktopCollapseFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "mobile sidebar focus trap wraps both directions and ignores inactive paths" {
+  let forward_event = ffi_install_sidebar_focus_fixture(0)
+  let forward_handled = sidebar_trap_focus(forward_event)
+  let forward_focus = ffi_sidebar_focus_fixture_focused()
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(forward_handled)
+  assert_eq(forward_focus, 0)
+
+  let backward_event = ffi_install_sidebar_focus_fixture(1)
+  let backward_handled = sidebar_trap_focus(backward_event)
+  let backward_focus = ffi_sidebar_focus_fixture_focused()
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(backward_handled)
+  assert_eq(backward_focus, 1)
+
+  let middle_event = ffi_install_sidebar_focus_fixture(2)
+  let middle_handled = sidebar_trap_focus(middle_event)
+  let middle_focus = ffi_sidebar_focus_fixture_focused()
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(middle_handled)
+  assert_eq(middle_focus, 1)
+
+  let empty_event = ffi_install_sidebar_focus_fixture(3)
+  let empty_handled = sidebar_trap_focus(empty_event)
+  let empty_focus = ffi_sidebar_focus_fixture_focused()
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(empty_handled)
+  assert_eq(empty_focus, 2)
+
+  let hidden_event = ffi_install_sidebar_focus_fixture(4)
+  let hidden_handled = sidebar_trap_focus(hidden_event)
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(!hidden_handled)
+
+  let escape_event = ffi_install_sidebar_focus_fixture(5)
+  let escape_handled = sidebar_trap_focus(escape_event)
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(!escape_handled)
+
+  let disabled_link_event = ffi_install_sidebar_focus_fixture(6)
+  let disabled_link_handled = sidebar_trap_focus(disabled_link_event)
+  let disabled_link_focus = ffi_sidebar_focus_fixture_focused()
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(disabled_link_handled)
+  assert_eq(disabled_link_focus, 7)
+
+  let excluded_native_event = ffi_install_sidebar_focus_fixture(7)
+  let excluded_native_handled = sidebar_trap_focus(excluded_native_event)
+  let excluded_native_focus = ffi_sidebar_focus_fixture_focused()
+  ffi_restore_sidebar_focus_fixture()
+  assert_true(excluded_native_handled)
+  assert_eq(excluded_native_focus, 12)
+}
+
+///|
+#cfg(target="js")
+test "mobile sidebar restores only a connected visible opener" {
+  let visible_event = ffi_install_sidebar_restore_fixture(false)
+  sidebar_capture_restore_trigger(visible_event)
+  sidebar_restore_captured_trigger()
+  let visible_focus = ffi_sidebar_restore_fixture_focused()
+  ffi_restore_sidebar_restore_fixture()
+  assert_eq(visible_focus, 1)
+
+  let blocked_event = ffi_install_sidebar_restore_fixture(true)
+  sidebar_capture_restore_trigger(blocked_event)
+  sidebar_restore_captured_trigger()
+  let blocked_focus = ffi_sidebar_restore_fixture_focused()
+  ffi_restore_sidebar_restore_fixture()
+  assert_eq(blocked_focus, 0)
+}
+
+///|
+#cfg(target="js")
+test "opening mobile sidebar moves focus in and contains outside focus" {
+  ffi_install_sidebar_open_focus_fixture(false)
+  assert_true(sidebar_focus_open())
+  assert_eq(ffi_sidebar_open_focus_fixture_focused(), 0)
+  ffi_fire_sidebar_outside_focus_fixture()
+  assert_eq(ffi_sidebar_open_focus_fixture_focused(), 0)
+  assert_true(ffi_fire_sidebar_outside_tab_fixture(true))
+  assert_eq(ffi_sidebar_open_focus_fixture_focused(), 1)
+  sidebar_restore_captured_trigger()
+  assert_eq(ffi_sidebar_open_focus_fixture_focused(), 3)
+  ffi_restore_sidebar_open_focus_fixture()
+}
+
+///|
+#cfg(target="js")
+test "opening mobile sidebar skips native controls removed from tab order" {
+  ffi_install_sidebar_open_focus_fixture(true)
+  assert_true(sidebar_focus_open())
+  assert_eq(ffi_sidebar_open_focus_fixture_focused(), 7)
+  ffi_restore_sidebar_open_focus_fixture()
+}
+
+///|
+#cfg(target="js")
+test "mobile sidebar promotes a requested open layer" {
+  ffi_install_sidebar_mobile_layer_fixture(0)
+  sidebar_sync_mobile_layers()
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(0), 1)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(1), 0)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(2), 1)
+  ffi_restore_sidebar_mobile_layer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "mobile sidebar dismisses a native layer requested closed" {
+  ffi_install_sidebar_mobile_layer_fixture(1)
+  sidebar_sync_mobile_layers()
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(0), 0)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(1), 0)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(2), 1)
+  ffi_sidebar_mobile_layer_fixture_flush()
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(1), 1)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(2), 0)
+  ffi_restore_sidebar_mobile_layer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "mobile sidebar synchronizes every layer idempotently" {
+  ffi_install_sidebar_mobile_layer_fixture(2)
+  sidebar_sync_mobile_layers()
+  sidebar_sync_mobile_layers()
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(0), 1)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(1), 0)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(2), 3)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(4), 2)
+  ffi_sidebar_mobile_layer_fixture_flush()
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(1), 1)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(2), 2)
+  ffi_restore_sidebar_mobile_layer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "mobile sidebar cancels a pending native dismissal when reopened" {
+  ffi_install_sidebar_mobile_layer_fixture(1)
+  sidebar_sync_mobile_layers()
+  ffi_sidebar_mobile_layer_fixture_request_open()
+  sidebar_sync_mobile_layers()
+  ffi_sidebar_mobile_layer_fixture_flush()
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(0), 0)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(1), 0)
+  assert_eq(ffi_sidebar_mobile_layer_fixture_count(2), 1)
+  ffi_restore_sidebar_mobile_layer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "desktop collapse moves focus only when the captured control becomes hidden" {
+  ffi_install_sidebar_desktop_collapse_fixture()
+  sidebar_capture_desktop_collapse_focus()
+  ffi_sidebar_desktop_collapse_fixture_collapse()
+  sidebar_restore_desktop_collapse_focus()
+  let restored = ffi_sidebar_desktop_collapse_fixture_focused()
+  ffi_restore_sidebar_desktop_collapse_fixture()
+  assert_eq(restored, 1)
+
+  ffi_install_sidebar_desktop_collapse_fixture()
+  sidebar_capture_desktop_collapse_focus()
+  ffi_sidebar_desktop_collapse_fixture_collapse()
+  ffi_sidebar_desktop_collapse_fixture_replace_focus()
+  sidebar_restore_desktop_collapse_focus()
+  let preserved = ffi_sidebar_desktop_collapse_fixture_focused()
+  ffi_restore_sidebar_desktop_collapse_fixture()
+  assert_eq(preserved, 0)
+}

--- a/rui/skeleton.mbt
+++ b/rui/skeleton.mbt
@@ -1,0 +1,23 @@
+///|
+const SkeletonBaseStyle : String = "display:block;border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-accent,oklch(0.97 0 0));animation:rui-pulse 2s cubic-bezier(0.4,0,0.6,1) infinite"
+
+///|
+/// Render the Vega pulse skeleton. `theme` supplies its static keyframes and a
+/// reduced-motion override; no external stylesheet is required.
+pub fn skeleton(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("slot", "skeleton")
+  @html.div(
+    style=ui_styles([UiBoxSizing, SkeletonBaseStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    @html.nothing,
+  )
+}

--- a/rui/slider.mbt
+++ b/rui/slider.mbt
@@ -1,0 +1,1076 @@
+///|
+priv enum SliderMsg {
+  SetSliderValue(Int, Int)
+  SetSliderKeyboardValue(Int, Int)
+  CommitSliderValue(Int, Int)
+}
+
+///|
+const SliderThumbStyle : String = "position:absolute;z-index:2;display:block;width:1rem;height:1rem;border:1px solid var(--rui-primary,oklch(0.205 0 0));border-radius:9999px;background:var(--rui-slider-thumb,var(--rui-background,oklch(1 0 0)));--rui-slider-thumb-base-shadow:0 1px 2px rgb(0 0 0 / 0.1);box-shadow:var(--rui-slider-thumb-shadow,var(--rui-slider-thumb-base-shadow,0 1px 2px rgb(0 0 0 / 0.1)));pointer-events:none"
+
+///|
+fn slider_parse(value : String, fallback : Int) -> Int {
+  @string.parse_int(value) catch {
+    _ => fallback
+  }
+}
+
+///|
+fn slider_clamp(value : Int, min : Int, max : Int) -> Int {
+  if value < min {
+    min
+  } else if value > max {
+    max
+  } else {
+    value
+  }
+}
+
+///|
+fn slider_step_amount(step : Int) -> Int {
+  if step > 0 {
+    step
+  } else {
+    1
+  }
+}
+
+///|
+fn slider_align_to_step(value : Int, min : Int, max : Int, step : Int) -> Int {
+  let value = slider_clamp(value, min, max)
+  let amount = slider_step_amount(step)
+  let offset = value - min
+  let aligned = min + (offset + amount / 2) / amount * amount
+  slider_clamp(aligned, min, max)
+}
+
+///|
+fn slider_percent(value : Int, min : Int, max : Int) -> Int {
+  if max <= min {
+    0
+  } else {
+    (slider_clamp(value, min, max) - min) * 100 / (max - min)
+  }
+}
+
+///|
+fn slider_minimum_gap(
+  count : Int,
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+) -> Int {
+  if count <= 1 || min_steps_between_values <= 0 || max <= min {
+    0
+  } else {
+    let amount = slider_step_amount(step)
+    let available_steps = (max - min) / amount
+    let possible_steps = available_steps / (count - 1)
+    slider_clamp(min_steps_between_values, 0, possible_steps) * amount
+  }
+}
+
+///|
+fn slider_normalize_values(
+  values : Array[Int],
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+) -> Array[Int] {
+  let requested = if values.length() == 0 { [min] } else { values }
+  let normalized = requested.map(value => {
+    slider_align_to_step(value, min, max, step)
+  })
+  normalized.sort()
+  let count = normalized.length()
+  if count > 1 {
+    let gap = slider_minimum_gap(
+      count, min, max, step, min_steps_between_values,
+    )
+    for index in 0..<count {
+      let lower = if index == 0 { min } else { normalized[index - 1] + gap }
+      let upper = max - (count - index - 1) * gap
+      normalized[index] = slider_clamp(normalized[index], lower, upper)
+    }
+  }
+  normalized
+}
+
+///|
+fn slider_set_thumb_value(
+  values : Array[Int],
+  index : Int,
+  value : Int,
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+) -> Array[Int] {
+  slider_constrain_thumb_value(
+    values,
+    index,
+    slider_align_to_step(value, min, max, step),
+    min,
+    max,
+    step,
+    min_steps_between_values,
+  )
+}
+
+///|
+fn slider_constrain_thumb_value(
+  values : Array[Int],
+  index : Int,
+  value : Int,
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+) -> Array[Int] {
+  let next = values.copy()
+  if index < 0 || index >= next.length() {
+    return next
+  }
+  let gap = slider_minimum_gap(
+    next.length(),
+    min,
+    max,
+    step,
+    min_steps_between_values,
+  )
+  let lower = if index == 0 { min } else { next[index - 1] + gap }
+  let upper = if index + 1 >= next.length() {
+    max
+  } else {
+    next[index + 1] - gap
+  }
+  next[index] = slider_clamp(value, lower, upper)
+  next
+}
+
+///|
+fn slider_round_to_step(value : Int, min : Int, step : Int) -> Int {
+  let amount = slider_step_amount(step)
+  let offset = value - min
+  min + (offset + amount / 2) / amount * amount
+}
+
+///|
+fn slider_key_value(
+  value : Int,
+  min : Int,
+  max : Int,
+  step : Int,
+  large_step : Int,
+  shift : Bool,
+  rtl : Bool,
+  key : String,
+) -> Int? {
+  let amount = if shift { large_step } else { slider_step_amount(step) }
+  let rounded = slider_round_to_step(value, min, step)
+  let requested = match key {
+    "Home" => Some(min)
+    "End" => Some(max)
+    "ArrowUp" => Some(rounded + amount)
+    "ArrowRight" => Some(rounded + (if rtl { -amount } else { amount }))
+    "ArrowDown" => Some(rounded - amount)
+    "ArrowLeft" => Some(rounded + (if rtl { amount } else { -amount }))
+    "PageUp" => Some(rounded + large_step)
+    "PageDown" => Some(rounded - large_step)
+    _ => None
+  }
+  requested.map(next => slider_clamp(next, min, max))
+}
+
+///|
+fn slider_thumb_key_value(
+  values : Array[Int],
+  index : Int,
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+  large_step : Int,
+  shift : Bool,
+  rtl : Bool,
+  key : String,
+) -> Int? {
+  if index < 0 || index >= values.length() {
+    return None
+  }
+  let current = values[index]
+  let gap = slider_minimum_gap(
+    values.length(),
+    min,
+    max,
+    step,
+    min_steps_between_values,
+  )
+  let lower = if index == 0 { min } else { values[index - 1] }
+  let upper = if index + 1 >= values.length() { max } else { values[index + 1] }
+  let requested = match key {
+    "Home" => Some(if index == 0 { min } else { lower + gap })
+    "End" => Some(if index + 1 >= values.length() { max } else { upper - gap })
+    _ => slider_key_value(current, min, max, step, large_step, shift, rtl, key)
+  }
+  match requested {
+    Some(requested) => {
+      let next = slider_clamp(requested, lower, upper)
+      if (index > 0 && next - lower < gap) ||
+        (index + 1 < values.length() && upper - next < gap) {
+        Some(current)
+      } else {
+        Some(next)
+      }
+    }
+    None => None
+  }
+}
+
+///|
+#cfg(target="js")
+priv struct SliderPointerConfig {
+  min : Int
+  max : Int
+  step : Int
+  gap : Int
+}
+
+///|
+#cfg(target="js")
+priv struct SliderPointerBinding {
+  root : @dom.Element
+  mut active_index : Int
+  mut active_pointer_id : Int?
+  mut last_used_index : Int
+}
+
+///|
+#cfg(target="js")
+let slider_pointer_bindings : Array[SliderPointerBinding] = []
+
+///|
+#cfg(target="js")
+fn slider_prune_pointer_bindings() -> Unit {
+  let mut index = 0
+  while index < slider_pointer_bindings.length() {
+    if slider_pointer_bindings[index].root.get_is_connected() {
+      index += 1
+    } else {
+      ignore(slider_pointer_bindings.remove(index))
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_binding(root : @dom.Element) -> SliderPointerBinding? {
+  for binding in slider_pointer_bindings {
+    if binding.root.is_same_node(root.as_node()) {
+      return Some(binding)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_controls(
+  binding : SliderPointerBinding,
+) -> Array[@dom.HTMLInputElement] {
+  let controls : Array[@dom.HTMLInputElement] = []
+  for
+    element in binding.root.query_selector_all("[data-slot=\"slider-control\"]") {
+    if ui_element_is_enabled(element) &&
+      element.to_html_input_element() is Some(input) {
+      controls.push(input)
+    }
+  }
+  controls
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_config(
+  binding : SliderPointerBinding,
+  count : Int,
+) -> SliderPointerConfig {
+  let min = ui_parse_int_or(
+    binding.root.get_attribute("data-min").unwrap_or(""),
+    0,
+  )
+  let max = ui_parse_int_or(
+    binding.root.get_attribute("data-max").unwrap_or(""),
+    100,
+  )
+  let step = ui_parse_int_or(
+    binding.root.get_attribute("data-step").unwrap_or(""),
+    1,
+  ).max(1)
+  let min_steps = ui_parse_int_or(
+    binding.root.get_attribute("data-min-steps-between-values").unwrap_or(""),
+    0,
+  ).max(0)
+  let available_steps = (max - min).max(0) / step
+  let possible_steps = if count > 1 { available_steps / (count - 1) } else { 0 }
+  let effective_steps = if count > 1 {
+    min_steps.min(possible_steps.max(0))
+  } else {
+    0
+  }
+  { min, max, step, gap: step * effective_steps }
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_value_at(
+  binding : SliderPointerBinding,
+  pointer : @dom.PointerEvent,
+) -> Int? {
+  let rect = binding.root.get_bounding_client_rect()
+  let vertical = binding.root.get_attribute("data-orientation").unwrap_or("") ==
+    "vertical"
+  let size = if vertical { rect.get_height() } else { rect.get_width() }
+  if size <= 0.0 {
+    return None
+  }
+  let rtl = !vertical &&
+    (
+      binding.root.get_attribute("data-direction").unwrap_or("") == "rtl" ||
+      binding.root.get_attribute("dir").unwrap_or("") == "rtl" ||
+      ui_element_is_rtl(binding.root)
+    )
+  let offset = if vertical {
+    rect.get_bottom() - pointer.get_client_y().to_double()
+  } else if rtl {
+    rect.get_right() - pointer.get_client_x().to_double()
+  } else {
+    pointer.get_client_x().to_double() - rect.get_left()
+  }
+  let percent = (offset / size).clamp(min=0.0, max=1.0)
+  let config = slider_pointer_config(binding, 1)
+  let raw = config.min.to_double() +
+    percent * (config.max - config.min).to_double()
+  let aligned = config.min +
+    ((raw - config.min.to_double()) / config.step.to_double()).round().to_int() *
+    config.step
+  Some(slider_clamp(aligned, config.min, config.max))
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_closest_index(
+  binding : SliderPointerBinding,
+  requested : Int,
+  controls : Array[@dom.HTMLInputElement],
+) -> Int {
+  let mut best = -1
+  let mut distance = 0
+  for index, input in controls {
+    let next_distance = (ui_parse_int_or(input.value(), requested) - requested).abs()
+    if best < 0 ||
+      next_distance < distance ||
+      (
+        next_distance == distance &&
+        (
+          index == binding.last_used_index ||
+          (best != binding.last_used_index && index < best)
+        )
+      ) {
+      best = index
+      distance = next_distance
+    }
+  }
+  best
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_activate(
+  binding : SliderPointerBinding,
+  index : Int,
+  controls : Array[@dom.HTMLInputElement],
+) -> Bool {
+  if index < 0 || index >= controls.length() {
+    return false
+  }
+  binding.active_index = index
+  binding.last_used_index = index
+  for current, input in controls {
+    input
+    .get_style()
+    .set_property(
+      "z-index",
+      (if current == index { controls.length() + 4 } else { current + 3 }).to_string(),
+    )
+  }
+  controls[index].focus_with_options(prevent_scroll=true)
+  true
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_update(
+  binding : SliderPointerBinding,
+  pointer : @dom.PointerEvent,
+  commit : Bool,
+) -> Unit {
+  let controls = slider_pointer_controls(binding)
+  let index = binding.active_index
+  if index < 0 || index >= controls.length() {
+    return
+  }
+  guard slider_pointer_value_at(binding, pointer) is Some(requested) else {
+    return
+  }
+  let config = slider_pointer_config(binding, controls.length())
+  let lower = if index == 0 {
+    config.min
+  } else {
+    ui_parse_int_or(controls[index - 1].value(), config.min) + config.gap
+  }
+  let upper = if index + 1 >= controls.length() {
+    config.max
+  } else {
+    ui_parse_int_or(controls[index + 1].value(), config.max) - config.gap
+  }
+  let next = requested.clamp(min=lower, max=upper)
+  let input = controls[index]
+  if ui_parse_int_or(input.value(), next) != next {
+    input.set_value(next.to_string())
+    input.dispatch_event(@dom.Event::new("input", bubbles=true))
+  }
+  if commit {
+    input.dispatch_event(@dom.Event::new("change", bubbles=true))
+  }
+}
+
+///|
+#cfg(target="js")
+fn slider_pointer_finish(
+  binding : SliderPointerBinding,
+  pointer : @dom.PointerEvent,
+  commit : Bool,
+) -> Unit {
+  guard binding.active_pointer_id is Some(pointer_id) else { return }
+  guard pointer_id == pointer.get_pointer_id() else { return }
+  if commit {
+    slider_pointer_update(binding, pointer, true)
+  }
+  if binding.root.has_pointer_capture(pointer_id) {
+    binding.root.release_pointer_capture(pointer_id)
+  }
+  binding.active_index = -1
+  binding.active_pointer_id = None
+}
+
+///|
+#cfg(target="js")
+fn slider_bind_pointer_listeners(binding : SliderPointerBinding) -> Unit {
+  binding.root.add_event_listener("pointerdown", event => {
+    guard event.to_pointer_event() is Some(pointer) else { return }
+    if binding.root.get_attribute("data-disabled").unwrap_or("") == "true" ||
+      pointer.get_button() != 0 ||
+      binding.active_pointer_id is Some(_) {
+      return
+    }
+    guard slider_pointer_value_at(binding, pointer) is Some(requested) else {
+      return
+    }
+    let controls = slider_pointer_controls(binding)
+    if controls.length() == 0 {
+      return
+    }
+    let index = slider_pointer_closest_index(binding, requested, controls)
+    if !slider_pointer_activate(binding, index, controls) {
+      return
+    }
+    binding.active_pointer_id = Some(pointer.get_pointer_id())
+    pointer.prevent_default()
+    binding.root.set_pointer_capture(pointer.get_pointer_id())
+    slider_pointer_update(binding, pointer, false)
+  })
+  binding.root.add_event_listener("pointermove", event => {
+    guard event.to_pointer_event() is Some(pointer) else { return }
+    guard binding.active_pointer_id is Some(pointer_id) else { return }
+    if pointer_id != pointer.get_pointer_id() {
+      return
+    }
+    pointer.prevent_default()
+    slider_pointer_update(binding, pointer, false)
+  })
+  binding.root.add_event_listener("pointerup", event => {
+    if event.to_pointer_event() is Some(pointer) {
+      slider_pointer_finish(binding, pointer, true)
+    }
+  })
+  binding.root.add_event_listener("pointercancel", event => {
+    if event.to_pointer_event() is Some(pointer) {
+      slider_pointer_finish(binding, pointer, false)
+    }
+  })
+  binding.root.add_event_listener("lostpointercapture", event => {
+    guard event.to_pointer_event() is Some(pointer) else { return }
+    guard binding.active_pointer_id is Some(pointer_id) else { return }
+    if pointer_id == pointer.get_pointer_id() {
+      binding.active_index = -1
+      binding.active_pointer_id = None
+    }
+  })
+}
+
+///|
+#cfg(target="js")
+fn bind_slider_pointer(id : String) -> Unit {
+  guard ui_element_by_id(id + "-root") is Some(root) else { return }
+  slider_prune_pointer_bindings()
+  if slider_pointer_binding(root) is Some(_) {
+    return
+  }
+  let binding : SliderPointerBinding = {
+    root,
+    active_index: -1,
+    active_pointer_id: None,
+    last_used_index: -1,
+  }
+  slider_pointer_bindings.push(binding)
+  slider_bind_pointer_listeners(binding)
+}
+
+///|
+#cfg(target="js")
+fn slider_bind_pointer_cmd(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, _ => {
+    ui_after_mount(
+      id + "-root",
+      () => bind_slider_pointer(id),
+      purpose="slider-pointer-bind",
+    )
+  })
+}
+
+///|
+#cfg(target="js")
+fn slider_input_pointer_style() -> String {
+  "pointer-events:none"
+}
+
+///|
+#cfg(not(target="js"))
+fn slider_input_pointer_style() -> String {
+  ""
+}
+
+///|
+#cfg(target="js")
+fn slider_event_is_rtl(event : @dom.KeyboardEvent) -> Bool {
+  let target = match event.current_target().to_option() {
+    Some(target) => target
+    None => event.target()
+  }
+  guard target.to_element() is Some(element) else { return false }
+  let root = element.closest("[data-slot=\"slider\"]").unwrap_or(element)
+  root.get_attribute("data-direction").unwrap_or("") == "rtl" ||
+  root.get_attribute("dir").unwrap_or("") == "rtl" ||
+  ui_element_is_rtl(root)
+}
+
+///|
+fn slider_key_stops_propagation(key : String) -> Bool {
+  key == "ArrowUp" ||
+  key == "ArrowRight" ||
+  key == "ArrowDown" ||
+  key == "ArrowLeft" ||
+  key == "Home" ||
+  key == "End"
+}
+
+///|
+#cfg(target="js")
+fn slider_control_attrs(
+  input_attrs : @html.Attrs?,
+  values : Array[Int],
+  index : Int,
+  emit : @cmd.Emit[SliderMsg],
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+  large_step : Int,
+  orientation : SeparatorOrientation,
+  disabled : Bool,
+) -> @html.Attrs {
+  let value = values[index]
+  let attrs = ui_attrs(input_attrs)
+    .data_set("slot", "slider-control")
+    .data_set("index", index.to_string())
+    .aria_orientation(separator_orientation_value(orientation))
+  if disabled {
+    ignore(attrs.disabled(true))
+  } else {
+    ignore(
+      attrs.on_keydown(event => {
+        if event.get_default_prevented() {
+          return @cmd.none
+        }
+        let key = event.key()
+        match
+          slider_thumb_key_value(
+            values,
+            index,
+            min,
+            max,
+            step,
+            min_steps_between_values,
+            large_step,
+            event.shift_key(),
+            slider_event_is_rtl(event),
+            key,
+          ) {
+          Some(next) => {
+            if slider_key_stops_propagation(key) {
+              event.stop_propagation()
+            }
+            event.prevent_default()
+            if next == value {
+              @cmd.none
+            } else {
+              emit(SetSliderKeyboardValue(index, next))
+            }
+          }
+          None => @cmd.none
+        }
+      }),
+    )
+  }
+  attrs
+}
+
+///|
+#cfg(not(target="js"))
+fn slider_control_attrs(
+  input_attrs : @html.Attrs?,
+  values : Array[Int],
+  index : Int,
+  emit : @cmd.Emit[SliderMsg],
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+  large_step : Int,
+  orientation : SeparatorOrientation,
+  disabled : Bool,
+) -> @html.Attrs {
+  ignore((values, emit, min, max, step, min_steps_between_values, large_step))
+  let attrs = ui_attrs(input_attrs)
+    .data_set("slot", "slider-control")
+    .data_set("index", index.to_string())
+    .aria_orientation(separator_orientation_value(orientation))
+  if disabled {
+    ignore(attrs.disabled(true))
+  }
+  attrs
+}
+
+///|
+fn slider_serialized_values(values : Array[Int]) -> String {
+  values.map(value => value.to_string()).join(",")
+}
+
+///|
+fn slider_thumb_label(aria_label : String, index : Int, count : Int) -> String {
+  if count <= 1 {
+    aria_label
+  } else {
+    "\{aria_label} \{index + 1}"
+  }
+}
+
+///|
+fn render_slider_values(
+  values : Array[Int],
+  emit : @cmd.Emit[SliderMsg],
+  min : Int,
+  max : Int,
+  step : Int,
+  min_steps_between_values : Int,
+  large_step : Int,
+  orientation : SeparatorOrientation,
+  disabled : Bool,
+  aria_label : String,
+  id : String,
+  legacy_single_id : Bool,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  input_attrs : @html.Attrs?,
+  style : Array[String],
+) -> @html.Html {
+  let count = values.length()
+  let orientation_value = separator_orientation_value(orientation)
+  let serialized_values = slider_serialized_values(values)
+  let first_value = if count == 0 { min } else { values[0] }
+  let last_value = if count == 0 { min } else { values[count - 1] }
+  let range_start = if count <= 1 { min } else { first_value }
+  let start_percent = slider_percent(range_start, min, max)
+  let end_percent = slider_percent(last_value, min, max)
+  let range_percent = end_percent - start_percent
+  let track = @html.div(
+    attrs=@html.Attrs::build()
+      .data_set("slot", "slider-track")
+      .aria_hidden("true"),
+    style=[
+      "position:absolute;overflow:hidden;border-radius:9999px;background:var(--rui-muted,oklch(0.97 0 0))",
+      if orientation is Vertical {
+        "left:50%;top:0;width:0.375rem;height:100%;transform:translateX(-50%)"
+      } else {
+        "inset-inline-start:0;top:50%;width:100%;height:0.375rem;transform:translateY(-50%)"
+      },
+    ],
+    @html.div(
+      attrs=@html.Attrs::build()
+        .data_set("slot", "slider-range")
+        .data_set("start", first_value.to_string())
+        .data_set("end", last_value.to_string()),
+      style=[
+        "position:absolute;background:var(--rui-primary,oklch(0.205 0 0))",
+        if orientation is Vertical {
+          "left:0;right:0;bottom:\{start_percent}%;height:\{range_percent}%"
+        } else {
+          "inset-inline-start:\{start_percent}%;top:0;bottom:0;width:\{range_percent}%"
+        },
+      ],
+      "",
+    ),
+  )
+  let children : Array[@html.Html] = [track]
+  for index in 0..<count {
+    let value = values[index]
+    let percent = slider_percent(value, min, max)
+    let thumb_id = "\{id}-thumb-\{index}"
+    let input_id = if legacy_single_id && count == 1 {
+      id
+    } else {
+      "\{id}-input-\{index}"
+    }
+    let control_attrs = slider_control_attrs(
+      input_attrs, values, index, emit, min, max, step, min_steps_between_values,
+      large_step, orientation, disabled,
+    )
+    children.push(
+      @html.span(
+        id=thumb_id,
+        attrs=@html.Attrs::build()
+          .data_set("slot", "slider-thumb")
+          .data_set("index", index.to_string())
+          .data_set("value", value.to_string())
+          .data_set("orientation", orientation_value)
+          .data_set("disabled", ui_bool(disabled))
+          .aria_hidden("true"),
+        style=[
+          UiBoxSizing,
+          UiTransition,
+          SliderThumbStyle,
+          if orientation is Vertical {
+            "left:50%;bottom:\{percent}%;transform:translate(-50%,50%)"
+          } else {
+            "top:50%;inset-inline-start:calc(\{percent}% - 0.5rem);transform:translateY(-50%)"
+          },
+        ],
+        "",
+      ),
+    )
+    children.push(
+      @html.input(
+        input_type=@html.Range,
+        value=value.to_string(),
+        min~,
+        max~,
+        step~,
+        id=input_id,
+        on_input=emit.map(text => {
+          SetSliderValue(index, slider_parse(text, value))
+        }),
+        on_change=emit.map(text => {
+          CommitSliderValue(index, slider_parse(text, value))
+        }),
+        attrs=control_attrs.aria_label(
+          slider_thumb_label(aria_label, index, count),
+        ),
+        style=[
+          "position:absolute;inset:0;z-index:\{3 + index};width:100%;height:100%;margin:0;background:transparent;cursor:pointer;appearance:none;-webkit-appearance:none",
+          slider_input_pointer_style(),
+          if orientation is Vertical {
+            "writing-mode:vertical-lr;direction:rtl"
+          } else {
+            ""
+          },
+        ],
+      ),
+    )
+  }
+  @html.div(
+    id="\{id}-root",
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .data_set("slot", "slider")
+      .data_set("orientation", orientation_value)
+      .data_set("disabled", ui_bool(disabled))
+      .data_set("min", min.to_string())
+      .data_set("max", max.to_string())
+      .data_set("step", step.to_string())
+      .data_set("large-step", large_step.to_string())
+      .data_set("value", serialized_values)
+      .data_set("values", serialized_values)
+      .data_set("thumb-count", count.to_string())
+      .data_set(
+        "min-steps-between-values",
+        min_steps_between_values.to_string(),
+      ),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "position:relative;display:flex;touch-action:none;align-items:center;user-select:none",
+        if orientation is Vertical {
+          "width:1rem;height:11rem;min-height:11rem;flex-direction:column"
+        } else {
+          "width:100%;height:1rem"
+        },
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+fn slider_values_notify(
+  notify : @cmd.Emit[Array[Int]]?,
+  values : Array[Int],
+) -> @cmd.Cmd {
+  if notify is Some(notify) {
+    notify(values.copy())
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn slider_values_impl(
+  default_values : Array[Int],
+  min : Int,
+  max : Int,
+  step : Int,
+  large_step : Int,
+  min_steps_between_values : Int,
+  orientation : SeparatorOrientation,
+  disabled : Bool,
+  aria_label : String,
+  on_value_change : @cmd.Emit[Array[Int]]?,
+  on_value_commit : @cmd.Emit[Array[Int]]?,
+  id : String,
+  legacy_single_id : Bool,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  input_attrs : @html.Attrs?,
+  style : Array[String],
+) -> @rabbita.Val[@html.Html] {
+  let max = if max < min { min } else { max }
+  let step = slider_step_amount(step)
+  let large_step = if large_step > 0 { large_step } else { 10 }
+  let min_steps_between_values = if min_steps_between_values > 0 {
+    min_steps_between_values
+  } else {
+    0
+  }
+  let initial = slider_normalize_values(
+    default_values, min, max, step, min_steps_between_values,
+  )
+  let (values, emit) = @rabbita.create_state_with_init(
+    init=_ => (initial, slider_bind_pointer_cmd(id)),
+    update=fn(_, msg, current) {
+      match msg {
+        SetSliderValue(index, value) => {
+          let next = slider_set_thumb_value(
+            current, index, value, min, max, step, min_steps_between_values,
+          )
+          let command = if next == current {
+            @cmd.none
+          } else {
+            slider_values_notify(on_value_change, next)
+          }
+          (next, command)
+        }
+        SetSliderKeyboardValue(index, value) => {
+          let next = slider_constrain_thumb_value(
+            current, index, value, min, max, step, min_steps_between_values,
+          )
+          let command = if next == current {
+            @cmd.none
+          } else {
+            @cmd.batch([
+              slider_values_notify(on_value_change, next),
+              slider_values_notify(on_value_commit, next),
+            ])
+          }
+          (next, command)
+        }
+        CommitSliderValue(index, value) => {
+          let next = slider_set_thumb_value(
+            current, index, value, min, max, step, min_steps_between_values,
+          )
+          (next, slider_values_notify(on_value_commit, next))
+        }
+      }
+    },
+  )
+  values.view(values => {
+    render_slider_values(
+      values, emit, min, max, step, min_steps_between_values, large_step, orientation,
+      disabled, aria_label, id, legacy_single_id, class, title, attrs, input_attrs,
+      style,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn slider_values_impl(
+  default_values : Array[Int],
+  min : Int,
+  max : Int,
+  step : Int,
+  large_step : Int,
+  min_steps_between_values : Int,
+  orientation : SeparatorOrientation,
+  disabled : Bool,
+  aria_label : String,
+  on_value_change : @cmd.Emit[Array[Int]]?,
+  on_value_commit : @cmd.Emit[Array[Int]]?,
+  id : String,
+  legacy_single_id : Bool,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  input_attrs : @html.Attrs?,
+  style : Array[String],
+) -> @rabbita.Val[@html.Html] {
+  ignore((on_value_change, on_value_commit))
+  let max = if max < min { min } else { max }
+  let step = slider_step_amount(step)
+  let large_step = if large_step > 0 { large_step } else { 10 }
+  let min_steps_between_values = if min_steps_between_values > 0 {
+    min_steps_between_values
+  } else {
+    0
+  }
+  let values = slider_normalize_values(
+    default_values, min, max, step, min_steps_between_values,
+  )
+  let emit : @cmd.Emit[SliderMsg] = @cmd.Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_slider_values(
+      values, emit, min, max, step, min_steps_between_values, large_step, orientation,
+      disabled, aria_label, id, legacy_single_id, class, title, attrs, input_attrs,
+      style,
+    ),
+  )
+}
+
+///|
+/// Stateful multi-thumb slider with sorted, non-crossing values.
+///
+/// Every thumb is backed by its own native range input. Initial and pointer
+/// values align to `step`; keyboard page/shift movement uses the exact
+/// `large_step`. Values stay sorted and at least
+/// `min_steps_between_values` steps apart.
+pub fn slider_values(
+  id~ : String,
+  default_values~ : Array[Int],
+  min? : Int = 0,
+  max? : Int = 100,
+  step? : Int = 1,
+  large_step? : Int = 10,
+  min_steps_between_values? : Int = 0,
+  orientation? : SeparatorOrientation = Horizontal,
+  disabled? : Bool = false,
+  aria_label? : String = "Value",
+  on_value_change? : @cmd.Emit[Array[Int]],
+  on_value_commit? : @cmd.Emit[Array[Int]],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  input_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  slider_values_impl(
+    default_values, min, max, step, large_step, min_steps_between_values, orientation,
+    disabled, aria_label, on_value_change, on_value_commit, id, false, class, title,
+    attrs, input_attrs, style,
+  )
+}
+
+///|
+fn slider_single_notify(
+  notify : @cmd.Emit[Int]?,
+  fallback : Int,
+) -> @cmd.Emit[Array[Int]]? {
+  match notify {
+    Some(notify) =>
+      Some(
+        @cmd.Emit(values => {
+          notify(if values.length() == 0 { fallback } else { values[0] })
+        }),
+      )
+    None => None
+  }
+}
+
+///|
+pub fn slider(
+  id~ : String,
+  default_value? : Int = 0,
+  min? : Int = 0,
+  max? : Int = 100,
+  step? : Int = 1,
+  large_step? : Int = 10,
+  orientation? : SeparatorOrientation = Horizontal,
+  disabled? : Bool = false,
+  aria_label? : String = "Value",
+  on_value_change? : @cmd.Emit[Int],
+  on_value_commit? : @cmd.Emit[Int],
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  input_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let fallback = slider_clamp(default_value, min, max)
+  slider_values_impl(
+    [default_value],
+    min,
+    max,
+    step,
+    large_step,
+    0,
+    orientation,
+    disabled,
+    aria_label,
+    slider_single_notify(on_value_change, fallback),
+    slider_single_notify(on_value_commit, fallback),
+    id,
+    true,
+    class,
+    title,
+    attrs,
+    input_attrs,
+    style,
+  )
+}

--- a/rui/slider_test.mbt
+++ b/rui/slider_test.mbt
@@ -1,0 +1,154 @@
+///|
+#cfg(target="js")
+extern "js" fn install_slider_incremental_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 }
+  #|   }
+  #| }
+
+///|
+#warnings("-alert_unstable")
+#cfg(target="js")
+fn render_incremental_slider(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_slider_incremental_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#warnings("-alert_unstable")
+#cfg(not(target="js"))
+fn render_incremental_slider(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn slider_assert_contains(actual : String, expected : String) -> Unit raise {
+  if !actual.contains(expected) {
+    fail(
+      "expected rendered slider HTML to contain `\{expected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+fn slider_assert_not_contains(
+  actual : String,
+  unexpected : String,
+) -> Unit raise {
+  if actual.contains(unexpected) {
+    fail(
+      "expected rendered slider HTML not to contain `\{unexpected}`; got `\{actual}`",
+    )
+  }
+}
+
+///|
+test "two-thumb slider renders unique native controls and a bounded range" {
+  let notify : @cmd.Emit[Array[Int]] = @cmd.Emit(_ => @cmd.none)
+  let html = render_incremental_slider(() => {
+    @rui.slider_values(
+      id="two-band",
+      default_values=[83, 24],
+      min=10,
+      max=90,
+      step=5,
+      large_step=13,
+      min_steps_between_values=2,
+      aria_label="Price band",
+      on_value_change=notify,
+      on_value_commit=notify,
+    )
+  })
+  slider_assert_contains(html, "id=\"two-band-root\"")
+  slider_assert_contains(html, "data-value=\"25,85\"")
+  slider_assert_contains(html, "data-thumb-count=\"2\"")
+  slider_assert_contains(html, "data-large-step=\"13\"")
+  slider_assert_contains(html, "id=\"two-band-thumb-0\"")
+  slider_assert_contains(html, "id=\"two-band-thumb-1\"")
+  slider_assert_contains(html, "data-orientation=\"horizontal\"")
+  slider_assert_contains(html, "data-disabled=\"false\"")
+  slider_assert_contains(
+    html, "--rui-slider-thumb-base-shadow:0 1px 2px rgb(0 0 0 / 0.1)",
+  )
+  slider_assert_contains(
+    html, "background:var(--rui-slider-thumb,var(--rui-background,oklch(1 0 0)))",
+  )
+  slider_assert_contains(
+    html, "box-shadow:var(--rui-slider-thumb-shadow,var(--rui-slider-thumb-base-shadow,0 1px 2px rgb(0 0 0 / 0.1)))",
+  )
+  slider_assert_contains(
+    html, "background:transparent;cursor:pointer;appearance:none;-webkit-appearance:none",
+  )
+  slider_assert_contains(html, "data-index=\"0\"")
+  slider_assert_contains(html, "data-index=\"1\"")
+  slider_assert_contains(html, "id=\"two-band-input-0\"")
+  slider_assert_contains(html, "id=\"two-band-input-1\"")
+  slider_assert_contains(html, "aria-label=\"Price band 1\"")
+  slider_assert_contains(html, "aria-label=\"Price band 2\"")
+  slider_assert_contains(html, "data-start=\"25\"")
+  slider_assert_contains(html, "data-end=\"85\"")
+}
+
+///|
+test "three-thumb and empty sliders keep every thumb operable" {
+  let notify : @cmd.Emit[Array[Int]] = @cmd.Emit(values => {
+    ignore(values)
+    @cmd.none
+  })
+  let three = render_incremental_slider(() => {
+    @rui.slider_values(
+      id="tri-band",
+      default_values=[79, 17, 52],
+      min=10,
+      max=90,
+      step=5,
+      min_steps_between_values=1,
+      on_value_change=notify,
+      on_value_commit=notify,
+    )
+  })
+  slider_assert_contains(three, "data-value=\"15,50,80\"")
+  slider_assert_contains(three, "data-thumb-count=\"3\"")
+  slider_assert_contains(three, "id=\"tri-band-thumb-2\"")
+  slider_assert_contains(three, "id=\"tri-band-input-2\"")
+
+  let empty = render_incremental_slider(() => {
+    @rui.slider_values(
+      id="empty-band",
+      default_values=[],
+      min=10,
+      max=90,
+      step=5,
+    )
+  })
+  slider_assert_contains(empty, "data-value=\"10\"")
+  slider_assert_contains(empty, "data-thumb-count=\"1\"")
+  slider_assert_contains(empty, "id=\"empty-band-input-0\"")
+}
+
+///|
+test "single slider preserves its public input id and accepts inherited RTL" {
+  let html = render_incremental_slider(() => {
+    @rui.slider(
+      id="legacy-level",
+      default_value=37,
+      large_step=13,
+      aria_label="Legacy level",
+      attrs=@html.Attrs::build().dir("rtl"),
+    )
+  })
+  slider_assert_contains(html, "id=\"legacy-level-root\"")
+  slider_assert_contains(html, "id=\"legacy-level\"")
+  slider_assert_not_contains(html, "id=\"legacy-level-input-0\"")
+  slider_assert_contains(html, "data-value=\"37\"")
+  slider_assert_contains(html, "data-large-step=\"13\"")
+  slider_assert_contains(html, "aria-label=\"Legacy level\"")
+  slider_assert_contains(html, "dir=\"rtl\"")
+  slider_assert_contains(html, "inset-inline-start")
+}

--- a/rui/slider_wbtest.mbt
+++ b/rui/slider_wbtest.mbt
@@ -1,0 +1,333 @@
+///|
+test "slider keyboard handles every arrow independent of orientation" {
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, false, "ArrowUp"),
+    Some(40),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, false, "ArrowRight"),
+    Some(40),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, false, "ArrowDown"),
+    Some(34),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, false, "ArrowLeft"),
+    Some(34),
+  )
+}
+
+///|
+test "slider keyboard supports large movement Home End and RTL" {
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, true, false, "ArrowRight"),
+    Some(48),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, false, "PageUp"),
+    Some(48),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, false, "PageDown"),
+    Some(26),
+  )
+  assert_eq(slider_key_value(37, 1, 97, 3, 11, false, false, "Home"), Some(1))
+  assert_eq(slider_key_value(37, 1, 97, 3, 11, false, false, "End"), Some(97))
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, true, "ArrowRight"),
+    Some(34),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, true, "ArrowLeft"),
+    Some(40),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, true, "ArrowUp"),
+    Some(40),
+  )
+  assert_eq(
+    slider_key_value(37, 1, 97, 3, 11, false, true, "ArrowDown"),
+    Some(34),
+  )
+  assert_eq(slider_key_value(37, 1, 97, 3, 11, false, false, "Escape"), None)
+}
+
+///|
+test "slider large step preserves its own grid" {
+  assert_eq(
+    slider_key_value(20, 0, 100, 2, 5, false, false, "PageUp"),
+    Some(25),
+  )
+  assert_eq(
+    slider_key_value(25, 0, 100, 2, 5, false, false, "ArrowUp"),
+    Some(28),
+  )
+  assert_eq(
+    slider_key_value(96, 0, 97, 2, 13, true, false, "ArrowRight"),
+    Some(97),
+  )
+  assert_eq(
+    slider_key_value(1, 1, 97, 0, 11, false, false, "ArrowRight"),
+    Some(2),
+  )
+}
+
+///|
+test "slider values normalize two and three thumbs" {
+  assert_eq(slider_normalize_values([83, 24], 10, 90, 5, 2), [25, 85])
+  assert_eq(slider_normalize_values([-9, 44, 113], 10, 90, 5, 1), [10, 45, 90])
+  assert_eq(slider_normalize_values([], 10, 90, 5, 0), [10])
+}
+
+///|
+test "slider thumb updates align and stop at constrained neighbours" {
+  let values = [20, 50, 80]
+  assert_eq(slider_set_thumb_value(values, 1, 76, 10, 90, 5, 2), [20, 70, 80])
+  assert_eq(slider_set_thumb_value(values, 1, 24, 10, 90, 5, 2), [20, 30, 80])
+  assert_eq(slider_set_thumb_value(values, 0, 87, 10, 90, 5, 2), [40, 50, 80])
+  assert_eq(
+    slider_thumb_key_value(values, 1, 10, 90, 5, 2, 13, false, false, "End"),
+    Some(70),
+  )
+  assert_eq(
+    slider_thumb_key_value(values, 1, 10, 90, 5, 2, 13, false, false, "Home"),
+    Some(30),
+  )
+  assert_eq(
+    slider_thumb_key_value(
+      values, 2, 10, 90, 5, 2, 13, false, false, "ArrowDown",
+    ),
+    Some(75),
+  )
+  // Reject a large move that would violate a positive neighbour gap.
+  assert_eq(
+    slider_thumb_key_value(
+      values, 1, 10, 90, 5, 2, 27, true, false, "ArrowRight",
+    ),
+    Some(50),
+  )
+  // With no requested gap, the same move clamps to the adjacent thumb.
+  assert_eq(
+    slider_thumb_key_value(
+      values, 1, 10, 90, 5, 0, 47, true, false, "ArrowRight",
+    ),
+    Some(80),
+  )
+}
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_slider_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const listeners = {}
+  #|   const fixture = globalThis.__ruiSliderPointerFixture = {
+  #|     document: globalThis.document,
+  #|     hadDocument: own("document"),
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     HTMLInputElement: globalThis.HTMLInputElement,
+  #|     hadHTMLInputElement: own("HTMLInputElement"),
+  #|     Event: globalThis.Event,
+  #|     hadEvent: own("Event"),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own("PointerEvent"),
+  #|     focused: -1,
+  #|     inputIndex: -1,
+  #|     commitIndex: -1,
+  #|     listeners,
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class HTMLInputElement extends HTMLElement {}
+  #|   class Event {
+  #|     constructor(type, init = {}) {
+  #|       this.type = type
+  #|       this.bubbles = !!init.bubbles
+  #|       this.defaultPrevented = false
+  #|     }
+  #|     preventDefault() { this.defaultPrevented = true }
+  #|   }
+  #|   class PointerEvent extends Event {
+  #|     constructor(type, init = {}) {
+  #|       super(type, init)
+  #|       Object.assign(this, init)
+  #|       this.button = init.button ?? 0
+  #|       this.pointerId = init.pointerId ?? 0
+  #|       this.clientX = init.clientX ?? 0
+  #|       this.clientY = init.clientY ?? 0
+  #|     }
+  #|   }
+  #|   Object.assign(globalThis, {
+  #|     EventTarget, Node, HTMLElement, HTMLInputElement, Event, PointerEvent,
+  #|   })
+  #|   const style = () => ({
+  #|     values: {},
+  #|     setProperty(name, value) { this.values[name] = value },
+  #|     getPropertyValue(name) { return this.values[name] || "" },
+  #|     removeProperty(name) {
+  #|       const value = this.values[name] || ""
+  #|       delete this.values[name]
+  #|       return value
+  #|     },
+  #|   })
+  #|   const inputs = [20, 50, 80].map((value, index) => {
+  #|     const input = new HTMLInputElement()
+  #|     Object.assign(input, {
+  #|       value: String(value),
+  #|       style: style(),
+  #|       focus: () => { fixture.focused = index },
+  #|       hasAttribute: name => name === "disabled" ? false : false,
+  #|       getAttribute: name => name === "aria-disabled" ? "" : "",
+  #|       dispatchEvent: event => {
+  #|         if (event.type === "input") fixture.inputIndex = index
+  #|         if (event.type === "change") fixture.commitIndex = index
+  #|         return true
+  #|       },
+  #|     })
+  #|     return input
+  #|   })
+  #|   const root = new HTMLElement()
+  #|   const attributes = {
+  #|     "data-min": "10",
+  #|     "data-max": "90",
+  #|     "data-step": "5",
+  #|     "data-min-steps-between-values": "2",
+  #|     "data-orientation": "horizontal",
+  #|     "data-disabled": "false",
+  #|   }
+  #|   Object.assign(root, {
+  #|     getAttribute: name => attributes[name] || "",
+  #|     hasAttribute: name => Object.prototype.hasOwnProperty.call(attributes, name),
+  #|     querySelectorAll: selector => selector === '[data-slot="slider-control"]'
+  #|       ? inputs
+  #|       : [],
+  #|     getBoundingClientRect: () => ({
+  #|       left: 0, right: 100, top: 0, bottom: 20, width: 100, height: 20,
+  #|     }),
+  #|     addEventListener: (type, callback) => { listeners[type] = callback },
+  #|     setPointerCapture(pointerId) { this.__capturedPointerId = pointerId },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId === pointerId) delete this.__capturedPointerId
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|   })
+  #|   fixture.inputs = inputs
+  #|   fixture.root = root
+  #|   globalThis.window = {
+  #|     getComputedStyle: () => ({ getPropertyValue: () => "ltr" }),
+  #|   }
+  #|   globalThis.document = {
+  #|     getElementById: id => id === "pointer-band-root" ? root : null,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_slider_pointer_fixture(client_x : Int) -> Unit =
+  #| clientX => {
+  #|   const fixture = globalThis.__ruiSliderPointerFixture
+  #|   const event = new PointerEvent("pointerdown", {
+  #|     button: 0,
+  #|     pointerId: 7,
+  #|     clientX,
+  #|     clientY: 10,
+  #|   })
+  #|   fixture.listeners.pointerdown(event)
+  #|   fixture.listeners.pointerup(event)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_lose_slider_pointer_fixture(client_x : Int) -> Unit =
+  #| clientX => {
+  #|   const fixture = globalThis.__ruiSliderPointerFixture
+  #|   const event = new PointerEvent("pointerdown", {
+  #|     button: 0,
+  #|     pointerId: 8,
+  #|     clientX,
+  #|     clientY: 10,
+  #|   })
+  #|   fixture.listeners.pointerdown(event)
+  #|   delete fixture.root.__capturedPointerId
+  #|   fixture.listeners.lostpointercapture(event)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_slider_pointer_fixture_result(kind : Int) -> Int =
+  #| kind => {
+  #|   const fixture = globalThis.__ruiSliderPointerFixture
+  #|   if (kind === 0) return fixture.focused
+  #|   if (kind === 1) return fixture.inputIndex
+  #|   if (kind === 2) return fixture.commitIndex
+  #|   return -2
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_slider_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiSliderPointerFixture
+  #|   if (!fixture) return
+  #|   if (fixture.hadDocument) globalThis.document = fixture.document
+  #|   else delete globalThis.document
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadHTMLInputElement) {
+  #|     globalThis.HTMLInputElement = fixture.HTMLInputElement
+  #|   } else delete globalThis.HTMLInputElement
+  #|   if (fixture.hadEvent) globalThis.Event = fixture.Event
+  #|   else delete globalThis.Event
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiSliderPointerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "slider pointer selection targets the nearest first and middle thumbs" {
+  ffi_install_slider_pointer_fixture()
+  bind_slider_pointer("pointer-band")
+  ffi_fire_slider_pointer_fixture(18)
+  let first_focus = ffi_slider_pointer_fixture_result(0)
+  let first_input = ffi_slider_pointer_fixture_result(1)
+  let first_commit = ffi_slider_pointer_fixture_result(2)
+  ffi_fire_slider_pointer_fixture(58)
+  let middle_focus = ffi_slider_pointer_fixture_result(0)
+  let middle_input = ffi_slider_pointer_fixture_result(1)
+  let middle_commit = ffi_slider_pointer_fixture_result(2)
+  ffi_lose_slider_pointer_fixture(31)
+  let active_after_capture_loss = match ui_element_by_id("pointer-band-root") {
+    Some(root) =>
+      match slider_pointer_binding(root) {
+        Some(binding) => binding.active_index
+        None => -1
+      }
+    None => -2
+  }
+  ffi_restore_slider_pointer_fixture()
+  assert_eq(first_focus, 0)
+  assert_eq(first_input, 0)
+  assert_eq(first_commit, 0)
+  assert_eq(middle_focus, 1)
+  assert_eq(middle_input, 1)
+  assert_eq(middle_commit, 1)
+  assert_eq(active_after_capture_loss, -1)
+}

--- a/rui/sonner.mbt
+++ b/rui/sonner.mbt
@@ -1,0 +1,40 @@
+///|
+const SonnerRichColorCss : String =
+  #|[data-slot="sonner"] [data-slot="toast"][data-variant="success"] {
+  #|  border-color:var(--rui-sonner-success-border,light-dark(oklch(0.72 0.17 142 / 0.45),oklch(0.55 0.13 142 / 0.55))) !important;
+  #|  background:var(--rui-sonner-success-background,light-dark(oklch(0.97 0.04 142),oklch(0.24 0.05 142))) !important;
+  #|  color:var(--rui-sonner-success-foreground,light-dark(oklch(0.38 0.12 142),oklch(0.79 0.17 142))) !important;
+  #|}
+  #|[data-slot="sonner"] [data-slot="toast"][data-variant="destructive"] {
+  #|  border-color:var(--rui-sonner-error-border,color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 35%,transparent)) !important;
+  #|  background:var(--rui-sonner-error-background,color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 12%,var(--rui-background,oklch(1 0 0)))) !important;
+  #|  color:var(--rui-sonner-error-foreground,var(--rui-destructive,oklch(0.577 0.245 27.325))) !important;
+  #|}
+  #|
+
+///|
+#warnings("-alert_xss_vulnerable")
+fn sonner_rich_color_stylesheet() -> @html.Html {
+  // Static selectors bridge Sonner's inline toast recipe to color-scheme-aware
+  // rich-color tokens without requiring a consumer stylesheet.
+  let attrs = @html.Attrs::build()
+    .data_set("rui-style", "sonner-rich-colors")
+    .inner_html(SonnerRichColorCss)
+  @html.style_tag(attrs~, ([] : Array[@html.Html]))
+}
+
+///|
+/// Stateful rich-color toast host matching shadcn's Sonner surface while using
+/// Rabbita incremental state instead of a global JavaScript singleton.
+pub fn sonner(
+  max_toasts? : Int = 3,
+  position? : String = "bottom-right",
+  class? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ToastScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  toaster_impl("sonner", true, max_toasts, position, class, attrs, style, scope => {
+    @html.fragment([sonner_rich_color_stylesheet(), children(scope)])
+  })
+}

--- a/rui/spinner.mbt
+++ b/rui/spinner.mbt
@@ -1,0 +1,44 @@
+///|
+const SpinnerStyle : String = "display:inline-flex;width:1rem;height:1rem;align-items:center;justify-content:center;color:currentColor;vertical-align:-0.125em"
+
+///|
+/// Render a self-contained SVG spinner. `theme` supplies the CSS keyframes and
+/// reduced-motion override so motion is not tracked by runtime script.
+pub fn spinner(
+  label? : String = "Loading",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.span(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .role("status")
+      .aria_label(label)
+      .data_set("slot", "spinner"),
+    style=ui_styles([UiBoxSizing, SpinnerStyle], style),
+    @svg.svg(
+      width=16,
+      height=16,
+      view_box="0 0 24 24",
+      style=[
+        "display:block;width:100%;height:100%;transform-origin:center;animation:rui-spin 1s linear infinite",
+      ],
+      [
+        @svg.path(
+          d="M21 12a9 9 0 1 1-6.219-8.56",
+          fill="none",
+          stroke="currentColor",
+          stroke_width=2,
+          attrs=@svg.Attrs::build()
+            .stroke_linecap("round")
+            .stroke_linejoin("round"),
+        ),
+      ],
+    ),
+  )
+}

--- a/rui/switch.mbt
+++ b/rui/switch.mbt
@@ -1,0 +1,292 @@
+///|
+pub(all) enum SwitchSize {
+  Default
+  Sm
+} derive(Debug, Eq)
+
+///|
+const SwitchBaseStyle : String = "display:inline-flex;flex-shrink:0;align-items:center;--rui-control-base-bg:var(--rui-switch-unchecked,var(--rui-input,oklch(0.922 0 0)));--rui-control-base-fg:currentColor;--rui-control-base-border:transparent;--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,transparent));border-radius:9999px;margin:0;background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-switch-unchecked,var(--rui-input,oklch(0.922 0 0)))));color:var(--rui-control-fg,var(--rui-control-base-fg,currentColor));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));cursor:pointer;appearance:none;-webkit-appearance:none;outline-offset:2px;vertical-align:middle"
+
+///|
+const SwitchCheckedStyle : String = "--rui-control-base-bg:var(--rui-primary,oklch(0.205 0 0))"
+
+///|
+const SwitchUncheckedStyle : String = "--rui-control-base-bg:var(--rui-switch-unchecked,var(--rui-input,oklch(0.922 0 0)))"
+
+///|
+const SwitchInvalidStyle : String = "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+const SwitchSizeDefaultStyle : String = "width:2rem;height:1.15rem;padding:0"
+
+///|
+const SwitchSizeSmStyle : String = "width:1.5rem;height:0.875rem;padding:0"
+
+///|
+const SwitchThumbStyle : String = "display:block;flex-shrink:0;border-radius:9999px;pointer-events:none;transition:transform 150ms ease"
+
+///|
+const SwitchThumbSizeDefaultStyle : String = "width:1rem;height:1rem"
+
+///|
+const SwitchThumbSizeSmStyle : String = "width:0.75rem;height:0.75rem"
+
+///|
+const SwitchThumbCheckedDefaultStyle : String = "transform:translateX(calc(100% - 2px))"
+
+///|
+const SwitchThumbCheckedSmStyle : String = "transform:translateX(calc(100% - 2px))"
+
+///|
+const SwitchThumbUncheckedStyle : String = "transform:translateX(0)"
+
+///|
+const SwitchReadOnlyStyle : String = "cursor:default"
+
+///|
+const SwitchRtlCss : String =
+  #|[data-slot="switch-thumb"][data-state="checked"]:dir(rtl) {
+  #|  transform:translateX(calc(-100% + 2px)) !important;
+  #|}
+  #|
+
+///|
+#warnings("-alert_xss_vulnerable")
+fn switch_rtl_stylesheet() -> @html.Html {
+  // `:dir()` follows the nearest inherited direction without runtime script.
+  let attrs = @html.Attrs::build()
+    .data_set("rui-style", "switch-rtl")
+    .inner_html(SwitchRtlCss)
+  @html.style_tag(attrs~, ([] : Array[@html.Html]))
+}
+
+///|
+fn switch_size_style(size : SwitchSize) -> String {
+  match size {
+    Default => SwitchSizeDefaultStyle
+    Sm => SwitchSizeSmStyle
+  }
+}
+
+///|
+fn switch_size_value(size : SwitchSize) -> String {
+  match size {
+    Default => "default"
+    Sm => "sm"
+  }
+}
+
+///|
+fn switch_thumb_size_style(size : SwitchSize) -> String {
+  match size {
+    Default => SwitchThumbSizeDefaultStyle
+    Sm => SwitchThumbSizeSmStyle
+  }
+}
+
+///|
+fn switch_state_style(checked : Bool) -> String {
+  if checked {
+    SwitchCheckedStyle
+  } else {
+    SwitchUncheckedStyle
+  }
+}
+
+///|
+fn switch_thumb_state_style(checked : Bool, size : SwitchSize) -> String {
+  if !checked {
+    "background:var(--rui-switch-thumb-unchecked,var(--rui-background,oklch(1 0 0)));\{SwitchThumbUncheckedStyle}"
+  } else {
+    let position = match size {
+      Default => SwitchThumbCheckedDefaultStyle
+      Sm => SwitchThumbCheckedSmStyle
+    }
+    "background:var(--rui-switch-thumb-checked,var(--rui-background,oklch(1 0 0)));\{position}"
+  }
+}
+
+///|
+fn switch_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    SwitchInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+fn switch_read_only_style(read_only : Bool) -> String {
+  if read_only {
+    SwitchReadOnlyStyle
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render one switch state for the incremental wrapper.
+///
+/// As a native button with `role="switch"`, mouse, Space, and Enter all request
+/// the next value. No hidden form input is created.
+fn render_switch(
+  checked? : Bool = false,
+  size? : SwitchSize = Default,
+  disabled? : Bool = false,
+  read_only? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_checked_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  let state = if checked { "checked" } else { "unchecked" }
+  let control_attrs = ui_attrs(attrs)
+    .data_set("slot", "switch")
+    .data_set("size", switch_size_value(size))
+    .data_set("state", state)
+  ignore(control_attrs.role("switch"))
+  ignore(control_attrs.aria_checked(ui_bool(checked)))
+  ignore(control_attrs.aria_disabled(ui_bool(disabled)))
+  ignore(control_attrs.aria_readonly(ui_bool(read_only)))
+  ignore(control_attrs.data_set(state, ""))
+  if disabled {
+    ignore(control_attrs.data_set("disabled", ""))
+  }
+  if read_only {
+    ignore(control_attrs.data_set("readonly", ""))
+  }
+  if invalid {
+    ignore(control_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  if aria_label is Some(label) {
+    ignore(control_attrs.aria_label(label))
+  }
+  if !disabled && !read_only && on_checked_change is Some(emit) {
+    ignore(control_attrs.on_click(_ => emit(!checked)))
+  }
+  let thumb_attrs = @html.Attrs::build()
+    .data_set("slot", "switch-thumb")
+    .data_set("state", state)
+    .data_set(state, "")
+  if disabled {
+    ignore(thumb_attrs.data_set("disabled", ""))
+  }
+  if read_only {
+    ignore(thumb_attrs.data_set("readonly", ""))
+  }
+  ignore(thumb_attrs.aria_hidden("true"))
+  let thumb = @html.span(
+    style=[
+      UiBoxSizing,
+      SwitchThumbStyle,
+      switch_thumb_size_style(size),
+      switch_thumb_state_style(checked, size),
+    ],
+    attrs=thumb_attrs,
+    "",
+  )
+  let control = @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiTransition,
+        SwitchBaseStyle,
+        switch_size_style(size),
+        switch_state_style(checked),
+        switch_read_only_style(read_only),
+        switch_invalid_style(invalid),
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=control_attrs,
+    thumb,
+  )
+  @html.fragment([switch_rtl_stylesheet(), control])
+}
+
+///|
+/// Build a black-box switch with component-local incremental state.
+#cfg(target="js")
+pub fn switch(
+  default_checked? : Bool = false,
+  size? : SwitchSize = Default,
+  disabled? : Bool = false,
+  read_only? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_checked_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let (checked, set_checked) = @rabbita.create_variable(default_checked)
+  checked.view(checked => {
+    render_switch(
+      checked~,
+      size~,
+      disabled~,
+      read_only~,
+      invalid~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      on_checked_change=@cmd.Emit(next => {
+        let update = set_checked(_ => next)
+        if on_checked_change is Some(notify) {
+          @cmd.batch([update, notify(next)])
+        } else {
+          update
+        }
+      }),
+      attrs?,
+      style~,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn switch(
+  default_checked? : Bool = false,
+  size? : SwitchSize = Default,
+  disabled? : Bool = false,
+  read_only? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_checked_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_checked_change)
+  @rabbita.Val::constant(
+    render_switch(
+      checked=default_checked,
+      size~,
+      disabled~,
+      read_only~,
+      invalid~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      attrs?,
+      style~,
+    ),
+  )
+}

--- a/rui/table.mbt
+++ b/rui/table.mbt
@@ -1,0 +1,262 @@
+///|
+const TableContainerStyle : String = "position:relative;width:100%;max-width:100%;overflow-x:auto"
+
+///|
+const TableBaseStyle : String = "width:100%;border-collapse:collapse;caption-side:bottom;color:var(--rui-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.25rem"
+
+///|
+const TableHeaderStyle : String = "display:table-header-group"
+
+///|
+const TableBodyStyle : String = "display:table-row-group"
+
+///|
+const TableFooterStyle : String = "display:table-footer-group;border-top:1px solid var(--rui-border,oklch(0.922 0 0));background:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent);font-weight:500"
+
+///|
+const TableRowStyle : String = "border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));background:var(--rui-table-row-bg,var(--rui-table-row-base-bg,transparent));transition:background-color 150ms ease"
+
+///|
+const TableRowSelectedStyle : String = "--rui-table-row-base-bg:var(--rui-muted,oklch(0.97 0 0))"
+
+///|
+const TableRowExpandedStyle : String = "--rui-table-row-base-bg:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent)"
+
+///|
+const TableHeadStyle : String = "height:2.5rem;padding-inline:0.5rem;color:var(--rui-foreground,oklch(0.145 0 0));text-align:start;vertical-align:middle;font-weight:500;white-space:nowrap"
+
+///|
+const TableCellStyle : String = "padding:0.5rem;vertical-align:middle;white-space:nowrap"
+
+///|
+const TableCaptionStyle : String = "margin-top:1rem;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem"
+
+///|
+fn table_part_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+fn table_row_state_style(selected : Bool, expanded : Bool) -> String {
+  if selected {
+    TableRowSelectedStyle
+  } else if expanded {
+    TableRowExpandedStyle
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render a semantic native table inside Vega's horizontal-scroll container.
+///
+/// `style` and `attrs` belong to the native `table`; use `container_style` and
+/// `container_attrs` when the scroll wrapper needs customization.
+pub fn[C : @html.IsChildren] table(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  container_attrs? : @html.Attrs,
+  container_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let table_node = @html.table(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TableBaseStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table"),
+    children,
+  )
+  @html.div(
+    style=ui_styles([UiBoxSizing, TableContainerStyle], container_style),
+    attrs=table_part_attrs(container_attrs, "table-container"),
+    table_node,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_header(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.thead(
+    style=ui_styles([UiBoxSizing, TableHeaderStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table-header"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_body(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.tbody(
+    style=ui_styles([UiBoxSizing, TableBodyStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table-body"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_footer(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.tfoot(
+    style=ui_styles([UiBoxSizing, TableFooterStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table-footer"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_row(
+  selected? : Bool = false,
+  expanded? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = table_part_attrs(attrs, "table-row")
+  if selected {
+    ignore(element_attrs.data_set("state", "selected").data_set("selected", ""))
+  }
+  if expanded {
+    ignore(
+      element_attrs
+      .data_set("expanded", "")
+      .data_set("state", if selected { "selected" } else { "expanded" }),
+    )
+  }
+  @html.tr(
+    style=ui_styles(
+      [UiBoxSizing, TableRowStyle, table_row_state_style(selected, expanded)],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_head(
+  scope? : @html.Scope = Col,
+  abbr? : String,
+  colspan? : Int,
+  rowspan? : Int,
+  headers? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.th(
+    style=ui_styles([UiBoxSizing, TableHeadStyle], style),
+    id?,
+    abbr?,
+    colspan?,
+    rowspan?,
+    headers?,
+    scope~,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table-head"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_cell(
+  colspan? : Int,
+  rowspan? : Int,
+  headers? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.td(
+    style=ui_styles([UiBoxSizing, TableCellStyle], style),
+    id?,
+    colspan?,
+    rowspan?,
+    headers?,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table-cell"),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] table_caption(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.caption(
+    style=ui_styles([UiBoxSizing, TableCaptionStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=table_part_attrs(attrs, "table-caption"),
+    children,
+  )
+}

--- a/rui/tabs.mbt
+++ b/rui/tabs.mbt
@@ -1,0 +1,621 @@
+///|
+pub(all) enum TabsOrientation {
+  TabsHorizontal
+  TabsVertical
+} derive(Debug, Eq)
+
+///|
+/// Visual treatment for a tabs list.
+///
+/// `TabsDefault` uses the compact muted surface. `TabsLine` removes that
+/// surface and marks the active trigger with the Vega edge indicator.
+pub(all) enum TabsListVariant {
+  TabsDefault
+  TabsLine
+} derive(Debug, Eq)
+
+///|
+/// One entry for the self-contained tabs component.
+///
+/// Use `icon` for a leading graphic. Use the compound `tabs_*` functions
+/// directly when a trigger needs richer content than an icon and text label.
+struct TabEntry {
+  value : String
+  label : String
+  icon : @html.Html?
+  content : @html.Html
+  disabled : Bool
+}
+
+///|
+const TabsRootStyle : String = "display:flex;width:100%;min-width:0;color:var(--rui-foreground,oklch(0.145 0 0))"
+
+///|
+const TabsRootHorizontalStyle : String = "flex-direction:column;gap:0.5rem"
+
+///|
+const TabsRootVerticalStyle : String = "flex-direction:row;flex-wrap:wrap;align-items:flex-start;gap:0.75rem"
+
+///|
+const TabsListStyle : String = "display:inline-flex;width:fit-content;max-width:100%;align-items:center;justify-content:flex-start;padding:0.1875rem;color:var(--rui-muted-foreground,oklch(0.556 0 0))"
+
+///|
+const TabsListDefaultStyle : String = "gap:0.125rem;border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-muted,oklch(0.97 0 0));overflow-x:auto"
+
+///|
+const TabsListLineStyle : String = "gap:0.25rem;border-radius:0;background:transparent;overflow:visible"
+
+///|
+const TabsListHorizontalStyle : String = "min-height:2.25rem;flex-direction:row"
+
+///|
+const TabsListVerticalStyle : String = "min-width:min(9rem,100%);flex:0 1 9rem;flex-direction:column;align-items:stretch;overflow-x:visible"
+
+///|
+const TabsTriggerStyle : String = "display:inline-flex;min-width:0;min-height:1.75rem;flex:1;align-items:center;justify-content:center;gap:0.375rem;--rui-tabs-base-bg:transparent;--rui-tabs-base-fg:inherit;--rui-tabs-base-border:transparent;--rui-tabs-base-shadow:none;--rui-control-base-shadow:var(--rui-tabs-base-shadow,none);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-tabs-border,var(--rui-tabs-base-border,transparent)));border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);margin:0;padding:0.25rem 0.625rem;background:var(--rui-tabs-bg,var(--rui-tabs-base-bg,transparent));color:var(--rui-tabs-fg,var(--rui-tabs-base-fg,inherit));box-shadow:var(--rui-control-shadow,var(--rui-tabs-shadow,var(--rui-tabs-base-shadow,none)));font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center;white-space:nowrap;cursor:pointer;user-select:none;appearance:none;-webkit-appearance:none;outline-offset:2px"
+
+///|
+const TabsTriggerActiveStyle : String = "--rui-tabs-base-border:var(--rui-tabs-active-border,transparent);--rui-tabs-base-bg:var(--rui-tabs-active-bg,var(--rui-background,oklch(1 0 0)));--rui-tabs-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-tabs-base-shadow:var(--rui-tabs-active-shadow,0 1px 2px rgb(0 0 0 / 0.05))"
+
+///|
+const TabsTriggerInactiveStyle : String = "--rui-tabs-base-bg:transparent;--rui-tabs-base-fg:var(--rui-muted-foreground,oklch(0.556 0 0));--rui-tabs-base-border:transparent;--rui-tabs-base-shadow:none"
+
+///|
+const TabsContentStyle : String = "display:block;min-width:0;flex:1;border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);color:var(--rui-foreground,oklch(0.145 0 0));font-size:0.875rem;line-height:1.5;outline-offset:2px"
+
+///|
+fn tabs_orientation_value(orientation : TabsOrientation) -> String {
+  match orientation {
+    TabsHorizontal => "horizontal"
+    TabsVertical => "vertical"
+  }
+}
+
+///|
+fn tabs_root_orientation_style(orientation : TabsOrientation) -> String {
+  match orientation {
+    TabsHorizontal => TabsRootHorizontalStyle
+    TabsVertical => TabsRootVerticalStyle
+  }
+}
+
+///|
+fn tabs_list_orientation_style(orientation : TabsOrientation) -> String {
+  match orientation {
+    TabsHorizontal => TabsListHorizontalStyle
+    TabsVertical => TabsListVerticalStyle
+  }
+}
+
+///|
+fn tabs_list_variant_value(variant : TabsListVariant) -> String {
+  match variant {
+    TabsDefault => "default"
+    TabsLine => "line"
+  }
+}
+
+///|
+fn tabs_list_variant_style(variant : TabsListVariant) -> String {
+  match variant {
+    TabsDefault => TabsListDefaultStyle
+    TabsLine => TabsListLineStyle
+  }
+}
+
+///|
+fn tabs_state(selected : Bool) -> String {
+  if selected {
+    "active"
+  } else {
+    "inactive"
+  }
+}
+
+///|
+fn tabs_state_attrs(
+  attrs : @html.Attrs?,
+  slot : String,
+  selected : Bool,
+) -> @html.Attrs {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("state", tabs_state(selected))
+  if selected {
+    ignore(element_attrs.data_set("active", ""))
+  } else {
+    ignore(element_attrs.data_set("inactive", ""))
+  }
+  element_attrs
+}
+
+///|
+#cfg(target="js")
+fn tabs_move_focus(event : @dom.KeyboardEvent, orientation : String) -> Bool {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.shift_key() {
+    return false
+  }
+  guard event.target().to_element() is Some(target) else { return false }
+  guard target.closest("[role=\"tab\"]") is Some(current) else { return false }
+  guard current.closest("[role=\"tablist\"]") is Some(list) else {
+    return false
+  }
+  let key = event.key()
+  if key == "Enter" || key == " " {
+    if ui_element_is_enabled(current) {
+      ui_click_element(current)
+    }
+    return true
+  }
+  guard ui_roving_context(
+      event, "[role=\"tab\"]", "[role=\"tablist\"]", "[role=\"tab\"]",
+    )
+    is Some(context) else {
+    return false
+  }
+  guard ui_roving_target(context, key, orientation, ui_element_is_rtl(list))
+    is Some(next) else {
+    return false
+  }
+  ui_focus_element(next)
+  if !next.is_same_node(current.as_node()) {
+    ui_click_element(next)
+  }
+  true
+}
+
+///|
+#cfg(target="js")
+fn tabs_bind_keyboard(
+  attrs : @html.Attrs,
+  orientation : TabsOrientation,
+) -> Unit {
+  ignore(
+    attrs.on_keydown(event => {
+      if tabs_move_focus(event, tabs_orientation_value(orientation)) {
+        event.prevent_default()
+      }
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn tabs_bind_keyboard(
+  attrs : @html.Attrs,
+  orientation : TabsOrientation,
+) -> Unit {
+  ignore((attrs, orientation))
+}
+
+///|
+fn tab_entry_enabled(items : Array[TabEntry], value : String) -> Bool {
+  for item in items {
+    if item.value == value {
+      return !item.disabled
+    }
+  }
+  false
+}
+
+///|
+fn tabs_initial_value(
+  items : Array[TabEntry],
+  default_value : String?,
+) -> String? {
+  if default_value is Some(value) && tab_entry_enabled(items, value) {
+    return Some(value)
+  }
+  for item in items {
+    if !item.disabled {
+      return Some(item.value)
+    }
+  }
+  None
+}
+
+///|
+fn tabs_focus_value(items : Array[TabEntry], value : String?) -> String? {
+  if value is Some(value) && tab_entry_enabled(items, value) {
+    return Some(value)
+  }
+  for item in items {
+    if !item.disabled {
+      return Some(item.value)
+    }
+  }
+  None
+}
+
+///|
+/// Construct one black-box tab entry.
+pub fn tab_entry(
+  value~ : String,
+  label~ : String,
+  icon? : @html.Html,
+  content~ : @html.Html,
+  disabled? : Bool = false,
+) -> TabEntry {
+  { value, label, icon, content, disabled }
+}
+
+///|
+fn tab_entry_trigger_content(item : TabEntry) -> @html.Html {
+  match item.icon {
+    Some(icon) =>
+      @html.fragment([
+        @html.span(
+          attrs=@html.Attrs::build()
+            .aria_hidden("true")
+            .data_set("slot", "tabs-trigger-icon"),
+          style=[
+            "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;pointer-events:none",
+          ],
+          icon,
+        ),
+        @html.text(item.label),
+      ])
+    None => @html.text(item.label)
+  }
+}
+
+///|
+/// Render the root for a composed tabs interface.
+pub fn[C : @html.IsChildren] tabs_root(
+  value? : String,
+  orientation? : TabsOrientation = TabsHorizontal,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "tabs")
+    .data_set("orientation", tabs_orientation_value(orientation))
+  if value is Some(value) {
+    ignore(element_attrs.data_set("value", value))
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        TabsRootStyle,
+        tabs_root_orientation_style(orientation),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the ARIA `tablist` container.
+pub fn[C : @html.IsChildren] tabs_list(
+  orientation? : TabsOrientation = TabsHorizontal,
+  variant? : TabsListVariant = TabsDefault,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "tabs-list")
+    .data_set("orientation", tabs_orientation_value(orientation))
+    .data_set("variant", tabs_list_variant_value(variant))
+    .role("tablist")
+    .aria_orientation(tabs_orientation_value(orientation))
+  if aria_label is Some(label) {
+    ignore(element_attrs.aria_label(label))
+  }
+  tabs_bind_keyboard(element_attrs, orientation)
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        TabsListStyle,
+        tabs_list_variant_style(variant),
+        tabs_list_orientation_style(orientation),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render one native button with ARIA tab semantics.
+///
+/// The browser supplies native focus plus Enter and Space activation. The
+/// component appends its value request after any caller click handler stored
+/// in `attrs`.
+pub fn[C : @html.IsChildren] tabs_trigger(
+  value~ : String,
+  selected? : Bool = false,
+  disabled? : Bool = false,
+  tab_stop? : Bool,
+  controls? : String,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let tab_stop = tab_stop.unwrap_or(selected && !disabled)
+  let element_attrs = tabs_state_attrs(attrs, "tabs-trigger", selected)
+    .data_set("value", value)
+    .role("tab")
+    .aria_selected(ui_bool(selected))
+    .aria_disabled(ui_bool(disabled))
+    .tabindex(if tab_stop && !disabled { 0 } else { -1 })
+  if controls is Some(controls) {
+    ignore(element_attrs.aria_controls(controls))
+  }
+  if disabled {
+    ignore(element_attrs.data_set("disabled", ""))
+  }
+  if !disabled && on_value_change is Some(emit) {
+    ignore(element_attrs.on_click(_ => emit(value)))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        TabsTriggerStyle,
+        if selected {
+          TabsTriggerActiveStyle
+        } else {
+          TabsTriggerInactiveStyle
+        },
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render one ARIA tab panel.
+pub fn[C : @html.IsChildren] tabs_content(
+  value~ : String,
+  selected? : Bool = false,
+  force_mount? : Bool = false,
+  labelledby? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = tabs_state_attrs(attrs, "tabs-content", selected)
+    .data_set("value", value)
+    .data_set("force-mount", ui_bool(force_mount))
+    .role("tabpanel")
+    .tabindex(0)
+    .aria_hidden(ui_bool(!selected))
+  if labelledby is Some(labelledby) {
+    ignore(element_attrs.aria_labelledby(labelledby))
+  }
+  @html.div(
+    style=ui_styles([UiBoxSizing, TabsContentStyle], style),
+    id?,
+    class?,
+    title?,
+    hidden=!selected,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+/// Render the current tabs state for the public incremental component.
+fn render_tabs(
+  items~ : Array[TabEntry],
+  value? : String,
+  orientation? : TabsOrientation = TabsHorizontal,
+  list_variant? : TabsListVariant = TabsDefault,
+  aria_label? : String,
+  force_mount? : Bool = false,
+  on_value_change? : @cmd.Emit[String],
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  list_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  list_style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+) -> @html.Html {
+  let trigger_nodes : Array[@html.Html] = []
+  let content_nodes : Array[@html.Html] = []
+  let focus_value = tabs_focus_value(items, value)
+  for index, item in items {
+    let selected = !item.disabled && value == Some(item.value)
+    let tab_stop = focus_value == Some(item.value)
+    let trigger_id = id.map(id => "\{id}-trigger-\{index}")
+    let content_id = id.map(id => "\{id}-content-\{index}")
+    let trigger_html = {
+      let controls = content_id
+      let id = trigger_id
+      tabs_trigger(
+        value=item.value,
+        selected~,
+        disabled=item.disabled,
+        tab_stop~,
+        controls?,
+        on_value_change?,
+        id?,
+        style=trigger_style,
+        tab_entry_trigger_content(item),
+      )
+    }
+    let content_html = {
+      let labelledby = trigger_id
+      let id = content_id
+      tabs_content(
+        value=item.value,
+        selected~,
+        force_mount~,
+        labelledby?,
+        id?,
+        style=content_style,
+        item.content,
+      )
+    }
+    trigger_nodes.push(trigger_html)
+    content_nodes.push(content_html)
+  }
+  let list = {
+    let attrs = list_attrs
+    tabs_list(
+      orientation~,
+      variant=list_variant,
+      aria_label?,
+      attrs?,
+      style=list_style,
+      trigger_nodes,
+    )
+  }
+  tabs_root(
+    value?,
+    orientation~,
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs?,
+    style~,
+    [list, @html.fragment(content_nodes)],
+  )
+}
+
+///|
+/// Build a self-contained tabs interface with component-local incremental
+/// state.
+#cfg(target="js")
+pub fn tabs(
+  items~ : Array[TabEntry],
+  default_value? : String,
+  orientation? : TabsOrientation = TabsHorizontal,
+  list_variant? : TabsListVariant = TabsDefault,
+  aria_label? : String,
+  force_mount? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  list_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  list_style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let (value, set_value) = @rabbita.create_variable(
+    tabs_initial_value(items, default_value),
+  )
+  let on_value_change = set_value.map(next => _ => Some(next))
+  value.view(value => {
+    render_tabs(
+      items~,
+      value?,
+      orientation~,
+      list_variant~,
+      aria_label?,
+      force_mount~,
+      on_value_change~,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      list_attrs?,
+      style~,
+      list_style~,
+      trigger_style~,
+      content_style~,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: render the requested initial selection as a constant
+/// incremental value.
+#cfg(not(target="js"))
+pub fn tabs(
+  items~ : Array[TabEntry],
+  default_value? : String,
+  orientation? : TabsOrientation = TabsHorizontal,
+  list_variant? : TabsListVariant = TabsDefault,
+  aria_label? : String,
+  force_mount? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  list_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  list_style? : Array[String] = [],
+  trigger_style? : Array[String] = [],
+  content_style? : Array[String] = [],
+) -> @rabbita.Val[@html.Html] {
+  let value = tabs_initial_value(items, default_value)
+  @rabbita.Val::constant(
+    render_tabs(
+      items~,
+      value?,
+      orientation~,
+      list_variant~,
+      aria_label?,
+      force_mount~,
+      id?,
+      class?,
+      title?,
+      hidden?,
+      attrs?,
+      list_attrs?,
+      style~,
+      list_style~,
+      trigger_style~,
+      content_style~,
+    ),
+  )
+}

--- a/rui/tabs_variant_test.mbt
+++ b/rui/tabs_variant_test.mbt
@@ -1,0 +1,93 @@
+///|
+test "tabs entries render optional SVG icons through the black-box API" {
+  let html = render_incremental(() => {
+    @rui.tabs(default_value="preview", aria_label="View mode", items=[
+      @rui.tab_entry(
+        value="preview",
+        label="Preview",
+        icon=@svg.svg(width=24, height=24, view_box="0 0 24 24", [
+          @svg.path(
+            d="M4 4h16v16H4zM4 9h16M9 9v11",
+            fill="none",
+            stroke="currentColor",
+            stroke_width=2,
+          ),
+        ]),
+        content=@html.p("Preview content"),
+      ),
+    ])
+  })
+  assert_contains(html, "data-slot=\"tabs-trigger-icon\"")
+  assert_contains(
+    html, "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;pointer-events:none",
+  )
+  assert_contains(html, "<svg")
+  assert_contains(html, "M4 4h16v16H4zM4 9h16M9 9v11")
+  assert_element_tag_contains(
+    html, "data-value=\"preview\" role=\"tab\"", "data-state=\"active\"",
+  )
+  assert_contains(html, "Preview")
+}
+
+///|
+test "tabs expose the Vega line list variant through the black-box API" {
+  let items = [
+    @rui.tab_entry(
+      value="preview",
+      label="Preview",
+      content=@html.p("Preview content"),
+    ),
+    @rui.tab_entry(value="code", label="Code", content=@html.p("Code content")),
+  ]
+  let html = render_incremental(() => {
+    @rui.tabs(items~, default_value="preview", list_variant=@rui.TabsLine, list_style=[
+      "gap:0.75rem",
+    ])
+  })
+  assert_contains(
+    html, "data-slot=\"tabs-list\" data-orientation=\"horizontal\" data-variant=\"line\"",
+  )
+  assert_contains(
+    html, "gap:0.25rem;border-radius:0;background:transparent;overflow:visible;min-height:2.25rem;flex-direction:row;gap:0.75rem",
+  )
+  assert_element_tag_contains(
+    html, "data-value=\"preview\" role=\"tab\"", "data-state=\"active\"",
+  )
+  assert_contains(
+    html, "--rui-tabs-base-shadow:var(--rui-tabs-active-shadow,0 1px 2px rgb(0 0 0 / 0.05))",
+  )
+}
+
+///|
+test "tabs keep the default muted list variant for existing callers" {
+  let html = render(
+    @rui.tabs_list(@rui.tabs_trigger(value="one", selected=true, "One")),
+  )
+  assert_contains(html, "data-variant=\"default\"")
+  assert_contains(
+    html, "background:var(--rui-muted,oklch(0.97 0 0));overflow-x:auto",
+  )
+}
+
+///|
+test "theme supplies line tab indicators without consumer CSS" {
+  let html = render(
+    @rui.theme(
+      @rui.tabs_list(
+        variant=@rui.TabsLine,
+        @rui.tabs_trigger(value="one", selected=true, "One"),
+      ),
+    ),
+  )
+  assert_contains(
+    html, "[data-slot=\"tabs-list\"][data-variant=\"line\"] > [data-slot=\"tabs-trigger\"]::after",
+  )
+  assert_contains(html, "--rui-tabs-active-bg:transparent")
+  assert_contains(html, "--rui-tabs-active-shadow:none")
+  assert_contains(html, "bottom:-5px")
+  assert_contains(html, "inset-inline-end:-0.25rem")
+  assert_contains(
+    html, "[data-slot=\"tabs-trigger\"][data-state=\"active\"]::after",
+  )
+  assert_not_contains(html, "&gt;")
+}

--- a/rui/textarea.mbt
+++ b/rui/textarea.mbt
@@ -1,0 +1,86 @@
+///|
+const TextareaBaseStyle : String = "display:flex;width:100%;min-height:4rem;min-width:0;field-sizing:content;resize:vertical;--rui-control-base-bg:var(--rui-input-background,transparent);--rui-control-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-control-base-border:var(--rui-input,oklch(0.922 0 0));--rui-control-base-shadow:0 1px 2px rgb(0 0 0 / 0.05);border:1px solid transparent;border-color:var(--rui-control-border,var(--rui-control-base-border,var(--rui-input,oklch(0.922 0 0))));border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);background:var(--rui-control-bg,var(--rui-control-base-bg,var(--rui-input-background,transparent)));padding:0.5rem 0.625rem;color:var(--rui-control-fg,var(--rui-control-base-fg,var(--rui-foreground,oklch(0.145 0 0))));box-shadow:var(--rui-control-shadow,var(--rui-control-base-shadow,0 1px 2px rgb(0 0 0 / 0.05)));font-size:1rem;line-height:1.5rem;outline-offset:2px"
+
+///|
+const TextareaInvalidStyle : String = "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+fn textarea_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    TextareaInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render a controlled native textarea using the shadcn/ui Vega field recipe.
+///
+/// `on_input` is the immediate value-change channel; `on_change` follows the
+/// browser's native change event. User styles are appended last.
+pub fn textarea(
+  name? : String,
+  value? : String,
+  rows? : Int,
+  cols? : Int,
+  placeholder? : String,
+  read_only? : Bool,
+  disabled? : Bool = false,
+  maxlength? : Int,
+  minlength? : Int,
+  required? : Bool,
+  autofocus? : Bool,
+  wrap? : String,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  on_change? : @cmd.Emit[String],
+  on_input? : @cmd.Emit[String],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "textarea",
+) -> @html.Html {
+  let attrs = ui_attrs(attrs).data_set("slot", slot)
+  if disabled {
+    ignore(attrs.data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  @html.textarea(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        TextareaBaseStyle,
+        textarea_invalid_style(invalid),
+        ui_disabled_visual_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    name?,
+    value?,
+    rows?,
+    cols?,
+    placeholder?,
+    read_only?,
+    disabled~,
+    maxlength?,
+    minlength?,
+    required?,
+    autofocus?,
+    wrap?,
+    on_change?,
+    on_input?,
+    attrs~,
+    ([] : Array[@html.Html]),
+  )
+}

--- a/rui/theme.mbt
+++ b/rui/theme.mbt
@@ -1,0 +1,1109 @@
+///|
+/// Shared Vega foundations. Component-specific recipes stay next to their
+/// component so copying source remains straightforward.
+const UiFontSans : String = "font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,\"Segoe UI\",sans-serif"
+
+///|
+const UiBoxSizing : String = "box-sizing:border-box"
+
+///|
+const UiTextRendering : String = "-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility"
+
+///|
+const UiTransition : String = "transition:color 150ms ease,background-color 150ms ease,border-color 150ms ease,box-shadow 150ms ease,opacity 150ms ease,transform 150ms ease"
+
+///|
+const UiShadowXs : String = "box-shadow:0 1px 2px rgb(0 0 0 / 0.05)"
+
+///|
+const UiDisabled : String = "cursor:not-allowed;pointer-events:none;opacity:0.5"
+
+///|
+const UiDisabledVisual : String = "cursor:not-allowed;opacity:0.5"
+
+///|
+/// Pseudo classes cannot live in an HTML `style` attribute. This small,
+/// declarative sheet supplies the interaction layer while every component's
+/// layout and base recipe remain inline. It is emitted by `theme`, so callers
+/// still import no CSS and no script registers or mutates hover state.
+const UiInteractionCss : String =
+  #|@keyframes rui-spin {
+  #|  to { transform:rotate(360deg); }
+  #|}
+  #|@keyframes rui-pulse {
+  #|  50% { opacity:0.5; }
+  #|}
+  #|@keyframes rui-shimmer {
+  #|  from { background-position:100% 0; }
+  #|  to { background-position:0 0; }
+  #|}
+  #|@keyframes rui-caret-blink {
+  #|  0%,70%,100% { opacity:1; }
+  #|  20%,50% { opacity:0; }
+  #|}
+  #|@keyframes rui-edge-overlay-enter {
+  #|  from { opacity:0; }
+  #|  to { opacity:1; }
+  #|}
+  #|@keyframes rui-edge-overlay-exit {
+  #|  from { opacity:1; }
+  #|  to { opacity:0; }
+  #|}
+  #|@keyframes rui-sheet-enter {
+  #|  from { opacity:0;transform:var(--rui-sheet-closed-transform); }
+  #|  to { opacity:1;transform:translate3d(0,0,0); }
+  #|}
+  #|@keyframes rui-sheet-exit {
+  #|  from { opacity:1;transform:translate3d(0,0,0); }
+  #|  to { opacity:0;transform:var(--rui-sheet-closed-transform); }
+  #|}
+  #|@keyframes rui-drawer-enter {
+  #|  from { opacity:0;transform:var(--rui-drawer-closed-transform); }
+  #|  to { opacity:1;transform:translate3d(0,0,0); }
+  #|}
+  #|@keyframes rui-drawer-exit {
+  #|  from { opacity:1;transform:translate3d(0,0,0); }
+  #|  to { opacity:0;transform:var(--rui-drawer-closed-transform); }
+  #|}
+  #|@layer rui-interactions {
+  #|  :where([hidden]:not([hidden="until-found"])) {
+  #|    display:none !important;
+  #|  }
+  #|  :where([data-slot="sheet-overlay"],[data-slot="drawer-overlay"])[data-state="open"] {
+  #|    animation:rui-edge-overlay-enter 200ms ease-out;
+  #|  }
+  #|  :where([data-slot="sheet-overlay"],[data-slot="drawer-overlay"])[data-state="closed"] {
+  #|    animation:rui-edge-overlay-exit 200ms ease-in;
+  #|  }
+  #|  :where([data-slot="input"],[data-slot="input-group-control"],[data-slot="textarea"])::placeholder {
+  #|    color:var(--rui-muted-foreground,oklch(0.556 0 0));
+  #|    opacity:1;
+  #|  }
+  #|  :where([data-slot="input"],[data-slot="input-group-control"],[data-slot="textarea"])::selection {
+  #|    background:var(--rui-primary,oklch(0.205 0 0));
+  #|    color:var(--rui-primary-foreground,oklch(0.985 0 0));
+  #|  }
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-control"]:is(textarea)) {
+  #|    height:auto;
+  #|  }
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-addon"][data-align="block-start"]),
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-addon"][data-align="block-end"]) {
+  #|    height:auto;
+  #|    flex-direction:column;
+  #|    align-items:stretch;
+  #|  }
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-addon"][data-align="inline-start"]) > [data-slot="input-group-control"] {
+  #|    padding-inline-start:0.375rem;
+  #|  }
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-addon"][data-align="inline-end"]) > [data-slot="input-group-control"] {
+  #|    padding-inline-end:0.375rem;
+  #|  }
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-addon"][data-align="block-start"]) > input[data-slot="input-group-control"] {
+  #|    padding-block-end:0.75rem;
+  #|  }
+  #|  [data-slot="input-group"]:has(> [data-slot="input-group-addon"][data-align="block-end"]) > input[data-slot="input-group-control"] {
+  #|    padding-block-start:0.75rem;
+  #|  }
+  #|  [data-slot="input-group"]:has([data-slot][aria-invalid="true"]) {
+  #|    --rui-control-border:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));
+  #|    --rui-control-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2));
+  #|  }
+  #|  [data-slot="input-group-addon"][data-align="inline-start"]:has(> button) {
+  #|    margin-inline-start:-0.3rem;
+  #|  }
+  #|  [data-slot="input-group-addon"][data-align="inline-end"]:has(> button) {
+  #|    margin-inline-end:-0.3rem;
+  #|  }
+  #|  [data-slot="input-group-addon"] > button {
+  #|    --rui-button-base-shadow:none;
+  #|  }
+  #|  [data-slot="input-group-addon"] > button:is([data-size="xs"],[data-size="icon-xs"]) {
+  #|    --rui-control-radius:calc(var(--rui-radius,0.625rem) - 0.1875rem);
+  #|  }
+  #|  [data-slot="input-group-addon"][data-align="inline-start"]:has(> [data-slot="kbd"]) {
+  #|    margin-inline-start:-0.15rem;
+  #|  }
+  #|  [data-slot="input-group-addon"][data-align="inline-end"]:has(> [data-slot="kbd"]) {
+  #|    margin-inline-end:-0.15rem;
+  #|  }
+  #|  :where([data-slot="input-group-addon"],[data-slot="input-group-text"]) :where(svg,[aria-hidden="true"]) {
+  #|    width:1rem;
+  #|    height:1rem;
+  #|    flex:none;
+  #|  }
+  #|  [data-slot="input"]::file-selector-button {
+  #|    display:inline-flex;
+  #|    height:1.75rem;
+  #|    align-items:center;
+  #|    border:0;
+  #|    margin-inline-end:0.5rem;
+  #|    background:transparent;
+  #|    padding:0;
+  #|    color:var(--rui-foreground,oklch(0.145 0 0));
+  #|    font:inherit;
+  #|    font-size:0.875rem;
+  #|    font-weight:500;
+  #|  }
+  #|  [data-slot="field-set"]:has(> :where([data-slot="checkbox-group"],[data-slot="radio-group"])) {
+  #|    gap:0.75rem;
+  #|  }
+  #|  [data-slot="field-group"] > [data-slot="field-group"] {
+  #|    gap:1rem;
+  #|  }
+  #|  [data-slot="field"][data-orientation="vertical"] > *,
+  #|  [data-slot="field"][data-orientation="responsive"] > * {
+  #|    width:100%;
+  #|  }
+  #|  [data-slot="field"][data-orientation="horizontal"] > [data-slot="field-label"] {
+  #|    flex:auto;
+  #|  }
+  #|  [data-slot="field"][data-orientation="horizontal"]:has(> [data-slot="field-content"]) {
+  #|    align-items:flex-start;
+  #|  }
+  #|  @container rui-field-group (min-width:28rem) {
+  #|    [data-slot="field"][data-orientation="responsive"] {
+  #|      flex-direction:row;
+  #|      align-items:center;
+  #|    }
+  #|    [data-slot="field"][data-orientation="responsive"] > * {
+  #|      width:auto;
+  #|    }
+  #|    [data-slot="field"][data-orientation="responsive"] > [data-slot="field-label"] {
+  #|      flex:auto;
+  #|    }
+  #|    [data-slot="field"][data-orientation="responsive"]:has(> [data-slot="field-content"]) {
+  #|      align-items:flex-start;
+  #|    }
+  #|  }
+  #|  [data-slot="input-otp-group"] > [data-slot="input-otp-slot"]:first-child {
+  #|    border-inline-start:1px solid var(--rui-otp-border,var(--rui-input,oklch(0.922 0 0)));
+  #|    border-start-start-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);
+  #|    border-end-start-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);
+  #|  }
+  #|  [data-slot="input-otp-group"] > [data-slot="input-otp-slot"]:last-child {
+  #|    border-start-end-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);
+  #|    border-end-end-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);
+  #|  }
+  #|  [data-slot="input-otp-group"] > [data-slot="input-otp-slot"]:only-child {
+  #|    border-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);
+  #|  }
+  #|  [data-slot="input-otp-caret"] {
+  #|    visibility:hidden;
+  #|  }
+  #|  [data-slot="input-otp"]:focus-within [data-slot="input-otp-slot"][data-current="true"] {
+  #|    z-index:10;
+  #|    --rui-otp-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-otp-shadow:0 0 0 3px color-mix(in oklch,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|  }
+  #|  [data-slot="input-otp"]:focus-within [data-slot="input-otp-slot"][data-current="true"][aria-invalid="true"] {
+  #|    --rui-otp-border:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));
+  #|    --rui-otp-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2));
+  #|  }
+  #|  [data-slot="input-otp"]:focus-within [data-slot="input-otp-caret"] {
+  #|    visibility:visible;
+  #|  }
+  #|  :where([data-slot="button"],[data-slot="attachment-action"],[data-slot="message-scroller-button"]) svg {
+  #|    width:var(--rui-button-icon-size,1rem);
+  #|    height:var(--rui-button-icon-size,1rem);
+  #|    flex-shrink:0;
+  #|    pointer-events:none;
+  #|  }
+  #|  :where([data-slot="toggle"],[data-slot="toggle-group-item"]) svg {
+  #|    width:var(--rui-toggle-icon-size,1rem);
+  #|    height:var(--rui-toggle-icon-size,1rem);
+  #|    flex-shrink:0;
+  #|    pointer-events:none;
+  #|  }
+  #|  :where([data-slot="badge"],[data-slot="kbd"],[data-slot="alert"],[data-slot="empty-icon"],[data-slot="item-media"][data-variant="icon"],[data-slot="marker"],[data-slot="marker-icon"],[data-slot="avatar-group-count"],[data-slot="attachment-media"],[data-slot="bubble-reactions"]) svg {
+  #|    width:var(--rui-icon-size,1rem);
+  #|    height:var(--rui-icon-size,1rem);
+  #|    flex-shrink:0;
+  #|    pointer-events:none;
+  #|  }
+  #|  :where([data-slot="select-trigger"],[data-slot="select-item"],[data-slot="select-scroll-up-button"],[data-slot="select-scroll-down-button"],[data-slot="combobox-trigger"],[data-slot="combobox-clear"],[data-slot="combobox-item"],[data-slot="combobox-chip-remove"],[data-slot="input-otp-separator"],[data-slot="command-input-wrapper"],[role^="menuitem"],[data-submenu-key]) svg {
+  #|    width:1rem;
+  #|    height:1rem;
+  #|    flex-shrink:0;
+  #|    pointer-events:none;
+  #|  }
+  #|  :where([data-slot="checkbox-indicator"],[data-slot="breadcrumb-separator"]) svg {
+  #|    width:0.875rem;
+  #|    height:0.875rem;
+  #|  }
+  #|  :where([data-icon="inline-end"],[data-icon="inline-start"]):dir(rtl) {
+  #|    transform:scaleX(-1);
+  #|  }
+  #|  [data-slot="command-group"]:not(:has([data-slot="command-item"]:not([hidden]))) {
+  #|    display:none !important;
+  #|  }
+  #|  dialog:where([data-slot="dialog-native"],[data-slot="alert-dialog-native"],[data-slot="sheet-native"],[data-slot="drawer-native"],[data-slot="command-dialog-native"],[data-slot="popover-content"])::backdrop {
+  #|    background:transparent;
+  #|  }
+  #|  :where([data-slot="sidebar-trigger"],[data-slot="sidebar-menu-button"],[data-slot="sidebar-menu-sub-button"],[data-slot="sidebar-group-action"],[data-slot="sidebar-menu-action"],[data-slot="dialog-close"],[data-slot="sheet-close"],[data-slot="drawer-close"]) svg {
+  #|    width:1rem;
+  #|    height:1rem;
+  #|    flex-shrink:0;
+  #|    pointer-events:none;
+  #|  }
+  #|  [data-slot="sidebar-content"]::-webkit-scrollbar {
+  #|    display:none;
+  #|  }
+  #|  :where([data-slot="sidebar-menu-button"],[data-slot="sidebar-menu-sub-button"]) > span:last-child {
+  #|    min-width:0;
+  #|    overflow:hidden;
+  #|    text-overflow:ellipsis;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-action"]) > [data-slot="sidebar-menu-button"],
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-badge"]) > [data-slot="sidebar-menu-button"] {
+  #|    --rui-sidebar-item-padding-end:2.25rem;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-action"]):has(> [data-slot="sidebar-menu-badge"]) > [data-slot="sidebar-menu-button"] {
+  #|    --rui-sidebar-item-padding-end:3.75rem;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-action"]) > [data-slot="sidebar-menu-badge"] {
+  #|    --rui-sidebar-badge-end:1.875rem;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-button"][data-size="sm"]) {
+  #|    --rui-sidebar-menu-action-top:0.25rem;
+  #|    --rui-sidebar-menu-badge-top:0.25rem;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-button"][data-size="default"]) {
+  #|    --rui-sidebar-menu-action-top:0.375rem;
+  #|    --rui-sidebar-menu-badge-top:0.375rem;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:has(> [data-slot="sidebar-menu-button"][data-size="lg"]) {
+  #|    --rui-sidebar-menu-action-top:0.875rem;
+  #|    --rui-sidebar-menu-badge-top:0.875rem;
+  #|  }
+  #|  [data-slot="sidebar"][data-collapsible="offcanvas"][data-state="collapsed"] > :not([data-slot="sidebar-rail"]) {
+  #|    visibility:hidden;
+  #|    pointer-events:none;
+  #|    transition:visibility 0s linear 200ms;
+  #|  }
+  #|  html:has([data-slot="sidebar"][data-mobile="true"][data-mobile-state="open"]),
+  #|  body:has([data-slot="sidebar"][data-mobile="true"][data-mobile-state="open"]) {
+  #|    overflow:hidden;
+  #|    overscroll-behavior:none;
+  #|  }
+  #|  html:has([data-slot="sidebar"][data-mobile="true"][data-mobile-state="open"]) {
+  #|    scrollbar-gutter:stable;
+  #|  }
+  #|  [data-slot="sidebar-wrapper"]:has(> [data-slot="sidebar-shell"][data-variant="inset"]) > [data-slot="sidebar-inset"] {
+  #|    margin:0.5rem;
+  #|    border-radius:calc(var(--rui-radius,0.625rem) + 0.25rem);
+  #|    box-shadow:0 1px 3px rgb(0 0 0 / 0.08);
+  #|  }
+  #|  [data-slot="sidebar-wrapper"]:has(> [data-slot="sidebar-shell"][data-variant="inset"]) {
+  #|    --rui-sidebar-wrapper-background:var(--rui-sidebar,oklch(0.985 0 0));
+  #|  }
+  #|  [data-slot="sidebar-wrapper"][data-state="expanded"]:has(> [data-slot="sidebar-shell"][data-variant="inset"][data-side="left"]) > [data-slot="sidebar-inset"] {
+  #|    margin-left:0;
+  #|  }
+  #|  [data-slot="sidebar-wrapper"][data-state="expanded"]:has(> [data-slot="sidebar-shell"][data-variant="inset"][data-side="right"]) > [data-slot="sidebar-inset"] {
+  #|    margin-right:0;
+  #|  }
+  #|  [data-slot="alert-dialog-media"] svg {
+  #|    width:2rem;
+  #|    height:2rem;
+  #|  }
+  #|  [data-slot="avatar-badge"] > svg {
+  #|    width:var(--rui-avatar-badge-icon-size,0.5rem);
+  #|    height:var(--rui-avatar-badge-icon-size,0.5rem);
+  #|  }
+  #|  [data-slot="attachment-media"] [data-slot="spinner"] {
+  #|    width:var(--rui-attachment-spinner-size,1rem);
+  #|    height:var(--rui-attachment-spinner-size,1rem);
+  #|  }
+  #|  :where([data-slot="attachment-media"][data-variant="image"],[data-slot="item-media"][data-variant="image"]) img {
+  #|    width:100%;
+  #|    height:100%;
+  #|    object-fit:cover;
+  #|  }
+  #|  [data-slot="attachment"]:has(> [data-slot="attachment-content"]) {
+  #|    --rui-attachment-padding-block:var(--rui-attachment-content-padding-block,0);
+  #|    --rui-attachment-padding-inline:var(--rui-attachment-content-padding-inline-root,0);
+  #|  }
+  #|  [data-slot="attachment"]:has(> [data-slot="attachment-media"]):not(:has(> [data-slot="attachment-content"])) {
+  #|    --rui-attachment-padding-block:var(--rui-attachment-media-padding,0);
+  #|    --rui-attachment-padding-inline:var(--rui-attachment-media-padding,0);
+  #|  }
+  #|  :where(button,a)[data-size]:has(> svg) {
+  #|    --rui-button-padding-inline:var(--rui-button-padding-inline-with-icon,var(--rui-button-padding-inline));
+  #|  }
+  #|  [data-slot="marker"][data-variant="separator"]::before,
+  #|  [data-slot="marker"][data-variant="separator"]::after {
+  #|    content:"";
+  #|    height:1px;
+  #|    min-width:0;
+  #|    flex:1;
+  #|    margin-inline:0.25rem;
+  #|    background:var(--rui-border,oklch(0.922 0 0));
+  #|  }
+  #|  [data-slot="marker"][data-variant="separator"] > [data-slot="marker-content"] {
+  #|    flex:none;
+  #|    text-align:center;
+  #|  }
+  #|  [data-slot="alert"]:has(> svg) {
+  #|    --rui-alert-columns:auto minmax(0,1fr) auto;
+  #|    --rui-alert-column-gap:0.75rem;
+  #|  }
+  #|  [data-slot="alert"] > svg {
+  #|    width:1rem;
+  #|    height:1rem;
+  #|    transform:translateY(0.125rem);
+  #|  }
+  #|  [data-slot="card-header"]:has(> [data-slot="card-action"]) {
+  #|    --rui-card-header-columns:minmax(0,1fr) auto;
+  #|    --rui-card-header-column-gap:0.5rem;
+  #|  }
+  #|  [data-slot="alert-description"] > p {
+  #|    line-height:1.625;
+  #|  }
+  #|  [data-slot="item"]:has([data-slot="item-description"]) > [data-slot="item-media"] {
+  #|    align-self:flex-start;
+  #|    transform:translateY(0.125rem);
+  #|  }
+  #|  [data-slot="item"]:not([aria-disabled="true"]):not(:disabled):focus-visible {
+  #|    --rui-item-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-item-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  :where(a,button)[data-slot="item"]:not([aria-disabled="true"]):not(:disabled):where(:hover,:focus-visible) {
+  #|    --rui-item-bg:color-mix(in oklab,var(--rui-accent,oklch(0.97 0 0)) 50%,transparent);
+  #|  }
+  #|  a[data-slot="badge"]:not([aria-disabled="true"]):focus-visible {
+  #|    --rui-badge-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-badge-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="badge"][aria-invalid="true"] {
+  #|    --rui-badge-border:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));
+  #|    --rui-badge-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2));
+  #|  }
+  #|  [data-slot="bubble"][data-variant] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):focus-visible {
+  #|    --rui-bubble-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-bubble-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="bubble-reactions"]:has(button) {
+  #|    padding:0;
+  #|  }
+  #|  a[data-slot="marker"]:not([aria-disabled="true"]):focus-visible {
+  #|    --rui-marker-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="message"]:has([data-slot="message-footer"]) [data-slot="message-avatar"] {
+  #|    transform:translateY(-2rem);
+  #|  }
+  #|  [data-slot="message"][data-align="end"] [data-slot="message-footer"] {
+  #|    justify-content:flex-end;
+  #|  }
+  #|  [data-slot="message"]:has([data-slot="bubble"][data-variant="ghost"]) :where([data-slot="message-header"],[data-slot="message-footer"]) {
+  #|    padding-inline:0;
+  #|  }
+  #|  [data-slot="tabs-list"][data-variant="line"] > [data-slot="tabs-trigger"] {
+  #|    position:relative;
+  #|    --rui-tabs-active-bg:transparent;
+  #|    --rui-tabs-active-border:transparent;
+  #|    --rui-tabs-active-shadow:none;
+  #|  }
+  #|  [data-slot="tabs-list"][data-variant="line"] > [data-slot="tabs-trigger"]::after {
+  #|    content:"";
+  #|    position:absolute;
+  #|    background:var(--rui-foreground,oklch(0.145 0 0));
+  #|    opacity:0;
+  #|    transition:opacity 150ms ease;
+  #|  }
+  #|  [data-slot="tabs-list"][data-variant="line"][data-orientation="horizontal"] > [data-slot="tabs-trigger"]::after {
+  #|    inset-inline:0;
+  #|    bottom:-5px;
+  #|    height:2px;
+  #|  }
+  #|  [data-slot="tabs-list"][data-variant="line"][data-orientation="vertical"] > [data-slot="tabs-trigger"]::after {
+  #|    inset-block:0;
+  #|    inset-inline-end:-0.25rem;
+  #|    width:2px;
+  #|  }
+  #|  [data-slot="tabs-list"][data-variant="line"] > [data-slot="tabs-trigger"][data-state="active"]::after {
+  #|    opacity:1;
+  #|  }
+  #|  [data-slot="typography-p"]:not(:first-child) {
+  #|    margin-top:1.5rem;
+  #|  }
+  #|  [data-slot="typography-list"] > li:not(:first-child) {
+  #|    margin-top:0.5rem;
+  #|  }
+  #|  [data-slot="table-body"] > [data-slot="table-row"]:last-child {
+  #|    border-bottom:0;
+  #|  }
+  #|  :where([data-slot="table-head"],[data-slot="table-cell"]):has([role="checkbox"]) {
+  #|    padding-inline-end:0;
+  #|  }
+  #|  :where([data-slot="table-head"],[data-slot="table-cell"]) > [role="checkbox"] {
+  #|    transform:translateY(2px);
+  #|  }
+  #|  [data-slot="scroll-area-viewport"]::-webkit-scrollbar {
+  #|    display:none;
+  #|  }
+  #|  [data-slot="carousel"]:dir(rtl) [data-slot="carousel-track"][data-orientation="horizontal"] {
+  #|    --rui-carousel-offset:var(--rui-carousel-rtl-offset);
+  #|  }
+  #|  [data-slot="carousel"]:dir(rtl) :where([data-slot="carousel-previous"] [data-icon="previous"],[data-slot="carousel-next"] [data-icon="next"]) {
+  #|    transform:scaleX(-1);
+  #|  }
+  #|  @media (max-width:767px) {
+  #|    [data-slot="popover-content"][data-date-range-picker-popup] {
+  #|      --rui-date-range-picker-width:15.5rem;
+  #|      --rui-date-range-picker-max-height:calc(100% - 1rem);
+  #|      --rui-date-range-picker-overflow-y:auto;
+  #|    }
+  #|  }
+  #|  @media (min-width:768px) {
+  #|    [data-slot="empty"] { --rui-empty-padding:3rem; }
+  #|    :where([data-slot="input"],[data-slot="input-group-control"],[data-slot="textarea"]) {
+  #|      font-size:0.875rem;
+  #|      line-height:1.25rem;
+  #|    }
+  #|  }
+  #|  /* A submenu can render its open state just before showPopover() promotes
+  #|     it to the top layer. Keep that pre-promotion frame non-painting; the
+  #|     @starting-style block below owns the visible entry transition. */
+  #|  [data-submenu-owner][data-state="open"]:not(:popover-open) {
+  #|    visibility:hidden !important;
+  #|    opacity:0 !important;
+  #|    pointer-events:none !important;
+  #|  }
+  #|  @starting-style {
+  #|    [data-slot="sidebar-mobile-layer"]:popover-open [data-slot="sidebar-overlay"][data-state="open"] {
+  #|      opacity:0 !important;
+  #|    }
+  #|    [data-slot="sidebar-mobile-layer"]:popover-open [data-slot="sidebar"][data-mobile="true"][data-state="expanded"][data-side="left"] {
+  #|      opacity:0 !important;
+  #|      transform:translateX(-100%) !important;
+  #|    }
+  #|    [data-slot="sidebar-mobile-layer"]:popover-open [data-slot="sidebar"][data-mobile="true"][data-state="expanded"][data-side="right"] {
+  #|      opacity:0 !important;
+  #|      transform:translateX(100%) !important;
+  #|    }
+  #|    :where([data-slot="popover-content"],[data-slot="tooltip-content"],[data-slot="hover-card-content"],[data-slot="select-content"],[data-slot="combobox-content"],[data-slot="dropdown-menu-content"],[data-slot="context-menu-content"],[data-slot="menubar-content"],[data-slot="navigation-menu-content"],[data-submenu-owner])[data-state="open"]:popover-open {
+  #|      visibility:hidden !important;
+  #|      opacity:0 !important;
+  #|      transform:scale(0.95) !important;
+  #|    }
+  #|    dialog[data-slot="popover-content"][data-state="open"][open] {
+  #|      visibility:hidden !important;
+  #|      opacity:0 !important;
+  #|      transform:scale(0.95) !important;
+  #|    }
+  #|    :where([data-slot="dialog-overlay"],[data-slot="alert-dialog-overlay"],[data-slot="command-dialog-overlay"])[data-state="open"] {
+  #|      opacity:0 !important;
+  #|    }
+  #|    :where([data-slot="dialog-content"],[data-slot="alert-dialog-content"],[data-slot="command-dialog-content"])[data-state="open"] {
+  #|      opacity:0 !important;
+  #|      transform:translateY(-0.5rem) scale(0.95) !important;
+  #|    }
+  #|    :where([data-slot="toaster"],[data-slot="sonner"])[data-position^="top"] > [data-slot="toast"][data-state="open"] {
+  #|      opacity:0 !important;
+  #|      transform:translateY(-0.5rem) scale(0.98) !important;
+  #|    }
+  #|    :where([data-slot="toaster"],[data-slot="sonner"])[data-position^="bottom"] > [data-slot="toast"][data-state="open"] {
+  #|      opacity:0 !important;
+  #|      transform:translateY(0.5rem) scale(0.98) !important;
+  #|    }
+  #|  }
+  #|  @media (prefers-reduced-motion:reduce) {
+  #|    :where([data-slot="popover-content"],[data-slot="tooltip-content"],[data-slot="hover-card-content"],[data-slot="select-content"],[data-slot="combobox-content"],[data-slot="dropdown-menu-content"],[data-slot="context-menu-content"],[data-slot="menubar-content"],[data-slot="navigation-menu-content"],[data-submenu-owner]) {
+  #|      transition-duration:0s !important;
+  #|    }
+  #|  }
+  #|
+  #|  @media (hover: hover) {
+  #|    :where(button,a)[data-variant][data-size]:not([data-slot="toggle"]):not([data-slot="toggle-group-item"]):not([data-rui-close-icon]):not(:disabled):not([aria-disabled="true"])[data-variant="default"]:hover {
+  #|      --rui-button-bg:color-mix(in oklab,var(--rui-primary,oklch(0.205 0 0)) 90%,transparent);
+  #|    }
+  #|    :where(button,a)[data-variant][data-size]:not([data-slot="toggle"]):not([data-slot="toggle-group-item"]):not([data-rui-close-icon]):not(:disabled):not([aria-disabled="true"])[data-variant="destructive"]:hover {
+  #|      --rui-button-bg:color-mix(in oklab,var(--rui-destructive,oklch(0.577 0.245 27.325)) 90%,transparent);
+  #|      --rui-button-fg:white;
+  #|    }
+  #|    :where(button,a)[data-variant][data-size]:not([data-slot="toggle"]):not([data-slot="toggle-group-item"]):not([data-rui-close-icon]):not(:disabled):not([aria-disabled="true"])[data-variant="outline"]:hover {
+  #|      --rui-button-bg:var(--rui-outline-hover-bg,var(--rui-accent,oklch(0.97 0 0)));
+  #|      --rui-button-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    :where(button,a)[data-variant][data-size]:not([data-slot="toggle"]):not([data-slot="toggle-group-item"]):not([data-slot="message-scroller-button"]):not([data-rui-close-icon]):not(:disabled):not([aria-disabled="true"])[data-variant="secondary"]:hover {
+  #|      --rui-button-bg:color-mix(in oklab,var(--rui-secondary,oklch(0.97 0 0)) 80%,transparent);
+  #|    }
+  #|    :where(button,a)[data-variant][data-size]:not([data-slot="toggle"]):not([data-slot="toggle-group-item"]):not([data-rui-close-icon]):not(:disabled):not([aria-disabled="true"])[data-variant="ghost"]:hover {
+  #|      --rui-button-bg:var(--rui-ghost-hover-bg,var(--rui-accent,oklch(0.97 0 0)));
+  #|      --rui-button-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    :where(button,a)[data-variant][data-size]:not(:disabled):not([aria-disabled="true"])[data-variant="link"]:hover {
+  #|      text-decoration-line:underline;
+  #|    }
+  #|    :where([data-slot="toggle"],[data-slot="toggle-group-item"]):not(:disabled):not([aria-disabled="true"])[data-state="off"][data-variant="default"]:hover {
+  #|      --rui-toggle-bg:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 65%,transparent);
+  #|      --rui-toggle-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    :where([data-slot="toggle"],[data-slot="toggle-group-item"]):not(:disabled):not([aria-disabled="true"])[data-state="off"][data-variant="outline"]:hover {
+  #|      --rui-toggle-bg:color-mix(in oklab,var(--rui-accent,oklch(0.97 0 0)) 65%,transparent);
+  #|      --rui-toggle-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    :where([role^="menuitem"],[data-slot="select-item"],[data-slot="combobox-item"],[data-slot="command-item"]):not([aria-disabled="true"]):hover {
+  #|      --rui-menu-item-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|      --rui-menu-item-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    :where([role^="menuitem"])[data-variant="destructive"]:not([aria-disabled="true"]):hover {
+  #|      --rui-menu-item-bg:var(--rui-destructive-subtle,oklch(0.577 0.245 27.325 / 0.1));
+  #|      --rui-menu-item-fg:var(--rui-destructive,oklch(0.577 0.245 27.325));
+  #|    }
+  #|    :where([data-slot="select-trigger"],[data-slot="combobox-trigger"],[data-slot="native-select"]):not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-control-bg:var(--rui-select-hover-bg,var(--rui-control-base-bg,transparent));
+  #|    }
+  #|    [data-slot="combobox-chip-remove"]:not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-chip-remove-opacity:1;
+  #|    }
+  #|    [data-slot="message-scroller-button"]:not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-button-bg:var(--rui-muted,oklch(0.97 0 0));
+  #|      --rui-button-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    :where([data-slot="navigation-menu-trigger"],[data-slot="navigation-menu-link"]):not(:disabled):hover {
+  #|      --rui-nav-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|      --rui-nav-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    [data-slot="navigation-menu-trigger"][data-state="open"]:not(:disabled):hover,
+  #|    [data-slot="navigation-menu-link"][data-active="true"]:not(:disabled):hover {
+  #|      --rui-nav-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|      --rui-nav-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    [data-slot="tabs-trigger"][data-state="inactive"]:not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-tabs-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    [data-slot="accordion-trigger"]:not([aria-disabled="true"]):hover {
+  #|      text-decoration-line:underline;
+  #|    }
+  #|    [data-slot="collapsible-trigger"]:not([aria-disabled="true"]):hover {
+  #|      --rui-accordion-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|      --rui-accordion-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|      text-decoration-line:none;
+  #|    }
+  #|    :where([data-slot="calendar-previous"],[data-slot="calendar-next"],[data-slot="calendar-day-button"]):not(:disabled):not([aria-disabled="true"]):not([data-selected-single="true"]):not([data-range-start]):not([data-range-end]):hover {
+  #|      --rui-calendar-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|      --rui-calendar-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    [data-slot="slider-thumb"]:has(+ [data-slot="slider-control"]:not(:disabled):hover) {
+  #|      --rui-slider-thumb-shadow:0 0 0 4px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-slider-thumb-base-shadow,0 1px 2px rgb(0 0 0 / 0.1));
+  #|    }
+  #|    :where([data-slot="sidebar-menu-button"],[data-slot="sidebar-menu-sub-button"]):not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-sidebar-item-bg:var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)));
+  #|      --rui-sidebar-item-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|    }
+  #|    [data-slot="sidebar-menu-button"][data-variant="outline"]:not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-sidebar-item-shadow:0 0 0 1px var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)));
+  #|    }
+  #|    [data-slot="sidebar-rail"]:hover {
+  #|      --rui-sidebar-rail-line-bg:var(--rui-sidebar-border,var(--rui-border,oklch(0.922 0 0)));
+  #|    }
+  #|    :where([data-slot="sidebar-group-action"],[data-slot="sidebar-menu-action"]):not(:disabled):not([aria-disabled="true"]):hover {
+  #|      --rui-sidebar-action-bg:var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)));
+  #|      --rui-sidebar-action-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|    }
+  #|    [data-slot="sidebar-menu-item"]:hover > [data-slot="sidebar-menu-action"][data-show-on-hover="true"]:not(:disabled):not([aria-disabled="true"]) {
+  #|      --rui-sidebar-action-opacity:1;
+  #|    }
+  #|    [data-slot="sidebar-menu-item"]:hover > [data-slot="sidebar-menu-action"][data-show-on-hover="true"]:where(:disabled,[aria-disabled="true"]) {
+  #|      --rui-sidebar-action-opacity:0.5;
+  #|    }
+  #|    [data-slot="sidebar-menu-item"]:hover > [data-slot="sidebar-menu-badge"] {
+  #|      --rui-sidebar-badge-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|    }
+  #|    [data-slot="sidebar-menu-item"]:hover > [data-slot="sidebar-menu-action"] {
+  #|      --rui-sidebar-action-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|    }
+  #|    [data-slot="attachment"]:has(> :where(a,button)[data-slot="attachment-trigger"]:not([aria-disabled="true"],:disabled):hover) {
+  #|      --rui-attachment-bg:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent);
+  #|    }
+  #|    a[data-slot="badge"]:not([aria-disabled="true"])[data-variant="default"]:hover {
+  #|      --rui-badge-bg:color-mix(in oklab,var(--rui-primary,oklch(0.205 0 0)) 90%,transparent);
+  #|    }
+  #|    a[data-slot="badge"]:not([aria-disabled="true"])[data-variant="secondary"]:hover {
+  #|      --rui-badge-bg:color-mix(in oklab,var(--rui-secondary,oklch(0.97 0 0)) 80%,transparent);
+  #|    }
+  #|    a[data-slot="badge"]:not([aria-disabled="true"])[data-variant="destructive"]:hover {
+  #|      --rui-badge-bg:color-mix(in oklab,var(--rui-destructive,oklch(0.577 0.245 27.325)) 90%,transparent);
+  #|    }
+  #|    a[data-slot="badge"]:not([aria-disabled="true"]):where([data-variant="outline"],[data-variant="ghost"]):hover {
+  #|      --rui-badge-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|      --rui-badge-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    }
+  #|    a[data-slot="badge"]:not([aria-disabled="true"])[data-variant="link"]:hover {
+  #|      text-decoration-line:underline;
+  #|    }
+  #|    [data-slot="bubble"][data-variant="default"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:color-mix(in oklch,var(--rui-primary,oklch(0.205 0 0)) 80%,transparent);
+  #|    }
+  #|    [data-slot="bubble"][data-variant="secondary"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:color-mix(in oklch,var(--rui-secondary,oklch(0.97 0 0)) 95%,var(--rui-foreground,oklch(0.145 0 0)) 5%);
+  #|    }
+  #|    [data-slot="bubble"][data-variant="muted"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:color-mix(in oklch,var(--rui-muted,oklch(0.97 0 0)) 95%,var(--rui-foreground,oklch(0.145 0 0)) 5%);
+  #|    }
+  #|    [data-slot="bubble"][data-variant="tinted"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:light-dark(oklch(from var(--rui-primary,oklch(0.205 0 0)) 0.88 calc(c * 0.5) h),oklch(from var(--rui-primary,oklch(0.922 0 0)) 0.35 calc(c * 0.5) h));
+  #|    }
+  #|    [data-slot="bubble"][data-variant="outline"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:light-dark(var(--rui-muted,oklch(0.97 0 0)),color-mix(in oklch,var(--rui-input,oklch(1 0 0 / 0.15)) 30%,transparent));
+  #|      --rui-bubble-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    [data-slot="bubble"][data-variant="ghost"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:light-dark(var(--rui-muted,oklch(0.97 0 0)),color-mix(in oklch,var(--rui-muted,oklch(0.269 0 0)) 50%,transparent));
+  #|      --rui-bubble-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    [data-slot="bubble"][data-variant="destructive"] > :is(a,button)[data-slot="bubble-content"]:not([aria-disabled="true"],:disabled):hover {
+  #|      --rui-bubble-bg:light-dark(color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 20%,transparent),color-mix(in oklch,var(--rui-destructive,oklch(0.704 0.191 22.216)) 30%,transparent));
+  #|    }
+  #|    [data-slot="table-row"]:not([data-state="selected"]):hover {
+  #|      --rui-table-row-bg:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent);
+  #|    }
+  #|    [data-slot="breadcrumb-link"]:hover {
+  #|      --rui-link-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    :where([data-slot="marker"],[data-slot="marker-content"]) a:hover {
+  #|      color:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    a[data-slot="marker"]:not([aria-disabled="true"]):hover {
+  #|      --rui-marker-fg:var(--rui-foreground,oklch(0.145 0 0));
+  #|    }
+  #|    :where([data-slot="field-description"],[data-slot="empty-description"],[data-slot="item-description"]) > a:hover {
+  #|      color:var(--rui-primary,oklch(0.205 0 0));
+  #|    }
+  #|    :where([data-slot="dialog-close"],[data-slot="sheet-close"],[data-slot="drawer-close"]):hover {
+  #|      --rui-close-opacity:1;
+  #|    }
+  #|  }
+  #|  @media (hover: none) {
+  #|    [data-slot="sidebar-menu-action"][data-show-on-hover="true"]:not(:disabled):not([aria-disabled="true"]) {
+  #|      --rui-sidebar-action-opacity:1;
+  #|    }
+  #|    [data-slot="sidebar-menu-action"][data-show-on-hover="true"]:where(:disabled,[aria-disabled="true"]) {
+  #|      --rui-sidebar-action-opacity:0.5;
+  #|    }
+  #|  }
+  #|
+  #|  :where(button,a)[data-variant][data-size]:not([data-slot="toggle"]):not([data-slot="toggle-group-item"]):not([data-slot="sidebar-rail"]):not(:disabled):not([aria-disabled="true"]):not([aria-haspopup]):active,
+  #|  [data-slot="date-picker-trigger"]:not(:disabled):not([aria-disabled="true"]):active,
+  #|  :where([data-slot="toggle"],[data-slot="toggle-group-item"]):not(:disabled):not([aria-disabled="true"]):active {
+  #|    transform:translateY(1px);
+  #|  }
+  #|  [data-slot="sidebar-menu-action"]:not(:disabled):not([aria-disabled="true"]):active {
+  #|    --rui-sidebar-action-press-offset:1px;
+  #|  }
+  #|  :is(a,button)[data-slot="bubble-content"]:not(:disabled):not([aria-disabled="true"]):active {
+  #|    transform:translateY(1px);
+  #|  }
+  #|
+  #|  [data-slot="slider-control"] {
+  #|    pointer-events:none;
+  #|  }
+  #|  [data-slot="slider-control"]::-webkit-slider-runnable-track {
+  #|    border:0;
+  #|    background:transparent;
+  #|  }
+  #|  [data-slot="slider-control"]::-webkit-slider-thumb {
+  #|    width:1rem;
+  #|    height:1rem;
+  #|    border:0;
+  #|    background:transparent;
+  #|    opacity:0;
+  #|    pointer-events:auto;
+  #|    -webkit-appearance:none;
+  #|  }
+  #|  [data-slot="slider-control"]::-moz-range-track {
+  #|    border:0;
+  #|    background:transparent;
+  #|  }
+  #|  [data-slot="slider-control"]::-moz-range-thumb {
+  #|    width:1rem;
+  #|    height:1rem;
+  #|    border:0;
+  #|    background:transparent;
+  #|    opacity:0;
+  #|    pointer-events:auto;
+  #|  }
+  #|  :where([data-slot="field-description"],[data-slot="empty-description"],[data-slot="item-description"]) > a {
+  #|    text-decoration-line:underline;
+  #|    text-underline-offset:4px;
+  #|  }
+  #|  [data-slot="calendar"]:dir(rtl) [data-slot="calendar-day"] {
+  #|    --rui-calendar-range-start-direction:to left;
+  #|    --rui-calendar-range-end-direction:to left;
+  #|  }
+  #|
+  #|  :where(button,a)[data-variant][data-size]:not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-button-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-button-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-button-base-shadow,0 0 #0000);
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="combobox-chip-remove"]:not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-chip-remove-opacity:1;
+  #|  }
+  #|  :where(button,a)[data-variant="destructive"][data-size]:not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-button-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2)),var(--rui-button-base-shadow,0 0 #0000);
+  #|  }
+  #|  :where([data-slot="dialog-close"],[data-slot="sheet-close"],[data-slot="drawer-close"])[data-rui-close-icon]:focus-visible {
+  #|    --rui-close-shadow:0 0 0 2px var(--rui-background,oklch(1 0 0)),0 0 0 4px var(--rui-ring,oklch(0.708 0 0));
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="input"],[data-slot="textarea"],[data-slot="native-select"],[data-slot="select-trigger"],[data-slot="combobox-trigger"],[data-slot="sidebar-input"],[data-slot="checkbox"],[data-slot="switch"],[data-slot="radio-group-item"],[data-slot="tabs-trigger"]):not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-control-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-control-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-control-base-shadow,0 0 #0000);
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="calendar-previous"],[data-slot="calendar-next"],[data-slot="calendar-day-button"]):not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-calendar-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-calendar-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-calendar-base-shadow,0 0 #0000);
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="slider-thumb"]:has(+ [data-slot="slider-control"]:not(:disabled):focus-visible) {
+  #|    --rui-slider-thumb-shadow:0 0 0 4px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-slider-thumb-base-shadow,0 1px 2px rgb(0 0 0 / 0.1));
+  #|  }
+  #|  [data-slot="slider-control"]:not(:disabled):focus-visible {
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="input-group"]:has([data-slot="input-group-control"]:focus-visible),
+  #|  :where([data-slot="combobox-control"],[data-slot="combobox-chips"]):focus-within {
+  #|    --rui-control-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-control-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-control-base-shadow,0 0 #0000);
+  #|  }
+  #|  [data-slot="combobox-chips"]:has([aria-invalid="true"]) {
+  #|    --rui-control-border:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));
+  #|    --rui-control-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2));
+  #|  }
+  #|  [data-slot="field-label"]:has(> [data-slot="field"]) {
+  #|    --rui-field-label-width:100%;
+  #|    --rui-field-label-direction:column;
+  #|    --rui-field-label-align:stretch;
+  #|    --rui-field-label-border-width:1px;
+  #|    --rui-field-label-border:var(--rui-border,oklch(0.922 0 0));
+  #|    --rui-field-label-radius:calc(var(--rui-radius,0.625rem) - 0.125rem);
+  #|  }
+  #|  [data-slot="field-label"] > [data-slot="field"] {
+  #|    padding:1rem;
+  #|  }
+  #|  [data-slot="field-label"]:has(:where([data-slot="checkbox"],[data-slot="radio-group-item"])[data-state="checked"]) {
+  #|    --rui-field-label-border:var(--rui-primary,oklch(0.205 0 0));
+  #|    --rui-field-label-bg:var(--rui-field-label-checked-bg,color-mix(in oklab,var(--rui-primary,oklch(0.205 0 0)) 5%,transparent));
+  #|  }
+  #|  :where([data-slot="toggle"],[data-slot="toggle-group-item"]):not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-toggle-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-toggle-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent),var(--rui-toggle-base-shadow,0 0 #0000);
+  #|    outline:none;
+  #|  }
+  #|  :where([role^="menuitem"],[data-slot="select-item"],[data-slot="combobox-item"],[data-slot="command-item"]):not([aria-disabled="true"]):where(:focus,[data-highlighted="true"],[data-selected="true"]) {
+  #|    --rui-menu-item-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|    --rui-menu-item-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    outline:none;
+  #|  }
+  #|  :where([role^="menuitem"])[data-variant="destructive"]:not([aria-disabled="true"]):where(:focus,[data-highlighted="true"]) {
+  #|    --rui-menu-item-bg:var(--rui-destructive-subtle,oklch(0.577 0.245 27.325 / 0.1));
+  #|    --rui-menu-item-fg:var(--rui-destructive,oklch(0.577 0.245 27.325));
+  #|  }
+  #|  :where([data-slot="dropdown-menu-sub-trigger"],[data-slot="context-menu-sub-trigger"],[data-slot="menubar-sub-trigger"],[data-slot="menubar-trigger"])[data-state="open"] {
+  #|    --rui-menu-item-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|    --rui-menu-item-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|  }
+  #|  :where([data-slot="toggle"],[data-slot="toggle-group-item"]):not(:disabled):not([aria-disabled="true"])[data-variant][data-state="on"] {
+  #|    --rui-toggle-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|    --rui-toggle-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|  }
+  #|  [data-slot="button-group"] > :where(button,a,[role="button"]):focus-visible {
+  #|    position:relative;
+  #|    z-index:10;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="horizontal"]:dir(ltr) > :not(:first-child) {
+  #|    --rui-control-border-left-width:0px;
+  #|    --rui-control-radius-top-left:0px;
+  #|    --rui-control-radius-bottom-left:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="horizontal"]:dir(ltr) > :not(:last-child) {
+  #|    --rui-control-radius-top-right:0px;
+  #|    --rui-control-radius-bottom-right:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="horizontal"]:dir(ltr) > :has(+ [data-slot="button-group-separator"][data-orientation="vertical"]) {
+  #|    --rui-control-border-right-width:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="horizontal"]:dir(rtl) > :not(:first-child) {
+  #|    --rui-control-border-right-width:0px;
+  #|    --rui-control-radius-top-right:0px;
+  #|    --rui-control-radius-bottom-right:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="horizontal"]:dir(rtl) > :not(:last-child) {
+  #|    --rui-control-radius-top-left:0px;
+  #|    --rui-control-radius-bottom-left:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="horizontal"]:dir(rtl) > :has(+ [data-slot="button-group-separator"][data-orientation="vertical"]) {
+  #|    --rui-control-border-left-width:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="vertical"] > :not(:first-child) {
+  #|    --rui-control-border-top-width:0px;
+  #|    --rui-control-radius-top-left:0px;
+  #|    --rui-control-radius-top-right:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="vertical"] > :not(:last-child) {
+  #|    --rui-control-radius-bottom-left:0px;
+  #|    --rui-control-radius-bottom-right:0px;
+  #|  }
+  #|  [data-slot="button-group"][data-orientation="vertical"] > :has(+ [data-slot="button-group-separator"][data-orientation="horizontal"]) {
+  #|    --rui-control-border-bottom-width:0px;
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"] > [data-slot="toggle-group-item"]:focus,
+  #|  [data-slot="toggle-group"][data-spacing="0"] > [data-slot="toggle-group-item"]:focus-visible {
+  #|    z-index:10;
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="horizontal"] > [data-slot="toggle-group-item"][data-variant="outline"]:not(:first-child) {
+  #|    --rui-toggle-border-inline-start-width:0px;
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="horizontal"]:dir(ltr) > [data-slot="toggle-group-item"]:first-child,
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="horizontal"]:dir(rtl) > [data-slot="toggle-group-item"]:last-child {
+  #|    --rui-toggle-radius:var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)) 0 0 var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem));
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="horizontal"]:dir(ltr) > [data-slot="toggle-group-item"]:last-child,
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="horizontal"]:dir(rtl) > [data-slot="toggle-group-item"]:first-child {
+  #|    --rui-toggle-radius:0 var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)) var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)) 0;
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="vertical"] > [data-slot="toggle-group-item"][data-variant="outline"]:not(:first-child) {
+  #|    --rui-toggle-border-block-start-width:0px;
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="vertical"] > [data-slot="toggle-group-item"]:first-child {
+  #|    --rui-toggle-radius:var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)) var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)) 0 0;
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"][data-orientation="vertical"] > [data-slot="toggle-group-item"]:last-child {
+  #|    --rui-toggle-radius:0 0 var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem)) var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem));
+  #|  }
+  #|  [data-slot="toggle-group"][data-spacing="0"] > [data-slot="toggle-group-item"]:only-child {
+  #|    --rui-toggle-radius:var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem));
+  #|  }
+  #|  [data-slot="alert"]:dir(rtl) > [data-slot="alert-action"] {
+  #|    --rui-alert-action-offset-inline:-0.25rem;
+  #|  }
+  #|  [data-slot="navigation-menu-trigger"][data-state="open"] {
+  #|    --rui-nav-bg:color-mix(in oklab,var(--rui-accent,oklch(0.97 0 0)) 50%,transparent);
+  #|    --rui-nav-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|  }
+  #|  :where([data-slot="navigation-menu-trigger"],[data-slot="navigation-menu-link"]):focus {
+  #|    --rui-nav-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|    --rui-nav-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="navigation-menu-trigger"],[data-slot="navigation-menu-link"]):focus-visible {
+  #|    --rui-nav-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="sidebar-menu-button"],[data-slot="sidebar-menu-sub-button"]):not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-sidebar-item-border:var(--rui-sidebar-ring,var(--rui-ring,oklch(0.708 0 0)));
+  #|    --rui-sidebar-item-shadow:0 0 0 2px color-mix(in oklab,var(--rui-sidebar-ring,var(--rui-ring,oklch(0.708 0 0))) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="sidebar-group-action"],[data-slot="sidebar-menu-action"]):not(:disabled):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-sidebar-action-shadow:0 0 0 2px color-mix(in oklab,var(--rui-sidebar-ring,var(--rui-ring,oklch(0.708 0 0))) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="accordion-trigger"],[data-slot="collapsible-trigger"]):not([aria-disabled="true"]):focus-visible {
+  #|    --rui-accordion-border:var(--rui-ring,oklch(0.708 0 0));
+  #|    --rui-accordion-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:none;
+  #|  }
+  #|  [data-slot="navigation-menu-link"][data-active="true"] {
+  #|    --rui-nav-bg:color-mix(in oklab,var(--rui-accent,oklch(0.97 0 0)) 50%,transparent);
+  #|    --rui-nav-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|  }
+  #|  [data-slot="navigation-menu-trigger"][data-state="open"]:not(:disabled):focus,
+  #|  [data-slot="navigation-menu-link"][data-active="true"]:not(:disabled):focus {
+  #|    --rui-nav-bg:var(--rui-accent,oklch(0.97 0 0));
+  #|    --rui-nav-fg:var(--rui-accent-foreground,oklch(0.205 0 0));
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="sidebar-menu-button"],[data-slot="sidebar-menu-sub-button"]):where(:active,[data-active="true"]) {
+  #|    --rui-sidebar-item-bg:var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)));
+  #|    --rui-sidebar-item-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|  }
+  #|  [data-slot="sidebar-menu-button"][data-variant="outline"]:where(:active,[data-active="true"]) {
+  #|    --rui-sidebar-item-shadow:0 0 0 1px var(--rui-sidebar-accent,var(--rui-accent,oklch(0.97 0 0)));
+  #|  }
+  #|  [data-slot="sidebar-menu-button"][data-active="true"] ~ [data-slot="sidebar-menu-badge"] {
+  #|    --rui-sidebar-badge-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|  }
+  #|  [data-slot="sidebar-menu-button"][data-active="true"] ~ [data-slot="sidebar-menu-action"] {
+  #|    --rui-sidebar-action-fg:var(--rui-sidebar-accent-foreground,var(--rui-accent-foreground,oklch(0.205 0 0)));
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:focus-within > [data-slot="sidebar-menu-action"][data-show-on-hover="true"]:not(:disabled):not([aria-disabled="true"]) {
+  #|    --rui-sidebar-action-opacity:1;
+  #|  }
+  #|  [data-slot="sidebar-menu-item"]:focus-within > [data-slot="sidebar-menu-action"][data-show-on-hover="true"]:where(:disabled,[aria-disabled="true"]) {
+  #|    --rui-sidebar-action-opacity:0.5;
+  #|  }
+  #|  [data-slot="sidebar-menu-action"][data-show-on-hover="true"][data-state="open"] {
+  #|    --rui-sidebar-action-opacity:1;
+  #|  }
+  #|  [data-slot="attachment"]:focus-within {
+  #|    --rui-attachment-shadow:0 0 0 1px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|  }
+  #|  [data-slot="table-row"]:has([aria-expanded="true"]) {
+  #|    --rui-table-row-bg:color-mix(in oklab,var(--rui-muted,oklch(0.97 0 0)) 50%,transparent);
+  #|  }
+  #|  [data-slot="resizable-handle"]:has([data-slot="resizable-control"]:focus-visible) {
+  #|    box-shadow:0 0 0 1px var(--rui-ring,oklch(0.708 0 0));
+  #|    outline:none;
+  #|  }
+  #|  :where([data-slot="scroll-area"]:not([data-managed]):focus-visible,[data-slot="scroll-area"][data-managed]:has(> [data-slot="scroll-area-viewport"]:focus-visible),[data-slot="message-scroller"]:has([data-slot="message-scroller-viewport"]:focus-visible)) {
+  #|    box-shadow:0 0 0 3px color-mix(in oklab,var(--rui-ring,oklch(0.708 0 0)) 50%,transparent);
+  #|    outline:1px solid var(--rui-ring,oklch(0.708 0 0));
+  #|  }
+  #|  :where([data-slot="scroll-area-viewport"],[data-slot="message-scroller-viewport"]):focus-visible {
+  #|    outline:none;
+  #|  }
+  #|  @media (prefers-reduced-motion:reduce) {
+  #|    [data-slot="spinner"] svg,
+  #|    [data-slot="skeleton"],
+  #|    [data-slot="attachment-title"],
+  #|    [data-slot="input-otp-caret"] > span {
+  #|      animation:none !important;
+  #|    }
+  #|    :where([data-slot="attachment"][data-state="uploading"],[data-slot="attachment"][data-state="processing"]) [data-slot="attachment-title"] {
+  #|      background-image:none !important;
+  #|      -webkit-text-fill-color:currentColor !important;
+  #|    }
+  #|    :where([data-slot="accordion-content"],[data-slot="collapsible-content"],[data-slot="carousel-track"],[data-slot="toast"],[data-slot="dialog-overlay"],[data-slot="dialog-content"],[data-slot="alert-dialog-overlay"],[data-slot="alert-dialog-content"],[data-slot="sheet-overlay"],[data-slot="sheet-content"],[data-slot="drawer-overlay"],[data-slot="drawer-content"],[data-slot="command-dialog-overlay"],[data-slot="command-dialog-content"],[data-slot="sidebar-mobile-layer"],[data-slot="sidebar-shell"],[data-slot="sidebar"],[data-slot="sidebar-overlay"],[data-slot="sidebar-group-label"],[data-slot="sidebar-inset"]) {
+  #|      animation:none !important;
+  #|      transition-duration:0.01ms !important;
+  #|      transition-delay:0s !important;
+  #|    }
+  #|    [data-slot="sidebar"][data-collapsible="offcanvas"][data-state="collapsed"] > :not([data-slot="sidebar-rail"]) {
+  #|      transition-delay:0s !important;
+  #|    }
+  #|  }
+  #|}
+  #|
+
+///|
+pub(all) enum ColorMode {
+  Light
+  Dark
+} derive(Debug, Eq)
+
+///|
+const ThemeBaseStyle : String = "background:var(--rui-background);color:var(--rui-foreground)"
+
+///|
+const ThemeLightStyle : String = "color-scheme:light;--rui-radius:0.625rem;--rui-background:oklch(1 0 0);--rui-foreground:oklch(0.145 0 0);--rui-card:oklch(1 0 0);--rui-card-foreground:oklch(0.145 0 0);--rui-popover:oklch(1 0 0);--rui-popover-foreground:oklch(0.145 0 0);--rui-primary:oklch(0.205 0 0);--rui-primary-foreground:oklch(0.985 0 0);--rui-secondary:oklch(0.97 0 0);--rui-secondary-foreground:oklch(0.205 0 0);--rui-muted:oklch(0.97 0 0);--rui-muted-foreground:oklch(0.556 0 0);--rui-accent:oklch(0.97 0 0);--rui-accent-foreground:oklch(0.205 0 0);--rui-destructive:oklch(0.577 0.245 27.325);--rui-destructive-border:oklch(0.577 0.245 27.325);--rui-destructive-subtle:oklch(0.577 0.245 27.325 / 0.1);--rui-destructive-surface:var(--rui-destructive);--rui-destructive-ring:oklch(0.577 0.245 27.325 / 0.2);--rui-border:oklch(0.922 0 0);--rui-input:oklch(0.922 0 0);--rui-input-background:transparent;--rui-outline-background:oklch(1 0 0);--rui-outline-border:oklch(0.922 0 0);--rui-outline-hover-bg:oklch(0.97 0 0);--rui-ghost-hover-bg:oklch(0.97 0 0);--rui-select-hover-bg:var(--rui-control-base-bg,transparent);--rui-tabs-active-bg:var(--rui-background);--rui-tabs-active-border:transparent;--rui-field-label-checked-bg:color-mix(in oklab,var(--rui-primary) 5%,transparent);--rui-ring:oklch(0.708 0 0);--rui-switch-unchecked:oklch(0.922 0 0);--rui-switch-thumb-checked:oklch(1 0 0);--rui-switch-thumb-unchecked:oklch(1 0 0);--rui-sidebar:oklch(0.985 0 0);--rui-sidebar-foreground:oklch(0.145 0 0);--rui-sidebar-primary:oklch(0.205 0 0);--rui-sidebar-primary-foreground:oklch(0.985 0 0);--rui-sidebar-accent:oklch(0.97 0 0);--rui-sidebar-accent-foreground:oklch(0.205 0 0);--rui-sidebar-border:oklch(0.922 0 0);--rui-sidebar-ring:oklch(0.708 0 0)"
+
+///|
+const ThemeDarkStyle : String = "color-scheme:dark;--rui-radius:0.625rem;--rui-background:oklch(0.145 0 0);--rui-foreground:oklch(0.985 0 0);--rui-card:oklch(0.205 0 0);--rui-card-foreground:oklch(0.985 0 0);--rui-popover:oklch(0.205 0 0);--rui-popover-foreground:oklch(0.985 0 0);--rui-primary:oklch(0.922 0 0);--rui-primary-foreground:oklch(0.205 0 0);--rui-secondary:oklch(0.269 0 0);--rui-secondary-foreground:oklch(0.985 0 0);--rui-muted:oklch(0.269 0 0);--rui-muted-foreground:oklch(0.708 0 0);--rui-accent:oklch(0.269 0 0);--rui-accent-foreground:oklch(0.985 0 0);--rui-destructive:oklch(0.704 0.191 22.216);--rui-destructive-border:oklch(0.704 0.191 22.216 / 0.5);--rui-destructive-subtle:oklch(0.704 0.191 22.216 / 0.2);--rui-destructive-surface:color-mix(in oklab,var(--rui-destructive) 60%,transparent);--rui-destructive-ring:oklch(0.704 0.191 22.216 / 0.4);--rui-border:oklch(1 0 0 / 0.1);--rui-input:oklch(1 0 0 / 0.15);--rui-input-background:oklch(1 0 0 / 0.045);--rui-outline-background:oklch(1 0 0 / 0.045);--rui-outline-border:oklch(1 0 0 / 0.15);--rui-outline-hover-bg:color-mix(in oklab,oklch(1 0 0 / 0.15) 50%,transparent);--rui-ghost-hover-bg:color-mix(in oklab,oklch(0.269 0 0) 50%,transparent);--rui-select-hover-bg:color-mix(in oklab,var(--rui-input) 50%,transparent);--rui-tabs-active-bg:var(--rui-outline-background);--rui-tabs-active-border:var(--rui-input);--rui-field-label-checked-bg:color-mix(in oklab,var(--rui-primary) 10%,transparent);--rui-ring:oklch(0.556 0 0);--rui-switch-unchecked:oklch(1 0 0 / 0.12);--rui-switch-thumb-checked:oklch(0.205 0 0);--rui-switch-thumb-unchecked:oklch(0.985 0 0);--rui-sidebar:oklch(0.205 0 0);--rui-sidebar-foreground:oklch(0.985 0 0);--rui-sidebar-primary:oklch(0.488 0.243 264.376);--rui-sidebar-primary-foreground:oklch(0.985 0 0);--rui-sidebar-accent:oklch(0.269 0 0);--rui-sidebar-accent-foreground:oklch(0.985 0 0);--rui-sidebar-border:oklch(1 0 0 / 0.1);--rui-sidebar-ring:oklch(0.439 0 0)"
+
+///|
+fn theme_mode_style(mode : ColorMode) -> String {
+  match mode {
+    Light => ThemeLightStyle
+    Dark => ThemeDarkStyle
+  }
+}
+
+///|
+fn ui_disabled_style(disabled : Bool) -> String {
+  if disabled {
+    UiDisabled
+  } else {
+    ""
+  }
+}
+
+///|
+fn ui_disabled_visual_style(disabled : Bool) -> String {
+  if disabled {
+    UiDisabledVisual
+  } else {
+    ""
+  }
+}
+
+///|
+fn ui_bool(value : Bool) -> String {
+  if value {
+    "true"
+  } else {
+    "false"
+  }
+}
+
+///|
+fn ui_attrs(attrs : @html.Attrs?) -> @html.Attrs {
+  if attrs is Some(attrs) {
+    attrs.copy()
+  } else {
+    @html.Attrs::build()
+  }
+}
+
+///|
+fn ui_styles(parts : Array[String], extra : Array[String]) -> Array[String] {
+  let styles : Array[String] = []
+  for part in parts {
+    if part != "" {
+      styles.push(part)
+    }
+  }
+  for part in extra {
+    if part != "" {
+      styles.push(part)
+    }
+  }
+  styles
+}
+
+///|
+#warnings("-alert_xss_vulnerable")
+fn ui_interaction_stylesheet() -> @html.Html {
+  // `UiInteractionCss` is a closed library constant. `inner_html` is required
+  // here so SSR does not escape CSS selectors; no caller input reaches it.
+  let attrs = @html.Attrs::build()
+    .data_set("rui-style", "interactions")
+    .inner_html(UiInteractionCss)
+  @html.style_tag(attrs~, ([] : Array[@html.Html]))
+}
+
+///|
+/// Provide the official shadcn Neutral tokens to a subtree.
+///
+/// The wrapper emits the library's static pseudo-class interaction sheet, so
+/// no external CSS import or runtime stylesheet registration is required.
+/// Every component still carries light-theme fallback values. Append custom
+/// CSS variables through `style` to override any token.
+pub fn[C : @html.IsChildren] theme(
+  mode? : ColorMode = Light,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = ui_attrs(attrs).data_set("rui-theme", "")
+  @html.fragment([
+    ui_interaction_stylesheet(),
+    @html.div(
+      style=ui_styles(
+        [
+          UiBoxSizing,
+          UiFontSans,
+          UiTextRendering,
+          theme_mode_style(mode),
+          ThemeBaseStyle,
+        ],
+        style,
+      ),
+      id?,
+      class?,
+      title?,
+      attrs=element_attrs,
+      children,
+    ),
+  ])
+}

--- a/rui/toast.mbt
+++ b/rui/toast.mbt
@@ -1,0 +1,1013 @@
+///|
+pub(all) enum ToastVariant {
+  ToastDefault
+  ToastDestructive
+  ToastSuccess
+} derive(Debug, Eq)
+
+///|
+priv struct ToastEntry {
+  id : Int
+  title : String
+  description : String?
+  variant : ToastVariant
+  closing : Bool
+  swipe_direction : Int
+} derive(Eq)
+
+///|
+priv struct ToastModel {
+  next_id : Int
+  entries : Array[ToastEntry]
+  pause_sources : Array[String]
+  expired : Array[Int]
+} derive(Eq)
+
+///|
+priv enum ToastMsg {
+  ShowToast(String, String?, ToastVariant, Int)
+  DismissToast(Int, Int)
+  AutoDismissToast(Int)
+  SetToastPaused(String, Bool)
+  RemoveToast(Int)
+  DismissAllToasts
+}
+
+///|
+const ToastExitDurationMs : Int = 150
+
+///|
+const ToastSurfaceStyle : String = "position:relative;display:grid;width:100%;grid-template-columns:1fr auto;align-items:start;gap:0.25rem 0.75rem;border:1px solid;border-radius:var(--rui-toast-radius,var(--rui-toast-base-radius,1rem));padding:0.875rem 1rem;box-shadow:var(--rui-toast-shadow,var(--rui-toast-base-shadow,0 4px 12px rgb(0 0 0 / 0.1)));touch-action:pan-y;transition:opacity 150ms ease,transform 150ms ease,box-shadow 200ms ease"
+
+///|
+const ToastCardShadowStyle : String = "--rui-toast-base-shadow:0 4px 12px rgb(0 0 0 / 0.1)"
+
+///|
+const ToastViewportStyle : String = "position:fixed;z-index:100;display:flex;flex-direction:column;overflow:visible;border:0;background:transparent;box-shadow:none;pointer-events:none"
+
+///|
+const ToasterViewportStyle : String = "width:min(26rem,calc(100vw - 2rem));max-height:calc(100dvh - 2rem);gap:0.5rem;--rui-toast-base-offset:1rem"
+
+///|
+const SonnerViewportStyle : String = "width:min(22.25rem,calc(100vw - 3rem));max-height:calc(100dvh - 3rem);gap:0.875rem;--rui-toast-base-offset:1.5rem"
+
+///|
+/// Opaque command scope owned by `toaster` or `sonner`.
+struct ToastScope {
+  emit : @cmd.Emit[ToastMsg]
+}
+
+///|
+pub fn ToastScope::show(
+  self : ToastScope,
+  title~ : String,
+  description? : String,
+  variant? : ToastVariant = ToastDefault,
+  duration_ms? : Int = 4000,
+) -> @cmd.Cmd {
+  (self.emit)(ShowToast(title, description, variant, duration_ms))
+}
+
+///|
+pub fn ToastScope::dismiss(self : ToastScope, id~ : Int) -> @cmd.Cmd {
+  (self.emit)(DismissToast(id, 0))
+}
+
+///|
+pub fn ToastScope::dismiss_all(self : ToastScope) -> @cmd.Cmd {
+  (self.emit)(DismissAllToasts)
+}
+
+///|
+fn toast_variant_value(variant : ToastVariant) -> String {
+  match variant {
+    ToastDefault => "default"
+    ToastDestructive => "destructive"
+    ToastSuccess => "success"
+  }
+}
+
+///|
+fn toast_variant_style(variant : ToastVariant, rich_colors : Bool) -> String {
+  match variant {
+    ToastDefault =>
+      "border-color:var(--rui-border,oklch(0.922 0 0));background:var(--rui-background,white);color:var(--rui-foreground,oklch(0.145 0 0))"
+    ToastDestructive =>
+      if rich_colors {
+        "border-color:color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 35%,transparent);background:color-mix(in oklch,var(--rui-destructive,oklch(0.577 0.245 27.325)) 12%,var(--rui-background,white));color:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+      } else {
+        "border-color:var(--rui-destructive-border,var(--rui-destructive,oklch(0.577 0.245 27.325)));background:var(--rui-background,white);color:var(--rui-destructive,oklch(0.577 0.245 27.325))"
+      }
+    ToastSuccess =>
+      if rich_colors {
+        "border-color:oklch(0.72 0.17 142 / 0.45);background:oklch(0.97 0.04 142);color:oklch(0.38 0.12 142)"
+      } else {
+        "border-color:var(--rui-border,oklch(0.922 0 0));background:var(--rui-background,white);color:var(--rui-foreground,oklch(0.145 0 0))"
+      }
+  }
+}
+
+///|
+pub fn[C : @html.IsChildren] toast(
+  variant? : ToastVariant = ToastDefault,
+  open? : Bool = true,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    hidden=!open,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs)
+      .role(if variant is ToastDestructive { "alert" } else { "status" })
+      .aria_live(
+        if variant is ToastDestructive {
+          "assertive"
+        } else {
+          "polite"
+        },
+      )
+      .aria_atomic("true")
+      .data_set("slot", "toast")
+      .data_set("state", if open { "open" } else { "closed" })
+      .data_set("variant", toast_variant_value(variant)),
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        ToastSurfaceStyle,
+        ToastCardShadowStyle,
+        if open {
+          "opacity:1;transform:translateY(0) scale(1)"
+        } else {
+          "opacity:0;transform:translateY(0.5rem) scale(0.98);pointer-events:none"
+        },
+        toast_variant_style(variant, false),
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] toast_title(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "toast-title"),
+    style=ui_styles(
+      ["font-size:0.875rem;line-height:1.25rem;font-weight:500"],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] toast_description(
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "toast-description"),
+    style=ui_styles(
+      [
+        "grid-column:1;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.8125rem;line-height:1.25rem",
+      ],
+      style,
+    ),
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] toast_action(
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  button(
+    variant=Outline,
+    size=Sm,
+    slot="toast-action",
+    on_click?,
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "toast-action"),
+    style~,
+    children,
+  )
+}
+
+///|
+pub fn toast_close(
+  scope~ : ToastScope,
+  toast_id~ : Int,
+  label? : String = "Close notification",
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  button(
+    variant=Ghost,
+    size=IconXs,
+    slot="toast-close",
+    on_click=scope.dismiss(id=toast_id),
+    id?,
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).aria_label(label).data_set("slot", "toast-close"),
+    style~,
+    ui_x_icon(),
+  )
+}
+
+///|
+fn toast_trimmed(
+  entries : Array[ToastEntry],
+  max_toasts : Int,
+) -> Array[ToastEntry] {
+  let limit = if max_toasts < 1 { 1 } else { max_toasts }
+  let start = if entries.length() > limit {
+    entries.length() - limit
+  } else {
+    0
+  }
+  let result : Array[ToastEntry] = []
+  for index, entry in entries {
+    if index >= start {
+      result.push(entry)
+    }
+  }
+  result
+}
+
+///|
+fn toast_remove(entries : Array[ToastEntry], id : Int) -> Array[ToastEntry] {
+  let result : Array[ToastEntry] = []
+  for entry in entries {
+    if entry.id != id {
+      result.push(entry)
+    }
+  }
+  result
+}
+
+///|
+fn toast_mark_closing(
+  entries : Array[ToastEntry],
+  id : Int,
+  swipe_direction : Int,
+) -> (Array[ToastEntry], Bool) {
+  let result : Array[ToastEntry] = []
+  let mut changed = false
+  for entry in entries {
+    if entry.id == id && !entry.closing {
+      result.push({ ..entry, closing: true, swipe_direction })
+      changed = true
+    } else {
+      result.push(entry)
+    }
+  }
+  (result, changed)
+}
+
+///|
+fn toast_mark_all_closing(
+  entries : Array[ToastEntry],
+) -> (Array[ToastEntry], Array[Int]) {
+  let result : Array[ToastEntry] = []
+  let ids : Array[Int] = []
+  for entry in entries {
+    if entry.closing {
+      result.push(entry)
+    } else {
+      result.push({ ..entry, closing: true, swipe_direction: 0 })
+      ids.push(entry.id)
+    }
+  }
+  (result, ids)
+}
+
+///|
+#cfg(target="js")
+priv struct ToastPointerState {
+  surface : @dom.Element
+  pointer_id : Int
+  start_x : Int
+  start_y : Int
+  start_time : Double
+  direction : Int
+  mut active : Bool
+  transition : String
+}
+
+///|
+#cfg(target="js")
+let toast_pointer_states : Array[ToastPointerState] = []
+
+///|
+#cfg(target="js")
+fn toast_pointer_state(surface : @dom.Element) -> ToastPointerState? {
+  for state in toast_pointer_states {
+    if state.surface.is_same_node(surface.as_node()) {
+      return Some(state)
+    }
+  }
+  None
+}
+
+///|
+#cfg(target="js")
+fn toast_remove_pointer_state(surface : @dom.Element) -> Unit {
+  for index, state in toast_pointer_states {
+    if state.surface.is_same_node(surface.as_node()) {
+      ignore(toast_pointer_states.remove(index))
+      return
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn toast_restore_pointer_state(state : ToastPointerState) -> Unit {
+  if state.surface.to_html_element() is Some(surface) {
+    let style = surface.get_style()
+    ignore(style.remove_property("--rui-toast-swipe-x"))
+    if state.transition == "" {
+      ignore(style.remove_property("transition"))
+    } else {
+      style.set_property("transition", state.transition)
+    }
+  }
+  state.surface.remove_attribute("data-swipe")
+  if state.surface.has_pointer_capture(state.pointer_id) {
+    state.surface.release_pointer_capture(state.pointer_id)
+  }
+  toast_remove_pointer_state(state.surface)
+}
+
+///|
+#cfg(target="js")
+fn toast_pointer_start(event : @dom.MouseEvent) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  if !pointer.get_is_primary() || pointer.get_button() != 0 {
+    return false
+  }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(surface) else { return false }
+  guard surface.to_html_element() is Some(surface_html) else { return false }
+  if toast_pointer_state(surface) is Some(_) {
+    return false
+  }
+  if pointer.target().to_element() is Some(target) &&
+    target.closest("button,a,input,textarea,select,[contenteditable=true]")
+    is Some(_) {
+    return false
+  }
+  let state : ToastPointerState = {
+    surface,
+    pointer_id: pointer.get_pointer_id(),
+    start_x: pointer.get_client_x(),
+    start_y: pointer.get_client_y(),
+    start_time: pointer.get_time_stamp(),
+    direction: if ui_element_is_rtl(surface) {
+      -1
+    } else {
+      1
+    },
+    active: false,
+    transition: surface_html.get_style().get_property_value("transition"),
+  }
+  toast_pointer_states.push(state)
+  surface.set_pointer_capture(state.pointer_id)
+  true
+}
+
+///|
+#cfg(target="js")
+fn toast_pointer_move(event : @dom.MouseEvent) -> Bool {
+  guard event.to_pointer_event() is Some(pointer) else { return false }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return false
+  }
+  guard current_target.to_element() is Some(surface) else { return false }
+  guard toast_pointer_state(surface) is Some(state) else { return false }
+  guard state.pointer_id == pointer.get_pointer_id() else { return false }
+  guard surface.to_html_element() is Some(surface_html) else { return false }
+  let delta_x = pointer.get_client_x() - state.start_x
+  let delta_y = pointer.get_client_y() - state.start_y
+  if !state.active {
+    if delta_x.abs() < 6 && delta_y.abs() < 6 {
+      return false
+    }
+    if delta_x.abs() <= delta_y.abs() {
+      toast_restore_pointer_state(state)
+      return false
+    }
+    state.active = true
+    surface.set_attribute("data-swipe", "move")
+  }
+  let progress = delta_x * state.direction
+  let visual = if progress < 0 {
+    delta_x.to_double() * 0.2
+  } else {
+    delta_x.to_double()
+  }
+  let style = surface_html.get_style()
+  style.set_property("transition", "none")
+  style.set_property("--rui-toast-swipe-x", "\{visual}px")
+  true
+}
+
+///|
+#cfg(target="js")
+fn toast_pointer_end(event : @dom.MouseEvent) -> Int {
+  guard event.to_pointer_event() is Some(pointer) else { return 0 }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return 0
+  }
+  guard current_target.to_element() is Some(surface) else { return 0 }
+  guard toast_pointer_state(surface) is Some(state) else { return 0 }
+  guard state.pointer_id == pointer.get_pointer_id() else { return 0 }
+  let delta_x = pointer.get_client_x() - state.start_x
+  let progress = delta_x * state.direction
+  let elapsed = (pointer.get_time_stamp() - state.start_time).max(1.0)
+  let threshold = (surface.get_client_width() * 0.35).max(48.0).min(160.0)
+  let dismiss = state.active &&
+    progress > 0 &&
+    (
+      progress.to_double() >= threshold ||
+      (progress >= 16 && progress.to_double() / elapsed >= 0.5)
+    )
+  let active = state.active
+  toast_restore_pointer_state(state)
+  if dismiss {
+    state.direction * 2
+  } else if active {
+    1
+  } else {
+    0
+  }
+}
+
+///|
+#cfg(target="js")
+fn toast_pointer_cancel(event : @dom.MouseEvent) -> Unit {
+  guard event.to_pointer_event() is Some(pointer) else { return }
+  guard pointer.current_target().to_option() is Some(current_target) else {
+    return
+  }
+  guard current_target.to_element() is Some(surface) else { return }
+  guard toast_pointer_state(surface) is Some(state) else { return }
+  guard state.pointer_id == pointer.get_pointer_id() else { return }
+  toast_restore_pointer_state(state)
+}
+
+///|
+#cfg(target="js")
+fn toast_bind_pointer_attrs(
+  attrs : @html.Attrs,
+  scope : ToastScope,
+  id : Int,
+) -> Unit {
+  ignore(
+    attrs
+    .on_pointerdown(event => {
+      ignore(toast_pointer_start(event))
+      @cmd.none
+    })
+    .on_pointermove(event => {
+      if toast_pointer_move(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    })
+    .on_pointerup(event => {
+      let result = toast_pointer_end(event)
+      if result != 0 {
+        event.prevent_default()
+      }
+      if result == 2 {
+        (scope.emit)(DismissToast(id, 1))
+      } else if result == -2 {
+        (scope.emit)(DismissToast(id, -1))
+      } else {
+        @cmd.none
+      }
+    })
+    .on_pointercancel(event => {
+      toast_pointer_cancel(event)
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn toast_bind_pointer_attrs(
+  attrs : @html.Attrs,
+  scope : ToastScope,
+  id : Int,
+) -> Unit {
+  ignore((attrs, scope, id))
+}
+
+///|
+fn toast_entry_view(
+  scope : ToastScope,
+  entry : ToastEntry,
+  rich_colors : Bool,
+) -> @html.Html {
+  let variant = entry.variant
+  let element_attrs = @html.Attrs::build()
+    .role(if variant is ToastDestructive { "alert" } else { "status" })
+    .aria_live(if variant is ToastDestructive { "assertive" } else { "polite" })
+    .aria_atomic("true")
+    .data_set("slot", "toast")
+    .data_set("toast-id", "\{entry.id}")
+    .data_set("state", if entry.closing { "closed" } else { "open" })
+    .data_set("variant", toast_variant_value(variant))
+    .data_set("swipe-direction", "inline-end")
+    .on_mouseenter(_ => (scope.emit)(SetToastPaused("hover-\{entry.id}", true)))
+    .on_mouseleave(_ => (scope.emit)(SetToastPaused("hover-\{entry.id}", false)))
+  toast_bind_pointer_attrs(element_attrs, scope, entry.id)
+  let close_attrs = @html.Attrs::build()
+    .on_focus(_ => (scope.emit)(SetToastPaused("focus-\{entry.id}", true)))
+    .on_blur(_ => (scope.emit)(SetToastPaused("focus-\{entry.id}", false)))
+  @html.div(
+    attrs=element_attrs,
+    style=[
+      UiBoxSizing,
+      UiFontSans,
+      ToastSurfaceStyle,
+      ToastCardShadowStyle,
+      if entry.closing {
+        if entry.swipe_direction < 0 {
+          "opacity:0;transform:translate3d(-110%,0,0) scale(0.98);pointer-events:none"
+        } else if entry.swipe_direction > 0 {
+          "opacity:0;transform:translate3d(110%,0,0) scale(0.98);pointer-events:none"
+        } else {
+          "opacity:0;transform:translate3d(0,0.5rem,0) scale(0.98);pointer-events:none"
+        }
+      } else {
+        "opacity:1;transform:translate3d(var(--rui-toast-swipe-x,0px),0,0) scale(1);pointer-events:auto"
+      },
+      toast_variant_style(variant, rich_colors),
+    ],
+    [
+      toast_title(entry.title),
+      toast_close(scope~, toast_id=entry.id, attrs=close_attrs),
+      if entry.description is Some(description) {
+        toast_description(description)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+fn render_toaster(
+  model : ToastModel,
+  scope : ToastScope,
+  slot : String,
+  rich_colors : Bool,
+  position : String,
+  class : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (ToastScope) -> @html.Html,
+) -> @html.Html {
+  let entries : Array[@html.Html] = []
+  for entry in model.entries {
+    entries.push(toast_entry_view(scope, entry, rich_colors))
+  }
+  @html.fragment([
+    children(scope),
+    @html.div(
+      class?,
+      attrs=ui_attrs(attrs)
+        .role("region")
+        .aria_label("Notifications")
+        .data_set("slot", slot)
+        .data_set("position", position),
+      style=ui_styles(
+        [
+          UiBoxSizing,
+          ToastViewportStyle,
+          if rich_colors {
+            SonnerViewportStyle
+          } else {
+            ToasterViewportStyle
+          },
+          if position == "top-left" {
+            "top:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))"
+          } else if position == "top-center" {
+            "top:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:50%;transform:translateX(-50%)"
+          } else if position == "top-right" {
+            "top:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));right:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))"
+          } else if position == "bottom-left" {
+            "bottom:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))"
+          } else if position == "bottom-center" {
+            "bottom:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:50%;transform:translateX(-50%)"
+          } else {
+            "right:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));bottom:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))"
+          },
+        ],
+        style,
+      ),
+      entries,
+    ),
+  ])
+}
+
+///|
+#cfg(target="js")
+let toast_document_pause_callbacks : Map[String, (Bool) -> Unit] = Map([])
+
+///|
+#cfg(target="js")
+let toast_document_pause_bound_to : Ref[@dom.Document?] = Ref(None)
+
+///|
+#cfg(target="js")
+fn toast_notify_document_pause(paused : Bool) -> Unit {
+  for _, changed in toast_document_pause_callbacks {
+    changed(paused)
+  }
+}
+
+///|
+#cfg(target="js")
+fn bind_toast_document_pause(slot : String, changed : (Bool) -> Unit) -> Unit {
+  toast_document_pause_callbacks[slot] = changed
+  let document = @dom.document()
+  let already_bound = if toast_document_pause_bound_to.val is Some(bound) {
+    bound.to_node().is_same_node(document.to_node())
+  } else {
+    false
+  }
+  if !already_bound {
+    toast_document_pause_bound_to.val = Some(document)
+    document.add_event_listener("visibilitychange", _ => {
+      toast_notify_document_pause(document.hidden())
+    })
+    let window = @dom.window()
+    window.add_event_listener("blur", _ => toast_notify_document_pause(true))
+    window.add_event_listener("focus", _ => {
+      if !document.hidden() {
+        toast_notify_document_pause(false)
+      }
+    })
+  }
+  changed(document.hidden())
+}
+
+///|
+#cfg(target="js")
+fn toast_bind_document_pause_cmd(
+  slot : String,
+  emit : @cmd.Emit[ToastMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    bind_toast_document_pause(slot, paused => {
+      scheduler.add(emit(SetToastPaused("document", paused)))
+    })
+  })
+}
+
+///|
+fn toast_remove_pause_source(
+  sources : Array[String],
+  source : String,
+) -> Array[String] {
+  let result : Array[String] = []
+  for value in sources {
+    if value != source {
+      result.push(value)
+    }
+  }
+  result
+}
+
+///|
+fn toast_remove_entry_pause_sources(
+  sources : Array[String],
+  id : Int,
+) -> Array[String] {
+  let result = toast_remove_pause_source(sources, "hover-\{id}")
+  toast_remove_pause_source(result, "focus-\{id}")
+}
+
+///|
+fn toast_contains_entry(entries : Array[ToastEntry], id : Int) -> Bool {
+  for entry in entries {
+    if entry.id == id {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn toast_filter_expired(
+  expired : Array[Int],
+  entries : Array[ToastEntry],
+) -> Array[Int] {
+  let result : Array[Int] = []
+  for id in expired {
+    if toast_contains_entry(entries, id) {
+      result.push(id)
+    }
+  }
+  result
+}
+
+///|
+fn toast_with_pause_sources(
+  model : ToastModel,
+  pause_sources : Array[String],
+) -> (ToastModel, Array[Int]) {
+  let resumed = model.pause_sources.length() > 0 && pause_sources.length() == 0
+  (
+    {
+      ..model,
+      pause_sources,
+      expired: if resumed {
+        []
+      } else {
+        model.expired
+      },
+    },
+    if resumed {
+      model.expired.copy()
+    } else {
+      []
+    },
+  )
+}
+
+///|
+fn toast_set_paused(
+  model : ToastModel,
+  source : String,
+  paused : Bool,
+) -> (ToastModel, Array[Int]) {
+  if paused {
+    if model.pause_sources.contains(source) {
+      (model, [])
+    } else {
+      let pause_sources = model.pause_sources.copy()
+      pause_sources.push(source)
+      toast_with_pause_sources(model, pause_sources)
+    }
+  } else if !model.pause_sources.contains(source) {
+    (model, [])
+  } else {
+    toast_with_pause_sources(
+      model,
+      toast_remove_pause_source(model.pause_sources, source),
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+fn toaster_impl(
+  slot : String,
+  rich_colors : Bool,
+  max_toasts : Int,
+  position : String,
+  class : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (ToastScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  let (model, emit) = @rabbita.create_state_with_init(
+    init=emit => {
+      (
+        { next_id: 1, entries: [], pause_sources: [], expired: [] },
+        toast_bind_document_pause_cmd(slot, emit),
+      )
+    },
+    update=fn(emit, msg, model) {
+      match msg {
+        ShowToast(title, description, variant, duration_ms) => {
+          let id = model.next_id
+          let entries = model.entries.copy()
+          entries.push({
+            id,
+            title,
+            description,
+            variant,
+            closing: false,
+            swipe_direction: 0,
+          })
+          let entries = toast_trimmed(entries, max_toasts)
+          let mut pause_sources = model.pause_sources
+          for previous in model.entries {
+            if !toast_contains_entry(entries, previous.id) {
+              pause_sources = toast_remove_entry_pause_sources(
+                pause_sources,
+                previous.id,
+              )
+            }
+          }
+          let filtered = {
+            ..model,
+            next_id: id + 1,
+            entries,
+            expired: toast_filter_expired(model.expired, entries),
+          }
+          let (next, resume_ids) = toast_with_pause_sources(
+            filtered, pause_sources,
+          )
+          let commands : Array[@cmd.Cmd] = []
+          if duration_ms > 0 {
+            commands.push(
+              @rabbita.delay(emit(AutoDismissToast(id)), duration_ms),
+            )
+          }
+          for expired_id in resume_ids {
+            commands.push(emit(DismissToast(expired_id, 0)))
+          }
+          (next, @cmd.batch(commands))
+        }
+        DismissToast(id, swipe_direction) => {
+          let (entries, changed) = toast_mark_closing(
+            model.entries,
+            id,
+            swipe_direction,
+          )
+          let (unpaused, resume_ids) = toast_with_pause_sources(
+            model,
+            toast_remove_entry_pause_sources(model.pause_sources, id),
+          )
+          let commands : Array[@cmd.Cmd] = []
+          if changed {
+            commands.push(
+              @rabbita.delay(emit(RemoveToast(id)), ToastExitDurationMs),
+            )
+          }
+          for expired_id in resume_ids {
+            commands.push(emit(DismissToast(expired_id, 0)))
+          }
+          ({ ..unpaused, entries, }, @cmd.batch(commands))
+        }
+        AutoDismissToast(id) =>
+          if !toast_contains_entry(model.entries, id) {
+            (model, @cmd.none)
+          } else if model.pause_sources.length() > 0 {
+            let expired = model.expired.copy()
+            if !expired.contains(id) {
+              expired.push(id)
+            }
+            ({ ..model, expired, }, @cmd.none)
+          } else {
+            let (entries, changed) = toast_mark_closing(model.entries, id, 0)
+            (
+              { ..model, entries, },
+              if changed {
+                @rabbita.delay(emit(RemoveToast(id)), ToastExitDurationMs)
+              } else {
+                @cmd.none
+              },
+            )
+          }
+        SetToastPaused(source, paused) => {
+          let (next, resume_ids) = toast_set_paused(model, source, paused)
+          let commands : Array[@cmd.Cmd] = []
+          for expired_id in resume_ids {
+            commands.push(emit(DismissToast(expired_id, 0)))
+          }
+          (next, @cmd.batch(commands))
+        }
+        RemoveToast(id) => {
+          let entries = toast_remove(model.entries, id)
+          let cleaned = {
+            ..model,
+            entries,
+            expired: toast_filter_expired(model.expired, entries),
+          }
+          let (next, resume_ids) = toast_with_pause_sources(
+            cleaned,
+            toast_remove_entry_pause_sources(cleaned.pause_sources, id),
+          )
+          let commands : Array[@cmd.Cmd] = []
+          for expired_id in resume_ids {
+            commands.push(emit(DismissToast(expired_id, 0)))
+          }
+          (next, @cmd.batch(commands))
+        }
+        DismissAllToasts => {
+          let (entries, ids) = toast_mark_all_closing(model.entries)
+          let mut pause_sources = model.pause_sources
+          for entry in model.entries {
+            pause_sources = toast_remove_entry_pause_sources(
+              pause_sources,
+              entry.id,
+            )
+          }
+          let commands : Array[@cmd.Cmd] = []
+          for id in ids {
+            commands.push(
+              @rabbita.delay(emit(RemoveToast(id)), ToastExitDurationMs),
+            )
+          }
+          (
+            { ..model, entries, pause_sources, expired: [] },
+            @cmd.batch(commands),
+          )
+        }
+      }
+    },
+  )
+  model.view(model => {
+    render_toaster(
+      model,
+      { emit, },
+      slot,
+      rich_colors,
+      position,
+      class,
+      attrs,
+      style,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+fn toaster_impl(
+  slot : String,
+  rich_colors : Bool,
+  max_toasts : Int,
+  position : String,
+  class : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (ToastScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  ignore(max_toasts)
+  let scope = { emit: @cmd.Emit(_ => @cmd.none) }
+  @rabbita.Val::constant(
+    render_toaster(
+      { next_id: 1, entries: [], pause_sources: [], expired: [] },
+      scope,
+      slot,
+      rich_colors,
+      position,
+      class,
+      attrs,
+      style,
+      children,
+    ),
+  )
+}
+
+///|
+pub fn toaster(
+  max_toasts? : Int = 3,
+  position? : String = "bottom-right",
+  class? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ToastScope) -> @html.Html,
+) -> @rabbita.Val[@html.Html] {
+  toaster_impl(
+    "toaster", false, max_toasts, position, class, attrs, style, children,
+  )
+}

--- a/rui/toast_pointer_wbtest.mbt
+++ b/rui/toast_pointer_wbtest.mbt
@@ -1,0 +1,185 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_toast_pointer_fixture(rtl : Bool) -> Unit =
+  #| rtl => {
+  #|   const own = key => Object.prototype.hasOwnProperty.call(globalThis, key)
+  #|   const saved = {
+  #|     window: globalThis.window,
+  #|     hadWindow: own("window"),
+  #|     EventTarget: globalThis.EventTarget,
+  #|     hadEventTarget: own("EventTarget"),
+  #|     Node: globalThis.Node,
+  #|     hadNode: own("Node"),
+  #|     HTMLElement: globalThis.HTMLElement,
+  #|     hadHTMLElement: own("HTMLElement"),
+  #|     PointerEvent: globalThis.PointerEvent,
+  #|     hadPointerEvent: own("PointerEvent"),
+  #|   }
+  #|   class EventTarget {}
+  #|   class Node extends EventTarget {
+  #|     constructor() { super(); this.nodeType = 1 }
+  #|   }
+  #|   class HTMLElement extends Node {}
+  #|   class PointerEvent {
+  #|     constructor(init) { Object.assign(this, init) }
+  #|   }
+  #|   Object.assign(globalThis, { EventTarget, Node, HTMLElement, PointerEvent })
+  #|   const props = {
+  #|     transition: "opacity 150ms ease,transform 150ms ease",
+  #|   }
+  #|   const style = {
+  #|     getPropertyValue: key => props[key] || "",
+  #|     setProperty: (key, value) => { props[key] = value },
+  #|     removeProperty: key => {
+  #|       const value = props[key] || ""
+  #|       delete props[key]
+  #|       return value
+  #|     },
+  #|   }
+  #|   const plain = new HTMLElement()
+  #|   plain.closest = () => null
+  #|   const interactive = new HTMLElement()
+  #|   interactive.closest = selector => selector.includes("button") ? interactive : null
+  #|   const surface = new HTMLElement()
+  #|   Object.assign(surface, {
+  #|     clientWidth: 300,
+  #|     style,
+  #|     dataset: {},
+  #|     __direction: rtl ? "rtl" : "ltr",
+  #|     captures: 0,
+  #|     releases: 0,
+  #|     setAttribute(name, value) {
+  #|       if (name === "data-swipe") this.dataset.swipe = value
+  #|     },
+  #|     removeAttribute(name) {
+  #|       if (name === "data-swipe") delete this.dataset.swipe
+  #|     },
+  #|     setPointerCapture(pointerId) {
+  #|       this.__capturedPointerId = pointerId
+  #|       this.captures += 1
+  #|     },
+  #|     releasePointerCapture(pointerId) {
+  #|       if (this.__capturedPointerId !== pointerId) return
+  #|       delete this.__capturedPointerId
+  #|       this.releases += 1
+  #|     },
+  #|     hasPointerCapture(pointerId) { return this.__capturedPointerId === pointerId },
+  #|   })
+  #|   globalThis.window = {
+  #|     getComputedStyle: element => ({
+  #|       getPropertyValue: name => name === "direction"
+  #|         ? element.__direction || "ltr"
+  #|         : "",
+  #|     }),
+  #|   }
+  #|   globalThis.__ruiToastPointerFixture = {
+  #|     ...saved,
+  #|     props,
+  #|     plain,
+  #|     interactive,
+  #|     surface,
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_toast_pointer_fixture_event(
+  x : Int,
+  y : Int,
+  time : Int,
+  interactive : Bool,
+) -> @dom.MouseEvent =
+  #| (x, y, time, interactive) => {
+  #|   const fixture = globalThis.__ruiToastPointerFixture
+  #|   return new PointerEvent({
+  #|     currentTarget: fixture.surface,
+  #|     target: interactive ? fixture.interactive : fixture.plain,
+  #|     pointerId: 5,
+  #|     pointerType: "touch",
+  #|     isPrimary: true,
+  #|     button: 0,
+  #|     clientX: x,
+  #|     clientY: y,
+  #|     timeStamp: time,
+  #|     defaultPrevented: false,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_toast_fixture_value(key : String) -> String =
+  #| key => globalThis.__ruiToastPointerFixture?.props?.[key] || ""
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_toast_fixture_swiping() -> Bool =
+  #| () => globalThis.__ruiToastPointerFixture?.surface?.dataset?.swipe === "move"
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_toast_fixture_releases() -> Int =
+  #| () => globalThis.__ruiToastPointerFixture?.surface?.releases ?? 0
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_toast_pointer_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiToastPointerFixture
+  #|   if (fixture.hadWindow) globalThis.window = fixture.window
+  #|   else delete globalThis.window
+  #|   if (fixture.hadEventTarget) globalThis.EventTarget = fixture.EventTarget
+  #|   else delete globalThis.EventTarget
+  #|   if (fixture.hadNode) globalThis.Node = fixture.Node
+  #|   else delete globalThis.Node
+  #|   if (fixture.hadHTMLElement) globalThis.HTMLElement = fixture.HTMLElement
+  #|   else delete globalThis.HTMLElement
+  #|   if (fixture.hadPointerEvent) globalThis.PointerEvent = fixture.PointerEvent
+  #|   else delete globalThis.PointerEvent
+  #|   delete globalThis.__ruiToastPointerFixture
+  #| }
+
+///|
+#cfg(target="js")
+test "toast swipe dismisses toward logical inline end in LTR and RTL" {
+  ffi_install_toast_pointer_fixture(false)
+  let start = ffi_toast_pointer_fixture_event(20, 20, 0, false)
+  let drag_move = ffi_toast_pointer_fixture_event(145, 22, 200, false)
+  let finish = ffi_toast_pointer_fixture_event(145, 22, 350, false)
+  assert_true(toast_pointer_start(start))
+  assert_true(toast_pointer_move(drag_move))
+  assert_true(ffi_toast_fixture_swiping())
+  assert_eq(ffi_toast_fixture_value("--rui-toast-swipe-x"), "125px")
+  assert_eq(toast_pointer_end(finish), 2)
+  assert_eq(ffi_toast_fixture_value("--rui-toast-swipe-x"), "")
+  assert_eq(
+    ffi_toast_fixture_value("transition"),
+    "opacity 150ms ease,transform 150ms ease",
+  )
+  assert_eq(ffi_toast_fixture_releases(), 1)
+  ffi_restore_toast_pointer_fixture()
+
+  ffi_install_toast_pointer_fixture(true)
+  let rtl_start = ffi_toast_pointer_fixture_event(260, 20, 0, false)
+  let rtl_drag = ffi_toast_pointer_fixture_event(130, 20, 200, false)
+  let rtl_finish = ffi_toast_pointer_fixture_event(130, 20, 350, false)
+  assert_true(toast_pointer_start(rtl_start))
+  assert_true(toast_pointer_move(rtl_drag))
+  assert_eq(ffi_toast_fixture_value("--rui-toast-swipe-x"), "-130px")
+  assert_eq(toast_pointer_end(rtl_finish), -2)
+  ffi_restore_toast_pointer_fixture()
+}
+
+///|
+#cfg(target="js")
+test "toast swipe preserves vertical scrolling and interactive controls" {
+  ffi_install_toast_pointer_fixture(false)
+  let interactive = ffi_toast_pointer_fixture_event(20, 20, 0, true)
+  assert_true(!toast_pointer_start(interactive))
+  let start = ffi_toast_pointer_fixture_event(20, 20, 0, false)
+  let vertical = ffi_toast_pointer_fixture_event(24, 90, 100, false)
+  assert_true(toast_pointer_start(start))
+  assert_true(!toast_pointer_move(vertical))
+  assert_true(!ffi_toast_fixture_swiping())
+  assert_eq(ffi_toast_fixture_releases(), 1)
+  ffi_restore_toast_pointer_fixture()
+}

--- a/rui/toast_test.mbt
+++ b/rui/toast_test.mbt
@@ -1,0 +1,87 @@
+///|
+test "toast exposes motion states and SVG close control" {
+  let open = render(@rui.toast(@rui.toast_title("Saved")))
+  assert_contains(open, "data-slot=\"toast\"")
+  assert_contains(open, "data-state=\"open\"")
+  assert_contains(open, "transition:opacity 150ms ease,transform 150ms ease")
+  assert_contains(open, "--rui-toast-base-shadow:0 4px 12px rgb(0 0 0 / 0.1)")
+  assert_contains(
+    open, "box-shadow:var(--rui-toast-shadow,var(--rui-toast-base-shadow,0 4px 12px rgb(0 0 0 / 0.1)))",
+  )
+  assert_contains(
+    open, "border-radius:var(--rui-toast-radius,var(--rui-toast-base-radius,1rem))",
+  )
+  assert_not_contains(open, "0 10px 30px rgb(0 0 0 / 0.14)")
+  assert_contains(open, "opacity:1;transform:translateY(0) scale(1)")
+  let closed = render(@rui.toast(open=false, "Hidden"))
+  assert_contains(closed, "data-state=\"closed\"")
+  assert_contains(closed, "hidden")
+  assert_contains(closed, "opacity:0")
+  let toaster = render_incremental(() => {
+    @rui.toaster(scope => @rui.toast_close(scope~, toast_id=7))
+  })
+  assert_contains(toaster, "data-slot=\"toast-close\"")
+  assert_contains(toaster, "aria-label=\"Close notification\"")
+  assert_contains(
+    toaster, "width:min(26rem,calc(100vw - 2rem));max-height:calc(100dvh - 2rem)",
+  )
+  assert_contains(toaster, "overflow:visible")
+  assert_contains(
+    toaster, "border:0;background:transparent;box-shadow:none;pointer-events:none",
+  )
+  assert_not_contains(toaster, "overflow-y:auto")
+  assert_contains(toaster, "<svg")
+  assert_not_contains(toaster, ">×<")
+}
+
+///|
+test "sonner rich colors remain readable in light and dark schemes" {
+  let html = render_incremental(() => @rui.sonner(_ => @html.nothing))
+  assert_contains(html, "data-slot=\"sonner\"")
+  assert_contains(html, "data-rui-style=\"sonner-rich-colors\"")
+  assert_contains(html, "--rui-sonner-success-background")
+  assert_contains(html, "light-dark(")
+  assert_contains(html, "--rui-sonner-error-background")
+  assert_contains(html, "var(--rui-background")
+  assert_contains(
+    html, "width:min(22.25rem,calc(100vw - 3rem));max-height:calc(100dvh - 3rem);gap:0.875rem",
+  )
+  assert_contains(html, "--rui-toast-base-offset:1.5rem")
+  assert_contains(html, "overflow:visible")
+  assert_not_contains(html, "overflow-y:auto")
+}
+
+///|
+test "toast hosts preserve a shadow-safe offset in every position" {
+  let cases : Array[(String, String)] = [
+    (
+      "top-left", "top:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))",
+    ),
+    (
+      "top-center", "top:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:50%;transform:translateX(-50%)",
+    ),
+    (
+      "top-right", "top:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));right:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))",
+    ),
+    (
+      "bottom-left", "bottom:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))",
+    ),
+    (
+      "bottom-center", "bottom:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));left:50%;transform:translateX(-50%)",
+    ),
+    (
+      "bottom-right", "right:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem));bottom:var(--rui-toast-offset,var(--rui-toast-base-offset,1rem))",
+    ),
+  ]
+  for item in cases {
+    let position = item.0
+    let expected_style = item.1
+    let html = render_incremental(() => {
+      @rui.sonner(position~, _ => @html.nothing)
+    })
+    assert_contains(html, "data-position=\"\{position}\"")
+    assert_contains(html, expected_style)
+    assert_contains(html, "box-shadow:none")
+    assert_contains(html, "overflow:visible")
+  }
+}

--- a/rui/toast_wbtest.mbt
+++ b/rui/toast_wbtest.mbt
@@ -1,0 +1,113 @@
+///|
+test "toast and Sonner share the single overridable Vega shadow" {
+  assert_eq(
+    ToastCardShadowStyle,
+    "--rui-toast-base-shadow:0 4px 12px rgb(0 0 0 / 0.1)",
+  )
+  assert_true(
+    ToastSurfaceStyle.contains(
+      "box-shadow:var(--rui-toast-shadow,var(--rui-toast-base-shadow,",
+    ),
+  )
+  assert_true(ToastViewportStyle.contains("box-shadow:none"))
+  assert_true(ToastViewportStyle.contains("overflow:visible"))
+}
+
+///|
+test "toast dismissal retains one closing entry until removal" {
+  let entries : Array[ToastEntry] = [
+    {
+      id: 1,
+      title: "One",
+      description: None,
+      variant: ToastDefault,
+      closing: false,
+      swipe_direction: 0,
+    },
+    {
+      id: 2,
+      title: "Two",
+      description: Some("Details"),
+      variant: ToastSuccess,
+      closing: false,
+      swipe_direction: 0,
+    },
+  ]
+  let (closing, changed) = toast_mark_closing(entries, 1, 1)
+  assert_true(changed)
+  assert_true(closing[0].closing)
+  assert_true(!closing[1].closing)
+  assert_eq(closing[0].swipe_direction, 1)
+  let (same, changed_again) = toast_mark_closing(closing, 1, -1)
+  assert_true(!changed_again)
+  assert_eq(same.length(), 2)
+  assert_eq(same[0].id, 1)
+  assert_true(same[0].closing)
+  assert_eq(same[1].id, 2)
+  assert_true(!same[1].closing)
+  let remaining = toast_remove(closing, 1)
+  assert_eq(remaining.length(), 1)
+  assert_eq(remaining[0].id, 2)
+  assert_eq(remaining[0].title, "Two")
+}
+
+///|
+test "dismiss all schedules only entries not already closing" {
+  let entries : Array[ToastEntry] = [
+    {
+      id: 1,
+      title: "Closing",
+      description: None,
+      variant: ToastDefault,
+      closing: true,
+      swipe_direction: 0,
+    },
+    {
+      id: 2,
+      title: "Open",
+      description: None,
+      variant: ToastDestructive,
+      closing: false,
+      swipe_direction: 0,
+    },
+  ]
+  let (closing, ids) = toast_mark_all_closing(entries)
+  assert_true(closing[0].closing)
+  assert_true(closing[1].closing)
+  assert_eq(ids, [2])
+}
+
+///|
+test "toast timers resume only after every overlapping pause source leaves" {
+  let initial : ToastModel = {
+    next_id: 3,
+    entries: [],
+    pause_sources: [],
+    expired: [1, 2],
+  }
+  let (hovered, hover_resume) = toast_set_paused(initial, "hover-1", true)
+  assert_eq(hovered.pause_sources, ["hover-1"])
+  assert_eq(hover_resume, [])
+  let (focused, focus_resume) = toast_set_paused(hovered, "focus-1", true)
+  assert_eq(focused.pause_sources, ["hover-1", "focus-1"])
+  assert_eq(focus_resume, [])
+  let (still_paused, partial_resume) = toast_set_paused(
+    focused, "hover-1", false,
+  )
+  assert_eq(still_paused.pause_sources, ["focus-1"])
+  assert_eq(still_paused.expired, [1, 2])
+  assert_eq(partial_resume, [])
+  let (resumed, resume_ids) = toast_set_paused(still_paused, "focus-1", false)
+  assert_eq(resumed.pause_sources, [])
+  assert_eq(resumed.expired, [])
+  assert_eq(resume_ids, [1, 2])
+}
+
+///|
+test "removing a toast clears only that entry's hover and focus sources" {
+  let remaining = toast_remove_entry_pause_sources(
+    ["document", "hover-1", "focus-1", "hover-2"],
+    1,
+  )
+  assert_eq(remaining, ["document", "hover-2"])
+}

--- a/rui/toggle.mbt
+++ b/rui/toggle.mbt
@@ -1,0 +1,241 @@
+///|
+pub(all) enum ToggleVariant {
+  Default
+  Outline
+} derive(Debug, Eq)
+
+///|
+pub(all) enum ToggleSize {
+  Default
+  Sm
+  Lg
+} derive(Debug, Eq)
+
+///|
+const ToggleBaseStyle : String = "display:inline-flex;flex-shrink:0;align-items:center;justify-content:center;gap:0.5rem;--rui-toggle-base-bg:transparent;--rui-toggle-base-fg:currentColor;--rui-toggle-base-border:transparent;--rui-toggle-base-shadow:none;--rui-toggle-base-radius:var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem));--rui-toggle-padding-inline:0.5rem;--rui-toggle-icon-size:1rem;border:var(--rui-control-border-width,1px) solid transparent;border-block-start-width:var(--rui-toggle-border-block-start-width,var(--rui-control-border-width,1px));border-inline-start-width:var(--rui-toggle-border-inline-start-width,var(--rui-control-border-width,1px));border-color:var(--rui-toggle-border,var(--rui-toggle-base-border,transparent));border-radius:var(--rui-toggle-radius,var(--rui-toggle-base-radius,var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem))));margin:0;padding-block:0;padding-inline:var(--rui-toggle-padding-inline);background:var(--rui-toggle-bg,var(--rui-toggle-base-bg,transparent));background-clip:padding-box;color:var(--rui-toggle-fg,var(--rui-toggle-base-fg,currentColor));box-shadow:var(--rui-toggle-shadow,var(--rui-toggle-base-shadow,none));font-size:0.875rem;line-height:1.25rem;font-weight:500;white-space:nowrap;cursor:pointer;user-select:none;appearance:none;-webkit-appearance:none;outline:none;vertical-align:middle"
+
+///|
+const ToggleDefaultStyle : String = "--rui-toggle-base-bg:transparent;--rui-toggle-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-toggle-base-border:transparent;--rui-toggle-base-shadow:none"
+
+///|
+const ToggleOutlineStyle : String = "--rui-toggle-base-bg:transparent;--rui-toggle-base-fg:var(--rui-foreground,oklch(0.145 0 0));--rui-toggle-base-border:var(--rui-outline-border,var(--rui-input,oklch(0.922 0 0)));--rui-toggle-base-shadow:0 1px 2px rgb(0 0 0 / 0.05)"
+
+///|
+const TogglePressedStyle : String = "--rui-toggle-base-bg:var(--rui-accent,oklch(0.97 0 0));--rui-toggle-base-fg:var(--rui-accent-foreground,oklch(0.205 0 0))"
+
+///|
+const ToggleInvalidStyle : String = "border-color:var(--rui-destructive,oklch(0.577 0.245 27.325));box-shadow:0 0 0 3px var(--rui-destructive-ring,oklch(0.577 0.245 27.325 / 0.2))"
+
+///|
+const ToggleSizeDefaultStyle : String = "min-width:2.25rem;height:2.25rem;--rui-toggle-padding-inline:0.5rem"
+
+///|
+const ToggleSizeSmStyle : String = "min-width:2rem;height:2rem;--rui-toggle-padding-inline:0.375rem"
+
+///|
+const ToggleSizeLgStyle : String = "min-width:2.5rem;height:2.5rem;--rui-toggle-padding-inline:0.625rem"
+
+///|
+fn toggle_variant_style(variant : ToggleVariant) -> String {
+  match variant {
+    Default => ToggleDefaultStyle
+    Outline => ToggleOutlineStyle
+  }
+}
+
+///|
+fn toggle_variant_value(variant : ToggleVariant) -> String {
+  match variant {
+    Default => "default"
+    Outline => "outline"
+  }
+}
+
+///|
+fn toggle_size_style(size : ToggleSize) -> String {
+  match size {
+    Default => ToggleSizeDefaultStyle
+    Sm => ToggleSizeSmStyle
+    Lg => ToggleSizeLgStyle
+  }
+}
+
+///|
+fn toggle_size_value(size : ToggleSize) -> String {
+  match size {
+    Default => "default"
+    Sm => "sm"
+    Lg => "lg"
+  }
+}
+
+///|
+fn toggle_pressed_style(pressed : Bool) -> String {
+  if pressed {
+    TogglePressedStyle
+  } else {
+    ""
+  }
+}
+
+///|
+fn toggle_invalid_style(invalid : Bool) -> String {
+  if invalid {
+    ToggleInvalidStyle
+  } else {
+    ""
+  }
+}
+
+///|
+/// Render one toggle state for the incremental wrapper and Toggle Group.
+///
+/// User styles are appended last and therefore override the built-in recipe.
+fn[C : @html.IsChildren] render_toggle(
+  pressed? : Bool = false,
+  variant? : ToggleVariant = Default,
+  size? : ToggleSize = Default,
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_pressed_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "toggle",
+  children : C,
+) -> @html.Html {
+  let control_attrs = ui_attrs(attrs)
+    .data_set("slot", slot)
+    .data_set("variant", toggle_variant_value(variant))
+    .data_set("size", toggle_size_value(size))
+  ignore(control_attrs.aria_pressed(ui_bool(pressed)))
+  ignore(control_attrs.aria_disabled(ui_bool(disabled)))
+  ignore(control_attrs.data_set("state", if pressed { "on" } else { "off" }))
+  if pressed {
+    ignore(control_attrs.data_set("pressed", ""))
+  }
+  if disabled {
+    ignore(control_attrs.data_set("disabled", ""))
+  }
+  if invalid {
+    ignore(control_attrs.aria_invalid("true").data_set("invalid", ""))
+  }
+  if aria_label is Some(label) {
+    ignore(control_attrs.aria_label(label))
+  }
+  if !disabled && on_pressed_change is Some(emit) {
+    ignore(control_attrs.on_click(_ => emit(!pressed)))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ToggleBaseStyle,
+        toggle_variant_style(variant),
+        toggle_pressed_style(pressed),
+        toggle_size_style(size),
+        toggle_invalid_style(invalid),
+        ui_disabled_style(disabled),
+      ],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=control_attrs,
+    children,
+  )
+}
+
+///|
+/// Build a black-box toggle with component-local incremental state.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] toggle(
+  default_pressed? : Bool = false,
+  variant? : ToggleVariant = Default,
+  size? : ToggleSize = Default,
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_pressed_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "toggle",
+  children : C,
+) -> @rabbita.Val[@html.Html] {
+  let (pressed, set_pressed) = @rabbita.create_variable(default_pressed)
+  pressed.view(pressed => {
+    render_toggle(
+      pressed~,
+      variant~,
+      size~,
+      disabled~,
+      invalid~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      on_pressed_change=@cmd.Emit(next => {
+        let update = set_pressed(_ => next)
+        if on_pressed_change is Some(notify) {
+          @cmd.batch([update, notify(next)])
+        } else {
+          update
+        }
+      }),
+      attrs?,
+      style~,
+      slot~,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] toggle(
+  default_pressed? : Bool = false,
+  variant? : ToggleVariant = Default,
+  size? : ToggleSize = Default,
+  disabled? : Bool = false,
+  invalid? : Bool = false,
+  id? : String,
+  class? : String,
+  title? : String,
+  aria_label? : String,
+  on_pressed_change? : @cmd.Emit[Bool],
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  slot? : String = "toggle",
+  children : C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_pressed_change)
+  @rabbita.Val::constant(
+    render_toggle(
+      pressed=default_pressed,
+      variant~,
+      size~,
+      disabled~,
+      invalid~,
+      id?,
+      class?,
+      title?,
+      aria_label?,
+      attrs?,
+      style~,
+      slot~,
+      children,
+    ),
+  )
+}

--- a/rui/toggle_group.mbt
+++ b/rui/toggle_group.mbt
@@ -1,0 +1,334 @@
+///|
+priv enum ToggleGroupMsg {
+  ToggleGroupValue(String)
+} derive(Debug)
+
+///|
+/// Opaque render scope owned by `toggle_group`.
+struct ToggleGroupScope {
+  values : Array[String]
+  multiple : Bool
+  variant : ToggleVariant
+  size : ToggleSize
+  spacing : Int
+  emit : @cmd.Emit[ToggleGroupMsg]
+  tab_claimed : Ref[Bool]
+}
+
+///|
+#cfg(target="js")
+fn toggle_group_move_focus(event : @dom.KeyboardEvent) -> Bool {
+  if event.alt_key() ||
+    event.ctrl_key() ||
+    event.meta_key() ||
+    event.shift_key() {
+    return false
+  }
+  guard ui_roving_context(
+      event, "[data-slot=\"toggle-group-item\"]", "[data-slot=\"toggle-group\"]",
+      "[data-slot=\"toggle-group-item\"]",
+    )
+    is Some(context) else {
+    return false
+  }
+  let orientation = context.root.get_attribute("data-orientation").unwrap_or("")
+  guard ui_roving_target(
+      context,
+      event.key(),
+      orientation,
+      ui_element_is_rtl(context.root),
+    )
+    is Some(target) else {
+    return false
+  }
+  for item in context.items {
+    ui_set_element_tab_index(
+      item,
+      if item.is_same_node(target.as_node()) {
+        0
+      } else {
+        -1
+      },
+    )
+  }
+  ui_focus_element_without_scroll(target)
+  true
+}
+
+///|
+#cfg(target="js")
+fn toggle_group_bind_keyboard(attrs : @html.Attrs) -> Unit {
+  ignore(
+    attrs.on_keydown(event => {
+      if toggle_group_move_focus(event) {
+        event.prevent_default()
+      }
+      @cmd.none
+    }),
+  )
+}
+
+///|
+#cfg(not(target="js"))
+fn toggle_group_bind_keyboard(attrs : @html.Attrs) -> Unit {
+  ignore(attrs)
+}
+
+///|
+fn toggle_group_contains(values : Array[String], value : String) -> Bool {
+  for item in values {
+    if item == value {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn toggle_group_next_values(
+  values : Array[String],
+  value : String,
+  multiple : Bool,
+) -> Array[String] {
+  let selected = toggle_group_contains(values, value)
+  if !multiple {
+    if selected {
+      []
+    } else {
+      [value]
+    }
+  } else {
+    let next : Array[String] = []
+    for item in values {
+      if item != value {
+        next.push(item)
+      }
+    }
+    if !selected {
+      next.push(value)
+    }
+    next
+  }
+}
+
+///|
+fn[C : @html.IsChildren] render_toggle_group(
+  scope : ToggleGroupScope,
+  orientation : SeparatorOrientation,
+  variant : ToggleVariant,
+  size : ToggleSize,
+  spacing : Int,
+  aria_label : String?,
+  id : String?,
+  class : String?,
+  title : String?,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  children : (ToggleGroupScope) -> C,
+) -> @html.Html {
+  let orientation_value = separator_orientation_value(orientation)
+  let gap = spacing.to_double() / 4.0
+  let group_attrs = ui_attrs(attrs)
+    .role("group")
+    .aria_orientation(orientation_value)
+    .data_set("slot", "toggle-group")
+    .data_set("orientation", orientation_value)
+    .data_set("variant", toggle_variant_value(variant))
+    .data_set("size", toggle_size_value(size))
+    .data_set("spacing", "\{spacing}")
+    .data_set("multiple", ui_bool(scope.multiple))
+  if aria_label is Some(label) {
+    ignore(group_attrs.aria_label(label))
+  }
+  @html.div(
+    id?,
+    class?,
+    title?,
+    attrs=group_attrs,
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        "--rui-toggle-group-gap:\{gap}rem;display:inline-flex;width:fit-content;align-items:center;gap:var(--rui-toggle-group-gap);border-radius:var(--rui-control-radius,calc(var(--rui-radius,0.625rem) - 0.125rem))",
+        if spacing == 0 && variant is Outline {
+          UiShadowXs
+        } else {
+          ""
+        },
+        if orientation is Vertical {
+          "flex-direction:column;align-items:stretch"
+        } else {
+          "flex-direction:row"
+        },
+      ],
+      style,
+    ),
+    children(scope),
+  )
+}
+
+///|
+/// Stateful shadcn-style toggle group. Selection is component-local and the
+/// optional callback observes each committed value set.
+#cfg(target="js")
+pub fn[C : @html.IsChildren] toggle_group(
+  default_values? : Array[String] = [],
+  multiple? : Bool = false,
+  orientation? : SeparatorOrientation = Horizontal,
+  variant? : ToggleVariant = Default,
+  size? : ToggleSize = Default,
+  spacing? : Int = 0,
+  aria_label? : String,
+  on_value_change? : @cmd.Emit[Array[String]],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ToggleGroupScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  let (values, emit) = @rabbita.create_state(default_values, update=fn(
+    _,
+    msg,
+    values,
+  ) {
+    let next = match msg {
+      ToggleGroupValue(value) =>
+        toggle_group_next_values(values, value, multiple)
+    }
+    let command = if on_value_change is Some(notify) {
+      notify(next)
+    } else {
+      @cmd.none
+    }
+    (next, command)
+  })
+  values.view(values => {
+    render_toggle_group(
+      {
+        values,
+        multiple,
+        variant,
+        size,
+        spacing,
+        emit,
+        tab_claimed: Ref(false),
+      },
+      orientation,
+      variant,
+      size,
+      spacing,
+      aria_label,
+      id,
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    )
+  })
+}
+
+///|
+#cfg(not(target="js"))
+pub fn[C : @html.IsChildren] toggle_group(
+  default_values? : Array[String] = [],
+  multiple? : Bool = false,
+  orientation? : SeparatorOrientation = Horizontal,
+  variant? : ToggleVariant = Default,
+  size? : ToggleSize = Default,
+  spacing? : Int = 0,
+  aria_label? : String,
+  on_value_change? : @cmd.Emit[Array[String]],
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : (ToggleGroupScope) -> C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_value_change)
+  let emit = @cmd.Emit(_ => @cmd.none)
+  @rabbita.Val::constant(
+    render_toggle_group(
+      {
+        values: default_values,
+        multiple,
+        variant,
+        size,
+        spacing,
+        emit,
+        tab_claimed: Ref(false),
+      },
+      orientation,
+      variant,
+      size,
+      spacing,
+      aria_label,
+      id,
+      class,
+      title,
+      attrs,
+      style,
+      children,
+    ),
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] toggle_group_item(
+  scope~ : ToggleGroupScope,
+  value~ : String,
+  disabled? : Bool = false,
+  aria_label? : String,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let pressed = toggle_group_contains(scope.values, value)
+  let item_attrs = ui_attrs(attrs)
+    .data_set("slot", "toggle-group-item")
+    .data_set("variant", toggle_variant_value(scope.variant))
+    .data_set("size", toggle_size_value(scope.size))
+    .data_set("spacing", "\{scope.spacing}")
+    .data_set("value", value)
+    .data_set("state", if pressed { "on" } else { "off" })
+  let tab_stop = !disabled &&
+    !scope.tab_claimed.val &&
+    (scope.values.length() == 0 || pressed)
+  if tab_stop {
+    scope.tab_claimed.val = true
+  }
+  ignore(item_attrs.tabindex(if tab_stop { 0 } else { -1 }))
+  toggle_group_bind_keyboard(item_attrs)
+  if aria_label is Some(label) {
+    ignore(item_attrs.aria_label(label))
+  }
+  render_toggle(
+    pressed~,
+    variant=scope.variant,
+    size=scope.size,
+    disabled~,
+    slot="toggle-group-item",
+    id?,
+    class?,
+    title?,
+    on_pressed_change=@cmd.Emit(_ => (scope.emit)(ToggleGroupValue(value))),
+    attrs=item_attrs,
+    style=ui_styles(
+      [
+        "width:auto;min-width:0;flex-shrink:0;--rui-toggle-padding-inline:0.75rem",
+        if scope.spacing == 0 {
+          "--rui-toggle-base-radius:0;--rui-toggle-base-shadow:none"
+        } else {
+          ""
+        },
+      ],
+      style,
+    ),
+    children,
+  )
+}

--- a/rui/toggle_group_test.mbt
+++ b/rui/toggle_group_test.mbt
@@ -1,0 +1,61 @@
+///|
+test "toggle group propagates the Vega variant size and spacing recipe" {
+  let html = render_incremental(() => {
+    @rui.toggle_group(
+      default_values=["bold"],
+      multiple=true,
+      orientation=@rui.Vertical,
+      variant=@rui.Outline,
+      size=@rui.Lg,
+      spacing=0,
+      scope => {
+        [
+          @rui.toggle_group_item(scope~, value="bold", "Bold"),
+          @rui.toggle_group_item(scope~, value="italic", "Italic"),
+        ]
+      },
+    )
+  })
+  assert_contains(html, "data-slot=\"toggle-group\"")
+  assert_contains(html, "data-orientation=\"vertical\"")
+  assert_contains(html, "data-variant=\"outline\"")
+  assert_contains(html, "data-size=\"lg\"")
+  assert_contains(html, "data-spacing=\"0\"")
+  assert_contains(html, "--rui-toggle-group-gap:0rem")
+  assert_contains(html, "gap:var(--rui-toggle-group-gap)")
+  assert_contains(html, "flex-direction:column;align-items:stretch")
+  assert_contains(html, "--rui-toggle-base-border:var(--rui-outline-border")
+  assert_contains(
+    html, "background:var(--rui-toggle-bg,var(--rui-toggle-base-bg,transparent))",
+  )
+  assert_contains(html, "height:2.5rem")
+  assert_contains(
+    html, "width:auto;min-width:0;flex-shrink:0;--rui-toggle-padding-inline:0.75rem;--rui-toggle-base-radius:0;--rui-toggle-base-shadow:none",
+  )
+  assert_contains(
+    html, "--rui-toggle-base-bg:var(--rui-accent,oklch(0.97 0 0))",
+  )
+  assert_contains(
+    html, "data-slot=\"toggle-group-item\" data-variant=\"outline\" data-size=\"lg\" data-spacing=\"0\" data-value=\"bold\" data-state=\"on\"",
+  )
+  assert_contains(
+    html, "data-slot=\"toggle-group-item\" data-variant=\"outline\" data-size=\"lg\" data-spacing=\"0\" data-value=\"italic\" data-state=\"off\"",
+  )
+}
+
+///|
+test "toggle group keeps the Vega zero spacing on every item" {
+  let html = render_incremental(() => {
+    @rui.toggle_group(scope => {
+      [
+        @rui.toggle_group_item(scope~, value="left", "Left"),
+        @rui.toggle_group_item(scope~, value="right", "Right"),
+      ]
+    })
+  })
+  assert_contains(html, "data-spacing=\"0\"")
+  assert_contains(html, "--rui-toggle-group-gap:0rem")
+  assert_contains(
+    html, "data-slot=\"toggle-group-item\" data-variant=\"default\" data-size=\"default\" data-spacing=\"0\"",
+  )
+}

--- a/rui/tooltip.mbt
+++ b/rui/tooltip.mbt
@@ -1,0 +1,1000 @@
+///|
+const TooltipProviderStyle : String = "display:contents"
+
+///|
+const TooltipRootStyle : String = "display:contents"
+
+///|
+const TooltipContentStyle : String = "position:fixed;inset:auto;left:var(--rui-floating-left,auto);top:var(--rui-floating-top,auto);z-index:50;display:flex;width:max-content;max-width:calc(100vw - 1rem);transform-origin:var(--rui-floating-transform-origin,center);align-items:center;margin:0;border:0;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-primary,oklch(0.205 0 0));padding:0.375rem 0.75rem;color:var(--rui-primary-foreground,oklch(0.985 0 0));font-size:0.75rem;line-height:1rem;font-weight:400;text-wrap:balance;box-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1),0 2px 4px -2px rgb(0 0 0 / 0.1);outline:none;transition:opacity 100ms ease,transform 100ms ease,visibility 100ms ease"
+
+///|
+const TooltipArrowBaseStyle : String = "position:absolute;z-index:-1;top:var(--rui-tooltip-arrow-top,auto);right:var(--rui-tooltip-arrow-right,auto);bottom:var(--rui-tooltip-arrow-bottom,auto);left:var(--rui-tooltip-arrow-left,auto);width:0.625rem;height:0.625rem;margin-top:var(--rui-tooltip-arrow-margin-top,0);margin-left:var(--rui-tooltip-arrow-margin-left,0);border-radius:2px;background:var(--rui-primary,oklch(0.205 0 0));transform:rotate(45deg)"
+
+///|
+fn tooltip_delay(value : Int) -> Int {
+  if value < 0 {
+    0
+  } else {
+    value
+  }
+}
+
+///|
+fn tooltip_arrow_side_style(side : PopupSide) -> String {
+  match side {
+    Top =>
+      "--rui-tooltip-arrow-top:auto;--rui-tooltip-arrow-right:auto;--rui-tooltip-arrow-bottom:-0.25rem;--rui-tooltip-arrow-left:50%;--rui-tooltip-arrow-margin-top:0;--rui-tooltip-arrow-margin-left:-0.3125rem"
+    Right =>
+      "--rui-tooltip-arrow-top:50%;--rui-tooltip-arrow-right:auto;--rui-tooltip-arrow-bottom:auto;--rui-tooltip-arrow-left:-0.25rem;--rui-tooltip-arrow-margin-top:-0.3125rem;--rui-tooltip-arrow-margin-left:0"
+    Bottom =>
+      "--rui-tooltip-arrow-top:-0.25rem;--rui-tooltip-arrow-right:auto;--rui-tooltip-arrow-bottom:auto;--rui-tooltip-arrow-left:50%;--rui-tooltip-arrow-margin-top:0;--rui-tooltip-arrow-margin-left:-0.3125rem"
+    Left =>
+      "--rui-tooltip-arrow-top:50%;--rui-tooltip-arrow-right:-0.25rem;--rui-tooltip-arrow-bottom:auto;--rui-tooltip-arrow-left:auto;--rui-tooltip-arrow-margin-top:-0.3125rem;--rui-tooltip-arrow-margin-left:0"
+  }
+}
+
+///|
+/// Supply shared open and close delays to descendant tooltips.
+///
+/// shadcn's Vega preset opens without a wait, so `delay` defaults to zero.
+/// `timeout` is the instant-phase window: moving between tooltips within
+/// that period bypasses a non-zero opening delay. An individual `tooltip` can
+/// override the opening or closing delay.
+pub fn[C : @html.IsChildren] tooltip_provider(
+  delay? : Int = 0,
+  close_delay? : Int = 0,
+  timeout? : Int = 400,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let actual_delay = tooltip_delay(delay)
+  let actual_close_delay = tooltip_delay(close_delay)
+  let actual_timeout = tooltip_delay(timeout)
+  let element_attrs = ui_attrs(attrs)
+    .data_set("slot", "tooltip-provider")
+    .data_set("delay", "\{actual_delay}")
+    .data_set("close-delay", "\{actual_close_delay}")
+    .data_set("timeout", "\{actual_timeout}")
+  @html.span(
+    style=ui_styles([UiBoxSizing, TooltipProviderStyle], style),
+    id?,
+    class?,
+    title?,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] tooltip_trigger(
+  content_id~ : String,
+  open? : Bool = false,
+  disabled? : Bool = false,
+  variant? : ButtonVariant = Ghost,
+  size? : ButtonSize = Default,
+  on_click? : @cmd.Cmd,
+  id? : String,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let resolved_id = id.unwrap_or(content_id + "-trigger")
+  let element_attrs = popup_state_attrs(attrs, "tooltip-trigger", open)
+    .data_set("variant", button_variant_value(variant))
+    .data_set("size", button_size_value(size))
+  if open {
+    ignore(element_attrs.aria_describedby(content_id))
+  }
+  if disabled {
+    ignore(element_attrs.aria_disabled("true").data_set("disabled", ""))
+  }
+  if on_click is Some(command) {
+    ignore(element_attrs.on_click(_ => command))
+  }
+  @html.button(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        UiTransition,
+        ButtonBaseStyle,
+        button_variant_style(variant),
+        button_size_style(size),
+        ui_disabled_style(disabled),
+        popup_anchor_style(resolved_id),
+      ],
+      style,
+    ),
+    id=resolved_id,
+    class?,
+    title?,
+    type_="button",
+    disabled~,
+    attrs=element_attrs,
+    children,
+  )
+}
+
+///|
+pub fn tooltip_arrow(
+  side? : PopupSide = Top,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+) -> @html.Html {
+  @html.span(
+    style=ui_styles(
+      [UiBoxSizing, TooltipArrowBaseStyle, tooltip_arrow_side_style(side)],
+      style,
+    ),
+    class?,
+    title?,
+    attrs=ui_attrs(attrs).data_set("slot", "tooltip-arrow").aria_hidden("true"),
+    @html.nothing,
+  )
+}
+
+///|
+pub fn[C : @html.IsChildren] tooltip_content(
+  id~ : String,
+  trigger_id~ : String,
+  open? : Bool = false,
+  side? : PopupSide = Top,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  show_arrow? : Bool = true,
+  class? : String,
+  title? : String,
+  attrs? : @html.Attrs,
+  arrow_attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  arrow_style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  let element_attrs = popup_state_attrs(attrs, "tooltip-content", open)
+    .popover("manual")
+    .role("tooltip")
+    .data_set("initial-focus", "false")
+    .data_set("restore-focus", "false")
+    .data_set("trigger-id", trigger_id)
+    .data_set("requested-side", popup_side_value(side))
+    .data_set("requested-align", popup_align_value(align))
+    .data_set("side", popup_side_value(side))
+    .data_set("align", popup_align_value(align))
+    .data_set("side-offset", "\{side_offset}")
+    .data_set("align-offset", "\{align_offset}")
+    .data_set("collision-padding", "0")
+    .data_set("sticky", "partial")
+  let body = @html.span(
+    style=[UiBoxSizing, "display:contents"],
+    attrs=@html.Attrs::build().data_set("slot", "tooltip-content-body"),
+    children,
+  )
+  let content_children = if show_arrow {
+    [
+      body,
+      @html.span(
+        style=ui_styles([UiBoxSizing, TooltipArrowBaseStyle], arrow_style),
+        attrs=ui_attrs(arrow_attrs)
+          .data_set("slot", "tooltip-arrow")
+          .aria_hidden("true"),
+        @html.nothing,
+      ),
+    ]
+  } else {
+    [body]
+  }
+  @html.div(
+    style=ui_styles(
+      [
+        UiBoxSizing,
+        UiFontSans,
+        UiTextRendering,
+        TooltipContentStyle,
+        PopupTransition100Style,
+        popup_floating_anchor_style(
+          trigger_id, side, align, side_offset, align_offset,
+        ),
+        tooltip_arrow_side_style(side),
+        popup_state_style(open),
+      ],
+      style,
+    ),
+    id~,
+    class?,
+    title?,
+    attrs=element_attrs,
+    content_children,
+  )
+}
+
+///|
+#cfg(target="js")
+priv struct TooltipEventBinding {
+  popup : @dom.Element
+  trigger : @dom.Element
+  root : @dom.Element
+  sidebar : @dom.Element?
+  dispatch : Ref[(Int, Int) -> Unit]
+  sidebar_observer : Ref[@dom.MutationObserver?]
+}
+
+///|
+#cfg(target="js")
+let tooltip_event_bindings : Map[String, TooltipEventBinding] = Map([])
+
+///|
+#cfg(target="js")
+let tooltip_bound_document : Ref[@dom.Document?] = Ref(None)
+
+///|
+#cfg(target="js")
+fn tooltip_live_binding(id : String) -> TooltipEventBinding? {
+  guard tooltip_event_bindings.get(id) is Some(binding) else { return None }
+  guard binding.popup.get_is_connected() &&
+    binding.trigger.get_is_connected() &&
+    binding.root.get_is_connected() else {
+    ignore(tooltip_event_bindings.remove(id))
+    return None
+  }
+  guard ui_element_by_id(id) is Some(popup) &&
+    floating_same_element(binding.popup, popup) else {
+    ignore(tooltip_event_bindings.remove(id))
+    return None
+  }
+  Some(binding)
+}
+
+///|
+#cfg(target="js")
+fn tooltip_binding_provider(binding : TooltipEventBinding) -> @dom.Element? {
+  binding.root.closest("[data-slot=\"tooltip-provider\"]")
+}
+
+///|
+#cfg(target="js")
+fn tooltip_number_config(
+  binding : TooltipEventBinding,
+  name : String,
+  fallback : Int,
+) -> Int {
+  let attribute = "data-" + name
+  let value = if binding.root.has_attribute(attribute) {
+    binding.root.get_attribute(attribute).unwrap_or("")
+  } else if tooltip_binding_provider(binding) is Some(provider) &&
+    provider.has_attribute(attribute) {
+    provider.get_attribute(attribute).unwrap_or("")
+  } else {
+    ""
+  }
+  ui_parse_int_or(value, fallback).max(0)
+}
+
+///|
+#cfg(target="js")
+fn tooltip_content_is_open(element : @dom.Element) -> Bool {
+  let id = element.get_attribute("id").unwrap_or("")
+  if floating_live_layer(id) is Some(layer) {
+    floating_layer_is_open(layer)
+  } else {
+    element.get_attribute("data-state").unwrap_or("") == "open"
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_open_delay(binding : TooltipEventBinding) -> Int {
+  let configured = tooltip_number_config(binding, "delay", 0)
+  guard tooltip_binding_provider(binding) is Some(provider) else {
+    return configured
+  }
+  if configured <= 0 {
+    return configured
+  }
+  let timeout = ui_parse_int_or(
+    provider.get_attribute("data-timeout").unwrap_or(""),
+    400,
+  ).max(0)
+  let mut has_open = false
+  for content in provider.query_selector_all("[data-slot=\"tooltip-content\"]") {
+    if tooltip_content_is_open(content) {
+      has_open = true
+    }
+  }
+  let instant = if tooltip_provider_last_close(provider) is Some(closed_at) &&
+    ui_has_window() {
+    @dom.window().get_performance().now() - closed_at <= timeout.to_double()
+  } else {
+    false
+  }
+  if has_open || instant {
+    0
+  } else {
+    configured
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_can_open(binding : TooltipEventBinding) -> Bool {
+  if binding.root.get_attribute("data-sidebar-collapsed-only").unwrap_or("") !=
+    "true" {
+    return true
+  }
+  if binding.sidebar is Some(sidebar) {
+    sidebar.get_attribute("data-collapsible").unwrap_or("") == "icon" &&
+    sidebar.get_attribute("data-state").unwrap_or("") == "collapsed" &&
+    sidebar.get_attribute("data-mobile").unwrap_or("") != "true"
+  } else {
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_send(binding : TooltipEventBinding, kind : Int, wait : Int) -> Unit {
+  let opening = kind == 0 || kind == 2 || kind == 5
+  if opening &&
+    (!ui_element_is_enabled(binding.trigger) || !tooltip_can_open(binding)) {
+    return
+  }
+  (binding.dispatch.val)(kind, wait)
+}
+
+///|
+#cfg(target="js")
+fn tooltip_top_binding() -> TooltipEventBinding? {
+  guard floating_top_layer() is Some(layer) else { return None }
+  if layer.element.get_attribute("data-slot").unwrap_or("") != "tooltip-content" {
+    return None
+  }
+  tooltip_live_binding(layer.id)
+}
+
+///|
+#cfg(target="js")
+fn tooltip_bind_document_events() -> Unit {
+  let document = @dom.document()
+  if tooltip_bound_document.val is Some(bound) &&
+    bound.to_node().is_same_node(document.to_node()) {
+    return
+  }
+  tooltip_bound_document.val = Some(document)
+  document.add_event_listener("keydown", event => {
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    if keyboard.key() != "Escape" || event.get_default_prevented() {
+      return
+    }
+    guard tooltip_top_binding() is Some(binding) else { return }
+    event.prevent_default()
+    event.stop_propagation()
+    tooltip_send(binding, 7, 0)
+  })
+  document.add_event_listener("pointerdown", event => {
+    if event.get_default_prevented() {
+      return
+    }
+    guard tooltip_top_binding() is Some(binding) else { return }
+    if floating_event_inside(event, binding.popup) ||
+      floating_event_inside(event, binding.trigger) {
+      return
+    }
+    tooltip_send(binding, 8, 0)
+  })
+}
+
+///|
+#cfg(target="js")
+fn bind_tooltip_events_for_trigger(
+  id : String,
+  trigger_id : String,
+  root_id : String,
+  dispatch : (Int, Int) -> Unit,
+) -> Bool {
+  guard ui_has_document() else { return false }
+  guard ui_element_by_id(id) is Some(popup) else { return false }
+  guard ui_element_by_id(trigger_id) is Some(trigger) else { return false }
+  guard ui_element_by_id(root_id) is Some(root) else { return false }
+  if !popup.get_is_connected() ||
+    !trigger.get_is_connected() ||
+    !root.get_is_connected() {
+    return false
+  }
+  if tooltip_event_bindings.get(id) is Some(binding) &&
+    floating_same_element(binding.popup, popup) &&
+    floating_same_element(binding.trigger, trigger) &&
+    floating_same_element(binding.root, root) {
+    binding.dispatch.val = dispatch
+    return true
+  }
+  if tooltip_event_bindings.get(id) is Some(previous) &&
+    previous.sidebar_observer.val is Some(observer) {
+    observer.disconnect()
+  }
+  let sidebar = if root
+    .get_attribute("data-sidebar-collapsed-only")
+    .unwrap_or("") ==
+    "true" {
+    trigger.closest("[data-slot=\"sidebar\"]")
+  } else {
+    None
+  }
+  let binding : TooltipEventBinding = {
+    popup,
+    trigger,
+    root,
+    sidebar,
+    dispatch: Ref(dispatch),
+    sidebar_observer: Ref(None),
+  }
+  tooltip_event_bindings[id] = binding
+  trigger.add_event_listener("mouseenter", _ => {
+    tooltip_send(binding, 0, tooltip_open_delay(binding))
+  })
+  trigger.add_event_listener("mouseleave", _ => {
+    let hover_grace = if root.get_attribute("data-hoverable").unwrap_or("") ==
+      "true" {
+      80
+    } else {
+      0
+    }
+    tooltip_send(
+      binding,
+      1,
+      tooltip_number_config(binding, "close-delay", 0).max(hover_grace),
+    )
+  })
+  trigger.add_event_listener("focus", _ => {
+    if trigger.matches(":focus-visible") {
+      tooltip_send(binding, 2, 0)
+    }
+  })
+  trigger.add_event_listener("blur", _ => {
+    tooltip_send(binding, 3, tooltip_number_config(binding, "close-delay", 0))
+  })
+  trigger.add_event_listener("click", _ => {
+    if root.get_attribute("data-close-on-click").unwrap_or("") == "true" {
+      tooltip_send(binding, 4, 0)
+    }
+  })
+  popup.add_event_listener("mouseenter", _ => {
+    if root.get_attribute("data-hoverable").unwrap_or("") == "true" {
+      tooltip_send(binding, 5, 0)
+    }
+  })
+  popup.add_event_listener("mouseleave", _ => {
+    if root.get_attribute("data-hoverable").unwrap_or("") == "true" {
+      tooltip_send(binding, 6, tooltip_number_config(binding, "close-delay", 0))
+    }
+  })
+  if sidebar is Some(sidebar_element) {
+    let observer = @dom.MutationObserver::new((_records, _observer) => {
+      if !tooltip_can_open(binding) {
+        tooltip_send(binding, 9, 0)
+      }
+    })
+    observer.observe(sidebar_element.as_node(), attributes=true, attribute_filter=[
+      "data-collapsible", "data-state", "data-mobile",
+    ])
+    binding.sidebar_observer.val = Some(observer)
+  }
+  if !tooltip_can_open(binding) {
+    tooltip_send(binding, 9, 0)
+  }
+  tooltip_bind_document_events()
+  true
+}
+
+///|
+#cfg(target="js")
+fn bind_tooltip_events(id : String, dispatch : (Int, Int) -> Unit) -> Bool {
+  bind_tooltip_events_for_trigger(id, id + "-trigger", id + "-root", dispatch)
+}
+
+///|
+#cfg(target="js")
+priv struct TooltipModel {
+  open : Bool
+  trigger_hovered : Bool
+  trigger_focused : Bool
+  content_hovered : Bool
+  generation : Int
+} derive(Eq)
+
+///|
+#cfg(target="js")
+priv enum TooltipMsg {
+  TooltipDomEvent(Int, Int)
+  TooltipOpenAfter(Int)
+  TooltipCloseAfter(Int)
+  TooltipNativeChanged(Bool)
+}
+
+///|
+#cfg(target="js")
+fn tooltip_is_active(model : TooltipModel) -> Bool {
+  model.trigger_hovered || model.trigger_focused || model.content_hovered
+}
+
+///|
+#cfg(target="js")
+fn tooltip_notify_cmd(
+  on_open_change : @cmd.Emit[Bool]?,
+  open : Bool,
+) -> @cmd.Cmd {
+  if on_open_change is Some(notify) {
+    notify(open)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_commit_open(
+  id : String,
+  on_open_change : @cmd.Emit[Bool]?,
+  model : TooltipModel,
+  open : Bool,
+) -> (TooltipModel, @cmd.Cmd) {
+  if model.open == open {
+    (model, @cmd.none)
+  } else {
+    (
+      { ..model, open, },
+      @cmd.batch([
+        floating_set_open_cmd(id, open),
+        tooltip_notify_cmd(on_open_change, open),
+      ]),
+    )
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_commit_native(
+  on_open_change : @cmd.Emit[Bool]?,
+  model : TooltipModel,
+  open : Bool,
+) -> (TooltipModel, @cmd.Cmd) {
+  if open {
+    if model.open {
+      (model, @cmd.none)
+    } else {
+      ({ ..model, open: true }, tooltip_notify_cmd(on_open_change, true))
+    }
+  } else {
+    let next : TooltipModel = {
+      open: false,
+      trigger_hovered: false,
+      trigger_focused: false,
+      content_hovered: false,
+      generation: model.generation + 1,
+    }
+    if model.open {
+      (next, tooltip_notify_cmd(on_open_change, false))
+    } else {
+      (next, @cmd.none)
+    }
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_bind_events_cmd(
+  id : String,
+  emit : @cmd.Emit[TooltipMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_ready("tooltip-events:" + id, () => {
+      bind_tooltip_events(id, (kind, wait) => {
+        scheduler.add(emit(TooltipDomEvent(kind, wait)))
+      })
+    })
+  })
+}
+
+///|
+#cfg(target="js")
+fn tooltip_bind_trigger_events_cmd(
+  id : String,
+  trigger_id : String,
+  root_id : String,
+  emit : @cmd.Emit[TooltipMsg],
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(kind=@cmd.AfterRender, scheduler => {
+    ui_after_ready("tooltip-events:" + id, () => {
+      bind_tooltip_events_for_trigger(id, trigger_id, root_id, (kind, wait) => {
+        scheduler.add(emit(TooltipDomEvent(kind, wait)))
+      })
+    })
+  })
+}
+
+///|
+#cfg(target="js")
+fn tooltip_update(
+  id : String,
+  close_on_click : Bool,
+  on_open_change : @cmd.Emit[Bool]?,
+  emit : @cmd.Emit[TooltipMsg],
+  msg : TooltipMsg,
+  current : TooltipModel,
+) -> (TooltipModel, @cmd.Cmd) {
+  match msg {
+    TooltipDomEvent(kind, wait) =>
+      match kind {
+        // Trigger hover starts after the configured provider/root delay.
+        0 => {
+          let generation = current.generation + 1
+          let next = { ..current, trigger_hovered: true, generation }
+          if current.open {
+            (next, @cmd.none)
+          } else if wait <= 0 {
+            tooltip_commit_open(id, on_open_change, next, true)
+          } else {
+            (next, @cmd.delay(emit(TooltipOpenAfter(generation)), wait))
+          }
+        }
+        // Trigger hover ends; popup hover can cancel this delayed close.
+        1 => {
+          let generation = current.generation + 1
+          let next = { ..current, trigger_hovered: false, generation }
+          if tooltip_is_active(next) || !next.open {
+            (next, @cmd.none)
+          } else if wait <= 0 {
+            tooltip_commit_open(id, on_open_change, next, false)
+          } else {
+            (next, @cmd.delay(emit(TooltipCloseAfter(generation)), wait))
+          }
+        }
+        // Keyboard/programmatic focus opens immediately.
+        2 => {
+          let next = {
+            ..current,
+            trigger_focused: true,
+            generation: current.generation + 1,
+          }
+          tooltip_commit_open(id, on_open_change, next, true)
+        }
+        3 => {
+          let generation = current.generation + 1
+          let next = { ..current, trigger_focused: false, generation }
+          if tooltip_is_active(next) || !next.open {
+            (next, @cmd.none)
+          } else if wait <= 0 {
+            tooltip_commit_open(id, on_open_change, next, false)
+          } else {
+            (next, @cmd.delay(emit(TooltipCloseAfter(generation)), wait))
+          }
+        }
+        // Click-to-dismiss remains configurable.
+        4 =>
+          if close_on_click {
+            tooltip_commit_open(
+              id,
+              on_open_change,
+              {
+                ..current,
+                trigger_hovered: false,
+                trigger_focused: false,
+                content_hovered: false,
+                generation: current.generation + 1,
+              },
+              false,
+            )
+          } else {
+            (current, @cmd.none)
+          }
+        5 =>
+          (
+            {
+              ..current,
+              content_hovered: true,
+              generation: current.generation + 1,
+            },
+            @cmd.none,
+          )
+        6 => {
+          let generation = current.generation + 1
+          let next = { ..current, content_hovered: false, generation }
+          if tooltip_is_active(next) || !next.open {
+            (next, @cmd.none)
+          } else if wait <= 0 {
+            tooltip_commit_open(id, on_open_change, next, false)
+          } else {
+            (next, @cmd.delay(emit(TooltipCloseAfter(generation)), wait))
+          }
+        }
+        // Only the top floating layer dispatches Escape/outside dismissal.
+        _ =>
+          tooltip_commit_open(
+            id,
+            on_open_change,
+            {
+              ..current,
+              trigger_hovered: false,
+              trigger_focused: false,
+              content_hovered: false,
+              generation: current.generation + 1,
+            },
+            false,
+          )
+      }
+    TooltipOpenAfter(generation) =>
+      if generation == current.generation && tooltip_is_active(current) {
+        tooltip_commit_open(id, on_open_change, current, true)
+      } else {
+        (current, @cmd.none)
+      }
+    TooltipCloseAfter(generation) =>
+      if generation == current.generation && !tooltip_is_active(current) {
+        tooltip_commit_open(id, on_open_change, current, false)
+      } else {
+        (current, @cmd.none)
+      }
+    TooltipNativeChanged(open) =>
+      tooltip_commit_native(on_open_change, current, open)
+  }
+}
+
+///|
+fn[T : @html.IsChildren, C : @html.IsChildren] render_tooltip(
+  id : String,
+  open : Bool,
+  disabled : Bool,
+  delay : Int?,
+  close_delay : Int?,
+  close_on_click : Bool,
+  hoverable : Bool,
+  side : PopupSide,
+  align : PopupAlign,
+  side_offset : Int,
+  align_offset : Int,
+  show_arrow : Bool,
+  trigger_variant : ButtonVariant,
+  trigger_size : ButtonSize,
+  attrs : @html.Attrs?,
+  style : Array[String],
+  trigger_attrs : @html.Attrs?,
+  trigger_style : Array[String],
+  content_attrs : @html.Attrs?,
+  content_style : Array[String],
+  arrow_attrs : @html.Attrs?,
+  arrow_style : Array[String],
+  on_trigger_click : @cmd.Cmd?,
+  trigger : T,
+  content : C,
+) -> @html.Html {
+  let root_id = id + "-root"
+  let trigger_id = id + "-trigger"
+  let root_attrs = popup_state_attrs(attrs, "tooltip", open)
+    .data_set("close-on-click", ui_bool(close_on_click))
+    .data_set("hoverable", ui_bool(hoverable))
+  if delay is Some(delay) {
+    ignore(root_attrs.data_set("delay", "\{delay}"))
+  }
+  if close_delay is Some(close_delay) {
+    ignore(root_attrs.data_set("close-delay", "\{close_delay}"))
+  }
+  let on_click = on_trigger_click
+  let trigger_element_attrs = trigger_attrs
+  let popup_attrs = content_attrs
+  @html.span(
+    style=ui_styles([UiBoxSizing, TooltipRootStyle], style),
+    id=root_id,
+    attrs=root_attrs,
+    [
+      tooltip_trigger(
+        content_id=id,
+        open~,
+        disabled~,
+        variant=trigger_variant,
+        size=trigger_size,
+        on_click?,
+        id=trigger_id,
+        attrs?=trigger_element_attrs,
+        style=trigger_style,
+        trigger,
+      ),
+      tooltip_content(
+        id~,
+        trigger_id~,
+        open~,
+        side~,
+        align~,
+        side_offset~,
+        align_offset~,
+        show_arrow~,
+        attrs?=popup_attrs,
+        arrow_attrs?,
+        style=content_style,
+        arrow_style~,
+        content,
+      ),
+    ],
+  )
+}
+
+///|
+/// Imperatively open a mounted tooltip. The owning incremental component
+/// receives the resulting native `toggle` event and synchronizes its state.
+pub fn tooltip_open(id : String) -> @cmd.Cmd {
+  floating_set_open_cmd(id, true)
+}
+
+///|
+pub fn tooltip_close(id : String) -> @cmd.Cmd {
+  floating_set_open_cmd(id, false)
+}
+
+///|
+pub fn tooltip_toggle(id : String) -> @cmd.Cmd {
+  floating_toggle_cmd(id)
+}
+
+///|
+/// Build a black-box tooltip with Rabbita-owned incremental interaction state.
+///
+/// Hover, keyboard focus, click dismissal, Escape, hoverable content, provider
+/// delays, and native Popover top-layer synchronization are handled internally.
+#cfg(target="js")
+pub fn[T : @html.IsChildren, C : @html.IsChildren] tooltip(
+  id~ : String,
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  delay? : Int,
+  close_delay? : Int,
+  close_on_click? : Bool = true,
+  hoverable? : Bool = true,
+  side? : PopupSide = Top,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  show_arrow? : Bool = true,
+  trigger_variant? : ButtonVariant = Ghost,
+  trigger_size? : ButtonSize = Default,
+  on_open_change? : @cmd.Emit[Bool],
+  on_trigger_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  arrow_attrs? : @html.Attrs,
+  arrow_style? : Array[String] = [],
+  trigger : T,
+  content : C,
+) -> @rabbita.Val[@html.Html] {
+  let initial_open = default_open && !disabled
+  let initial_model : TooltipModel = {
+    open: initial_open,
+    trigger_hovered: false,
+    trigger_focused: false,
+    content_hovered: false,
+    generation: 0,
+  }
+  let (model, _) = @rabbita.create_state_with_init(
+    init=emit => {
+      let sync = emit.map(value => TooltipNativeChanged(value))
+      (
+        initial_model,
+        @cmd.batch([
+          floating_bind_sync_cmd(id, sync),
+          tooltip_bind_events_cmd(id, emit),
+          if initial_open {
+            floating_set_open_cmd(id, true)
+          } else {
+            @cmd.none
+          },
+        ]),
+      )
+    },
+    update=(emit, msg, current) => {
+      tooltip_update(id, close_on_click, on_open_change, emit, msg, current)
+    },
+  )
+  model.view(model => {
+    render_tooltip(
+      id,
+      model.open,
+      disabled,
+      delay,
+      close_delay,
+      close_on_click,
+      hoverable,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      show_arrow,
+      trigger_variant,
+      trigger_size,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      arrow_attrs,
+      arrow_style,
+      on_trigger_click,
+      trigger,
+      content,
+    )
+  })
+}
+
+///|
+/// Native/SSR fallback: render the requested initial state. Browser event and
+/// top-layer behavior is enabled by the JavaScript target.
+#cfg(not(target="js"))
+pub fn[T : @html.IsChildren, C : @html.IsChildren] tooltip(
+  id~ : String,
+  default_open? : Bool = false,
+  disabled? : Bool = false,
+  delay? : Int,
+  close_delay? : Int,
+  close_on_click? : Bool = true,
+  hoverable? : Bool = true,
+  side? : PopupSide = Top,
+  align? : PopupAlign = Center,
+  side_offset? : Int = 4,
+  align_offset? : Int = 0,
+  show_arrow? : Bool = true,
+  trigger_variant? : ButtonVariant = Ghost,
+  trigger_size? : ButtonSize = Default,
+  on_open_change? : @cmd.Emit[Bool],
+  on_trigger_click? : @cmd.Cmd,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  trigger_attrs? : @html.Attrs,
+  trigger_style? : Array[String] = [],
+  content_attrs? : @html.Attrs,
+  content_style? : Array[String] = [],
+  arrow_attrs? : @html.Attrs,
+  arrow_style? : Array[String] = [],
+  trigger : T,
+  content : C,
+) -> @rabbita.Val[@html.Html] {
+  ignore(on_open_change)
+  @rabbita.Val::constant(
+    render_tooltip(
+      id,
+      default_open && !disabled,
+      disabled,
+      delay,
+      close_delay,
+      close_on_click,
+      hoverable,
+      side,
+      align,
+      side_offset,
+      align_offset,
+      show_arrow,
+      trigger_variant,
+      trigger_size,
+      attrs,
+      style,
+      trigger_attrs,
+      trigger_style,
+      content_attrs,
+      content_style,
+      arrow_attrs,
+      arrow_style,
+      on_trigger_click,
+      trigger,
+      content,
+    ),
+  )
+}

--- a/rui/tooltip_hover_wbtest.mbt
+++ b/rui/tooltip_hover_wbtest.mbt
@@ -1,0 +1,426 @@
+///|
+#cfg(target="js")
+extern "js" fn ffi_install_late_mount_fixture(id : String) -> Unit =
+  #| id => {
+  #|   const keys = [
+  #|     "window", "document", "CSS", "EventTarget", "Node", "Element",
+  #|     "HTMLElement", "HTMLDialogElement", "Document", "Window", "Event",
+  #|     "MouseEvent", "KeyboardEvent", "FocusEvent", "ToggleEvent",
+  #|     "TransitionEvent",
+  #|   ]
+  #|   const globals = new Map(keys.map(key => [key, {
+  #|     had: Object.prototype.hasOwnProperty.call(globalThis, key),
+  #|     value: globalThis[key],
+  #|   }]))
+  #|   const frameQueue = []
+  #|   class FakeEventTarget {
+  #|     constructor() { this.listeners = new Map() }
+  #|     addEventListener(type, callback, options = {}) {
+  #|       const listeners = this.listeners.get(type) ?? []
+  #|       listeners.push({ callback, once: Boolean(options?.once) })
+  #|       this.listeners.set(type, listeners)
+  #|     }
+  #|     removeEventListener(type, callback) {
+  #|       this.listeners.set(
+  #|         type,
+  #|         (this.listeners.get(type) ?? []).filter(item => item.callback !== callback),
+  #|       )
+  #|     }
+  #|     dispatchEvent(event) {
+  #|       if (!(event instanceof FakeEvent)) throw new TypeError("Event required")
+  #|       if (!event.target) event.target = this
+  #|       event.currentTarget = this
+  #|       const listeners = [...(this.listeners.get(event.type) ?? [])]
+  #|       for (const item of listeners) {
+  #|         item.callback(event)
+  #|         if (item.once) this.removeEventListener(event.type, item.callback)
+  #|         if (event.immediatePropagationStopped) break
+  #|       }
+  #|       event.currentTarget = null
+  #|       return !event.defaultPrevented
+  #|     }
+  #|   }
+  #|   class FakeNode extends FakeEventTarget {
+  #|     constructor(nodeType) {
+  #|       super()
+  #|       this.nodeType = nodeType
+  #|       this.parentNode = null
+  #|       this.isConnected = true
+  #|     }
+  #|     contains(node) {
+  #|       for (let current = node; current; current = current.parentNode) {
+  #|         if (current === this) return true
+  #|       }
+  #|       return false
+  #|     }
+  #|   }
+  #|   class FakeStyle {
+  #|     constructor() {
+  #|       this.values = new Map([
+  #|         ["position-area", "bottom center"],
+  #|         ["position-try-fallbacks", "--rui-flip-block"],
+  #|       ])
+  #|     }
+  #|     getPropertyValue(name) { return this.values.get(name) ?? "" }
+  #|     setProperty(name, value) { this.values.set(name, String(value)) }
+  #|     removeProperty(name) {
+  #|       const previous = this.getPropertyValue(name)
+  #|       this.values.delete(name)
+  #|       return previous
+  #|     }
+  #|   }
+  #|   class FakeElement extends FakeNode {
+  #|     constructor(id, attributes = {}) {
+  #|       super(1)
+  #|       this.id = id
+  #|       this.attributes = new Map()
+  #|       this.children = []
+  #|       this.parentElement = null
+  #|       this.style = new FakeStyle()
+  #|       this.clientWidth = 0
+  #|       this.clientHeight = 0
+  #|       this.focusVisible = true
+  #|       for (const [name, value] of Object.entries(attributes)) {
+  #|         this.setAttribute(name, value)
+  #|       }
+  #|     }
+  #|     setAttribute(name, value) { this.attributes.set(name, String(value)) }
+  #|     getAttribute(name) {
+  #|       if (name === "id") return this.id
+  #|       return this.attributes.get(name) ?? ""
+  #|     }
+  #|     hasAttribute(name) { return this.attributes.has(name) }
+  #|     removeAttribute(name) { this.attributes.delete(name) }
+  #|     append(child) {
+  #|       child.parentNode = this
+  #|       child.parentElement = this
+  #|       this.children.push(child)
+  #|     }
+  #|     matches(selector) {
+  #|       if (selector === ":focus-visible") return this.focusVisible
+  #|       if (selector === ":popover-open") return Boolean(this.popoverOpen)
+  #|       const slot = selector.match(/^\[data-slot="([^"]+)"\]$/)?.[1]
+  #|       return slot ? this.getAttribute("data-slot") === slot : false
+  #|     }
+  #|     closest(selector) {
+  #|       for (let current = this; current; current = current.parentElement) {
+  #|         if (current.matches(selector)) return current
+  #|       }
+  #|       return null
+  #|     }
+  #|     querySelectorAll(selector) {
+  #|       const result = []
+  #|       const visit = element => {
+  #|         for (const child of element.children) {
+  #|           if (child.matches(selector)) result.push(child)
+  #|           visit(child)
+  #|         }
+  #|       }
+  #|       visit(this)
+  #|       return result
+  #|     }
+  #|     querySelector(selector) { return this.querySelectorAll(selector)[0] ?? null }
+  #|     getBoundingClientRect() {
+  #|       return this.rect ?? {
+  #|         left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0,
+  #|       }
+  #|     }
+  #|   }
+  #|   class FakeHTMLElement extends FakeElement {
+  #|     constructor(id, attributes = {}) {
+  #|       super(id, attributes)
+  #|       this.popover = null
+  #|       this.popoverOpen = false
+  #|       this.offsetWidth = 0
+  #|       this.offsetHeight = 0
+  #|     }
+  #|     focus() {}
+  #|     showPopover() {
+  #|       if (this.popoverOpen) return
+  #|       this.popoverOpen = true
+  #|       this.dispatchEvent(new FakeToggleEvent("toggle", {
+  #|         oldState: "closed", newState: "open",
+  #|       }))
+  #|     }
+  #|     hidePopover() {
+  #|       if (!this.popoverOpen) return
+  #|       this.popoverOpen = false
+  #|       this.dispatchEvent(new FakeToggleEvent("toggle", {
+  #|         oldState: "open", newState: "closed",
+  #|       }))
+  #|     }
+  #|   }
+  #|   class FakeHTMLDialogElement extends FakeHTMLElement {}
+  #|   class FakeEvent {
+  #|     constructor(type, init = {}) {
+  #|       this.type = type
+  #|       this.bubbles = Boolean(init.bubbles)
+  #|       this.cancelable = Boolean(init.cancelable)
+  #|       this.composed = Boolean(init.composed)
+  #|       this.defaultPrevented = false
+  #|       this.propagationStopped = false
+  #|       this.immediatePropagationStopped = false
+  #|       this.target = init.target ?? null
+  #|       this.currentTarget = null
+  #|       this.timeStamp = 0
+  #|     }
+  #|     preventDefault() { if (this.cancelable) this.defaultPrevented = true }
+  #|     stopPropagation() { this.propagationStopped = true }
+  #|     stopImmediatePropagation() {
+  #|       this.immediatePropagationStopped = true
+  #|       this.propagationStopped = true
+  #|     }
+  #|     composedPath() { return this.target ? [this.target] : [] }
+  #|   }
+  #|   class FakeMouseEvent extends FakeEvent {}
+  #|   class FakeKeyboardEvent extends FakeEvent {
+  #|     constructor(type, init = {}) { super(type, init); this.key = init.key ?? "" }
+  #|   }
+  #|   class FakeFocusEvent extends FakeEvent {
+  #|     constructor(type, init = {}) {
+  #|       super(type, init)
+  #|       this.relatedTarget = init.relatedTarget ?? null
+  #|     }
+  #|   }
+  #|   class FakeToggleEvent extends FakeEvent {
+  #|     constructor(type, init = {}) {
+  #|       super(type, init)
+  #|       this.oldState = init.oldState ?? "closed"
+  #|       this.newState = init.newState ?? "closed"
+  #|     }
+  #|   }
+  #|   class FakeTransitionEvent extends FakeEvent {}
+  #|   class FakeDocument extends FakeNode {
+  #|     constructor() {
+  #|       super(9)
+  #|       this.body = new FakeHTMLElement("body")
+  #|       this.documentElement = new FakeHTMLElement("html")
+  #|       this.documentElement.clientWidth = 1024
+  #|       this.documentElement.clientHeight = 768
+  #|       this.activeElement = this.body
+  #|     }
+  #|     getElementById(value) {
+  #|       if (value === id + "-root") return fixture.phase >= 1 ? root : null
+  #|       if (value === id + "-trigger") return fixture.phase >= 2 ? trigger : null
+  #|       if (value === id) return fixture.phase >= 2 ? popup : null
+  #|       return null
+  #|     }
+  #|   }
+  #|   class FakeWindow extends FakeEventTarget {
+  #|     constructor() {
+  #|       super()
+  #|       this.performance = { now: () => 0 }
+  #|       this.visualViewport = null
+  #|     }
+  #|     requestAnimationFrame(callback) {
+  #|       frameQueue.push(callback)
+  #|       return frameQueue.length
+  #|     }
+  #|     cancelAnimationFrame() {}
+  #|     queueMicrotask(callback) { callback() }
+  #|     getComputedStyle(element) { return element.style }
+  #|   }
+  #|   const root = new FakeHTMLElement(id + "-root", {
+  #|     "data-delay": "17",
+  #|     "data-close-delay": "7",
+  #|     "data-close-on-click": "true",
+  #|     "data-hoverable": "true",
+  #|     "data-open-delay": "23",
+  #|   })
+  #|   const trigger = new FakeHTMLElement(id + "-trigger", {
+  #|     "data-delay": "23", "data-close-delay": "11",
+  #|   })
+  #|   trigger.rect = {
+  #|     left: 20, right: 100, top: 20, bottom: 44, width: 80, height: 24,
+  #|   }
+  #|   const popup = new FakeHTMLElement(id, {
+  #|     "data-slot": "tooltip-content",
+  #|     "data-restore-focus": "false",
+  #|     "data-trigger-id": id + "-trigger",
+  #|   })
+  #|   popup.popover = "manual"
+  #|   popup.rect = {
+  #|     left: 0, right: 120, top: 0, bottom: 48, width: 120, height: 48,
+  #|   }
+  #|   root.append(trigger)
+  #|   root.append(popup)
+  #|   let fixture
+  #|   const document = new FakeDocument()
+  #|   const window = new FakeWindow()
+  #|   window.document = document
+  #|   fixture = globalThis.__ruiLateMountFixture = {
+  #|     globals, phase: 0, root, trigger, popup, frameQueue, window,
+  #|   }
+  #|   Object.assign(globalThis, {
+  #|     window, document, CSS: { supports: () => true },
+  #|     EventTarget: FakeEventTarget, Node: FakeNode, Element: FakeElement,
+  #|     HTMLElement: FakeHTMLElement, HTMLDialogElement: FakeHTMLDialogElement,
+  #|     Document: FakeDocument, Window: FakeWindow, Event: FakeEvent,
+  #|     MouseEvent: FakeMouseEvent, KeyboardEvent: FakeKeyboardEvent,
+  #|     FocusEvent: FakeFocusEvent, ToggleEvent: FakeToggleEvent,
+  #|     TransitionEvent: FakeTransitionEvent,
+  #|   })
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_mount_late_root_and_advance_frame() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiLateMountFixture
+  #|   fixture.phase = 1
+  #|   fixture.frameQueue.shift()?.(0)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_flush_late_mount_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiLateMountFixture
+  #|   fixture.phase = 2
+  #|   while (fixture.frameQueue.length) fixture.frameQueue.shift()(0)
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_fire_late_mount_mouseenter() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiLateMountFixture
+  #|   fixture.trigger.dispatchEvent(new MouseEvent("mouseenter"))
+  #| }
+
+///|
+#cfg(target="js")
+extern "js" fn ffi_restore_late_mount_fixture() -> Unit =
+  #| () => {
+  #|   const fixture = globalThis.__ruiLateMountFixture
+  #|   if (!fixture) return
+  #|   fixture.root.isConnected = false
+  #|   fixture.trigger.isConnected = false
+  #|   fixture.popup.isConnected = false
+  #|   for (const [key, saved] of fixture.globals) {
+  #|     if (saved.had) globalThis[key] = saved.value
+  #|     else delete globalThis[key]
+  #|   }
+  #|   delete globalThis.__ruiLateMountFixture
+  #| }
+
+///|
+#cfg(target="js")
+fn late_tooltip_bound(id : String) -> Bool {
+  tooltip_live_binding(id) is Some(_)
+}
+
+///|
+#cfg(target="js")
+fn late_hover_card_bound(id : String) -> Bool {
+  hover_card_event_bindings.get(id) is Some(_)
+}
+
+///|
+#cfg(target="js")
+fn late_floating_bound(id : String) -> Bool {
+  floating_live_layer(id) is Some(_)
+}
+
+///|
+#cfg(target="js")
+fn late_floating_open(id : String) -> Bool {
+  if floating_live_layer(id) is Some(layer) {
+    floating_layer_is_open(layer)
+  } else {
+    false
+  }
+}
+
+///|
+#cfg(target="js")
+fn reset_late_mount_bindings(id : String) -> Unit {
+  if tooltip_event_bindings.get(id) is Some(binding) &&
+    binding.sidebar_observer.val is Some(observer) {
+    observer.disconnect()
+  }
+  ignore(tooltip_event_bindings.remove(id))
+  ignore(hover_card_event_bindings.remove(id))
+  if floating_live_layer(id) is Some(_) {
+    ignore(set_floating_open(id, false))
+  }
+  floating_stop(id)
+  ignore(floating_layers.remove(id))
+  floating_update_stack(id, false)
+}
+
+///|
+#cfg(target="js")
+test "tooltip events and native sync bind after delayed mount" {
+  let kind = Ref(-1)
+  let wait = Ref(-1)
+  ffi_install_late_mount_fixture("late-tooltip")
+  ui_after_ready("tooltip-events:late-tooltip", () => {
+    bind_tooltip_events("late-tooltip", (next_kind, next_wait) => {
+      kind.val = next_kind
+      wait.val = next_wait
+    })
+  })
+  ui_after_mount("late-tooltip", () => {
+    bind_floating_sync("late-tooltip", _ => ())
+  })
+  let bound_before_mount = late_tooltip_bound("late-tooltip")
+  ffi_mount_late_root_and_advance_frame()
+  let bound_with_only_root = late_tooltip_bound("late-tooltip")
+  ffi_flush_late_mount_fixture()
+  ffi_fire_late_mount_mouseenter()
+  let bound = late_tooltip_bound("late-tooltip")
+  let floating_bound = late_floating_bound("late-tooltip")
+  reset_late_mount_bindings("late-tooltip")
+  ffi_restore_late_mount_fixture()
+  assert_true(!bound_before_mount)
+  assert_true(!bound_with_only_root)
+  assert_true(bound)
+  assert_true(floating_bound)
+  assert_eq(kind.val, 0)
+  assert_eq(wait.val, 17)
+}
+
+///|
+#cfg(target="js")
+test "hover card events bind after delayed mount" {
+  let kind = Ref(-1)
+  let wait = Ref(-1)
+  ffi_install_late_mount_fixture("late-hover-card")
+  ui_after_ready("hover-card-events:late-hover-card", () => {
+    bind_hover_card_events("late-hover-card", (next_kind, next_wait) => {
+      kind.val = next_kind
+      wait.val = next_wait
+    })
+  })
+  let bound_before_mount = late_hover_card_bound("late-hover-card")
+  ffi_mount_late_root_and_advance_frame()
+  let bound_with_only_root = late_hover_card_bound("late-hover-card")
+  ffi_flush_late_mount_fixture()
+  ffi_fire_late_mount_mouseenter()
+  let bound = late_hover_card_bound("late-hover-card")
+  reset_late_mount_bindings("late-hover-card")
+  ffi_restore_late_mount_fixture()
+  assert_true(!bound_before_mount)
+  assert_true(!bound_with_only_root)
+  assert_true(bound)
+  assert_eq(kind.val, 0)
+  assert_eq(wait.val, 23)
+}
+
+///|
+#cfg(target="js")
+test "floating default-open waits for its delayed popup mount" {
+  ffi_install_late_mount_fixture("late-default-open")
+  floating_set_open_when_ready("late-default-open", true)
+  let open_before_mount = late_floating_open("late-default-open")
+  ffi_mount_late_root_and_advance_frame()
+  let open_with_only_root = late_floating_open("late-default-open")
+  ffi_flush_late_mount_fixture()
+  let open = late_floating_open("late-default-open")
+  reset_late_mount_bindings("late-default-open")
+  ffi_restore_late_mount_fixture()
+  assert_true(!open_before_mount)
+  assert_true(!open_with_only_root)
+  assert_true(open)
+}

--- a/rui/tooltip_state_wbtest.mbt
+++ b/rui/tooltip_state_wbtest.mbt
@@ -1,0 +1,113 @@
+///|
+#cfg(target="js")
+fn tooltip_test_model(open : Bool) -> TooltipModel {
+  {
+    open,
+    trigger_hovered: false,
+    trigger_focused: false,
+    content_hovered: false,
+    generation: 0,
+  }
+}
+
+///|
+#cfg(target="js")
+fn tooltip_test_update(
+  current : TooltipModel,
+  message : TooltipMsg,
+  close_on_click? : Bool = true,
+) -> TooltipModel {
+  let (next, _) = tooltip_update(
+    "test-tooltip",
+    close_on_click,
+    None,
+    @cmd.Emit(_ => @cmd.none),
+    message,
+    current,
+  )
+  next
+}
+
+///|
+#cfg(target="js")
+test "tooltip stale delayed open is cancelled when pointer leaves" {
+  let waiting = tooltip_test_update(
+    tooltip_test_model(false),
+    TooltipDomEvent(0, 100),
+  )
+  assert_true(waiting.trigger_hovered)
+  assert_true(!waiting.open)
+  let generation = waiting.generation
+  let left = tooltip_test_update(waiting, TooltipDomEvent(1, 0))
+  assert_true(!left.trigger_hovered)
+  assert_true(left.generation > generation)
+  let stale = tooltip_test_update(left, TooltipOpenAfter(generation))
+  assert_true(!stale.open)
+}
+
+///|
+#cfg(target="js")
+test "tooltip focus and hoverable content independently keep it open" {
+  let focused = tooltip_test_update(
+    tooltip_test_model(false),
+    TooltipDomEvent(2, 0),
+  )
+  assert_true(focused.open)
+  assert_true(focused.trigger_focused)
+  let pointer_left = tooltip_test_update(focused, TooltipDomEvent(1, 0))
+  assert_true(pointer_left.open)
+  let blurred = tooltip_test_update(pointer_left, TooltipDomEvent(3, 0))
+  assert_true(!blurred.open)
+
+  let hovering_trigger : TooltipModel = {
+    ..tooltip_test_model(true),
+    trigger_hovered: true,
+  }
+  let waiting_close = tooltip_test_update(
+    hovering_trigger,
+    TooltipDomEvent(1, 80),
+  )
+  let closing_generation = waiting_close.generation
+  let hovering_content = tooltip_test_update(
+    waiting_close,
+    TooltipDomEvent(5, 0),
+  )
+  let stale_close = tooltip_test_update(
+    hovering_content,
+    TooltipCloseAfter(closing_generation),
+  )
+  assert_true(stale_close.open)
+  assert_true(stale_close.content_hovered)
+  let content_left = tooltip_test_update(stale_close, TooltipDomEvent(6, 0))
+  assert_true(!content_left.open)
+}
+
+///|
+#cfg(target="js")
+test "tooltip click policy and native close reset every active source" {
+  let active : TooltipModel = {
+    open: true,
+    trigger_hovered: true,
+    trigger_focused: true,
+    content_hovered: true,
+    generation: 7,
+  }
+  let retained = tooltip_test_update(
+    active,
+    TooltipDomEvent(4, 0),
+    close_on_click=false,
+  )
+  assert_true(retained.open)
+  assert_true(retained.trigger_hovered)
+  let dismissed = tooltip_test_update(active, TooltipDomEvent(4, 0))
+  assert_true(!dismissed.open)
+  assert_true(!dismissed.trigger_hovered)
+  assert_true(!dismissed.trigger_focused)
+  assert_true(!dismissed.content_hovered)
+  let native_closed = tooltip_test_update(active, TooltipNativeChanged(false))
+  assert_true(!native_closed.open)
+  assert_true(!native_closed.trigger_hovered)
+  assert_true(!native_closed.trigger_focused)
+  assert_true(!native_closed.content_hovered)
+  assert_eq(native_closed.generation, 8)
+}

--- a/rui/typography.mbt
+++ b/rui/typography.mbt
@@ -1,0 +1,340 @@
+///|
+const TypographyH1Style : String = "margin:0;scroll-margin-top:5rem;font-size:2.25rem;line-height:2.5rem;font-weight:800;letter-spacing:-0.025em;text-align:center;text-wrap:balance"
+
+///|
+const TypographyH2Style : String = "margin:0;scroll-margin-top:5rem;border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));padding-bottom:0.5rem;font-size:1.875rem;line-height:2.25rem;font-weight:600;letter-spacing:-0.025em"
+
+///|
+const TypographyH3Style : String = "margin:0;scroll-margin-top:5rem;font-size:1.5rem;line-height:2rem;font-weight:600;letter-spacing:-0.025em"
+
+///|
+const TypographyH4Style : String = "margin:0;scroll-margin-top:5rem;font-size:1.25rem;line-height:1.75rem;font-weight:600;letter-spacing:-0.025em"
+
+///|
+const TypographyPStyle : String = "margin:0;line-height:1.75rem"
+
+///|
+const TypographyBlockquoteStyle : String = "margin:1.5rem 0 0;border-inline-start:2px solid var(--rui-border,oklch(0.922 0 0));padding-inline-start:1.5rem;font-style:italic"
+
+///|
+const TypographyListStyle : String = "margin-block:1.5rem;margin-inline:1.5rem 0;padding:0;list-style-position:outside;list-style-type:disc"
+
+///|
+const TypographyInlineCodeStyle : String = "position:relative;border-radius:calc(var(--rui-radius,0.625rem) - 0.25rem);background:var(--rui-muted,oklch(0.97 0 0));padding:0.2rem 0.3rem;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\"Liberation Mono\",\"Courier New\",monospace;font-size:0.875rem;line-height:1.25rem;font-weight:600"
+
+///|
+const TypographyLeadStyle : String = "margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:1.25rem;line-height:1.75rem"
+
+///|
+const TypographyLargeStyle : String = "font-size:1.125rem;line-height:1.75rem;font-weight:600"
+
+///|
+const TypographySmallStyle : String = "font-size:0.875rem;line-height:1;font-weight:500"
+
+///|
+const TypographyMutedStyle : String = "margin:0;color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:0.875rem;line-height:1.25rem"
+
+///|
+fn typography_attrs(attrs : @html.Attrs?, slot : String) -> @html.Attrs {
+  ui_attrs(attrs).data_set("slot", slot)
+}
+
+///|
+/// Render the Vega display heading recipe as a semantic `h1`.
+pub fn[C : @html.IsChildren] typography_h1(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.h1(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyH1Style],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-h1"),
+    children,
+  )
+}
+
+///|
+/// Render the Vega section heading recipe as a semantic `h2`.
+pub fn[C : @html.IsChildren] typography_h2(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.h2(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyH2Style],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-h2"),
+    children,
+  )
+}
+
+///|
+/// Render the Vega subsection heading recipe as a semantic `h3`.
+pub fn[C : @html.IsChildren] typography_h3(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.h3(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyH3Style],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-h3"),
+    children,
+  )
+}
+
+///|
+/// Render the Vega compact heading recipe as a semantic `h4`.
+pub fn[C : @html.IsChildren] typography_h4(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.h4(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyH4Style],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-h4"),
+    children,
+  )
+}
+
+///|
+/// Render a readable body paragraph.
+pub fn[C : @html.IsChildren] typography_p(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyPStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-p"),
+    children,
+  )
+}
+
+///|
+/// Render the Vega quotation recipe as a semantic `blockquote`.
+pub fn[C : @html.IsChildren] typography_blockquote(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.blockquote(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyBlockquoteStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-blockquote"),
+    children,
+  )
+}
+
+///|
+/// Render the Vega bulleted-list recipe as a semantic `ul`.
+pub fn[C : @html.IsChildren] typography_list(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.ul(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyListStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-list"),
+    children,
+  )
+}
+
+///|
+/// Render a short inline code fragment.
+pub fn[C : @html.IsChildren] typography_inline_code(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.code(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyInlineCodeStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-inline-code"),
+    children,
+  )
+}
+
+///|
+/// Render introductory copy with the Vega lead treatment.
+pub fn[C : @html.IsChildren] typography_lead(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyLeadStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-lead"),
+    children,
+  )
+}
+
+///|
+/// Render emphasized large text without adding heading semantics.
+pub fn[C : @html.IsChildren] typography_large(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.div(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyLargeStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-large"),
+    children,
+  )
+}
+
+///|
+/// Render compact supporting copy using the semantic `small` element.
+pub fn[C : @html.IsChildren] typography_small(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.small(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographySmallStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-small"),
+    children,
+  )
+}
+
+///|
+/// Render subdued helper copy.
+pub fn[C : @html.IsChildren] typography_muted(
+  id? : String,
+  class? : String,
+  title? : String,
+  hidden? : Bool,
+  attrs? : @html.Attrs,
+  style? : Array[String] = [],
+  children : C,
+) -> @html.Html {
+  @html.p(
+    style=ui_styles(
+      [UiBoxSizing, UiFontSans, UiTextRendering, TypographyMutedStyle],
+      style,
+    ),
+    id?,
+    class?,
+    title?,
+    hidden?,
+    attrs=typography_attrs(attrs, "typography-muted"),
+    children,
+  )
+}

--- a/rui/typography_test.mbt
+++ b/rui/typography_test.mbt
@@ -1,0 +1,67 @@
+///|
+test "typography wrappers keep their semantic elements and Vega recipes" {
+  let html = render(
+    @html.div([
+      @rui.typography_h1("Heading one"),
+      @rui.typography_h2("Heading two"),
+      @rui.typography_h3("Heading three"),
+      @rui.typography_h4("Heading four"),
+      @rui.typography_p("Body copy"),
+      @rui.typography_blockquote("Quoted copy"),
+      @rui.typography_list([@html.li("First"), @html.li("Second")]),
+      @rui.typography_inline_code("let answer = 42"),
+      @rui.typography_lead("Lead copy"),
+      @rui.typography_large("Large copy"),
+      @rui.typography_small("Small copy"),
+      @rui.typography_muted("Muted copy"),
+    ]),
+  )
+  assert_contains(html, "<h1 data-slot=\"typography-h1\"")
+  assert_contains(html, "<h2 data-slot=\"typography-h2\"")
+  assert_contains(html, "<h3 data-slot=\"typography-h3\"")
+  assert_contains(html, "<h4 data-slot=\"typography-h4\"")
+  assert_contains(html, "<p data-slot=\"typography-p\"")
+  assert_contains(html, "<blockquote data-slot=\"typography-blockquote\"")
+  assert_contains(html, "<ul data-slot=\"typography-list\"")
+  assert_contains(html, "<code data-slot=\"typography-inline-code\"")
+  assert_contains(html, "<p data-slot=\"typography-lead\"")
+  assert_contains(html, "<div data-slot=\"typography-large\"")
+  assert_contains(html, "<small data-slot=\"typography-small\"")
+  assert_contains(html, "<p data-slot=\"typography-muted\"")
+  assert_contains(html, "font-size:2.25rem;line-height:2.5rem;font-weight:800")
+  assert_contains(
+    html, "border-bottom:1px solid var(--rui-border,oklch(0.922 0 0));padding-bottom:0.5rem",
+  )
+  assert_contains(html, "border-inline-start:2px solid var(--rui-border")
+  assert_contains(html, "background:var(--rui-muted,oklch(0.97 0 0))")
+  assert_contains(
+    html, "color:var(--rui-muted-foreground,oklch(0.556 0 0));font-size:1.25rem",
+  )
+}
+
+///|
+test "typography appends caller styles and does not mutate caller attrs" {
+  let attrs = @html.Attrs::build().data_set("owner", "caller")
+  let html = render(
+    @rui.typography_h2(
+      attrs~,
+      id="custom-heading",
+      class="heading",
+      hidden=true,
+      style=["border-bottom:0", "color:rebeccapurple"],
+      "Custom",
+    ),
+  )
+  assert_contains(html, "data-owner=\"caller\"")
+  assert_contains(html, "data-slot=\"typography-h2\"")
+  assert_contains(html, "id=\"custom-heading\"")
+  assert_contains(html, "class=\"heading\"")
+  assert_contains(html, "hidden")
+  assert_contains(
+    html, "letter-spacing:-0.025em;border-bottom:0;color:rebeccapurple",
+  )
+
+  let original = render(@html.div(attrs~, @html.nothing))
+  assert_contains(original, "data-owner=\"caller\"")
+  assert_not_contains(original, "data-slot")
+}

--- a/utils/shiki/pkg.generated.mbti
+++ b/utils/shiki/pkg.generated.mbti
@@ -9,7 +9,11 @@ import {
 // Values
 pub fn initialize(langs~ : Array[String], themes~ : Array[String]) -> Unit
 
+pub async fn initialize_static(langs~ : Array[String], themes~ : Array[String]) -> Unit
+
 pub fn shiki_code(@rabbita.Val[String], lang~ : @rabbita.Val[String], theme~ : @rabbita.Val[String]) -> @rabbita.Val[@html.Html]
+
+pub fn static_code(String, lang~ : String, light_theme~ : String, dark_theme~ : String) -> @html.Html
 
 // Errors
 

--- a/utils/shiki/shiki.mbt
+++ b/utils/shiki/shiki.mbt
@@ -57,6 +57,145 @@ extern "js" fn code_to_html(
   #| }
 
 ///|
+extern "js" fn install_static_code_element(highlighter : @js.Value) -> Unit =
+  #| highlighter => {
+  #|   if (!globalThis.customElements) return
+  #|   const stateKey = Symbol.for('yoorkin.shiki.static-code')
+  #|   const state = globalThis[stateKey] ??= {
+  #|     highlighter,
+  #|     observer: null,
+  #|     pending: new Set(),
+  #|     scheduled: false,
+  #|   }
+  #|   state.highlighter = highlighter
+  #|
+  #|   const styles = `
+  #|     :host { display: block; min-width: 0; }
+  #|     .shiki {
+  #|       box-sizing: border-box;
+  #|       min-width: max-content;
+  #|       margin: 0;
+  #|       background: transparent !important;
+  #|       padding: var(--yoorkin-shiki-padding, 1.125rem 0);
+  #|       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  #|       font-size: var(--yoorkin-shiki-font-size, 0.8125rem);
+  #|       line-height: var(--yoorkin-shiki-line-height, 1.75);
+  #|       tab-size: 2;
+  #|       white-space: pre;
+  #|     }
+  #|     code { display: grid; counter-reset: yoorkin-shiki-line; }
+  #|     .line {
+  #|       display: block;
+  #|       min-height: 1lh;
+  #|       padding: 0 4rem 0 0;
+  #|       counter-increment: yoorkin-shiki-line;
+  #|     }
+  #|     .line::before {
+  #|       content: counter(yoorkin-shiki-line);
+  #|       display: inline-block;
+  #|       box-sizing: border-box;
+  #|       width: 4rem;
+  #|       padding-right: 1.5rem;
+  #|       color: var(--rui-muted-foreground, currentColor);
+  #|       text-align: right;
+  #|       opacity: 0.65;
+  #|       user-select: none;
+  #|     }
+  #|   `
+  #|
+  #|   const highlight = element => {
+  #|     if (!element.isConnected) return
+  #|     const lang = element.dataset.lang || ''
+  #|     const lightTheme = element.dataset.lightTheme || ''
+  #|     const darkTheme = element.dataset.darkTheme || ''
+  #|     const code = (element.textContent || '').replace(/\r?\n$/, '')
+  #|     const sourceKey = `${lang}\0${lightTheme}\0${darkTheme}\0${code}`
+  #|     if (
+  #|       element.dataset.shikiHighlighted !== undefined &&
+  #|       element.__yoorkinShikiSourceKey === sourceKey
+  #|     ) return
+  #|     try {
+  #|       const html = state.highlighter.codeToHtml(code, {
+  #|         lang,
+  #|         themes: { light: lightTheme, dark: darkTheme },
+  #|         defaultColor: 'light-dark()',
+  #|       })
+  #|       const shadow = element.shadowRoot || element.attachShadow({ mode: 'open' })
+  #|       shadow.innerHTML = `<style>${styles}</style>${html}`
+  #|       element.__yoorkinShikiSourceKey = sourceKey
+  #|       element.dataset.shikiHighlighted = ''
+  #|     } catch (error) {
+  #|       console.warn(
+  #|         `[shiki] dual-theme highlight failed: lang=${lang}, themes=${lightTheme}/${darkTheme}`,
+  #|         error,
+  #|       )
+  #|     }
+  #|   }
+  #|
+  #|   const schedule = element => {
+  #|     state.pending.add(element)
+  #|     if (state.scheduled) return
+  #|     state.scheduled = true
+  #|     const run = deadline => {
+  #|       state.scheduled = false
+  #|       for (const pending of state.pending) {
+  #|         state.pending.delete(pending)
+  #|         highlight(pending)
+  #|         if (!deadline.didTimeout && deadline.timeRemaining() < 4) break
+  #|       }
+  #|       if (state.pending.size > 0) schedule(state.pending.values().next().value)
+  #|     }
+  #|     if (globalThis.requestIdleCallback) {
+  #|       globalThis.requestIdleCallback(run, { timeout: 250 })
+  #|     } else {
+  #|       globalThis.setTimeout(() => run({ didTimeout: true, timeRemaining: () => 0 }), 0)
+  #|     }
+  #|   }
+  #|
+  #|   if (!state.observer && globalThis.IntersectionObserver) {
+  #|     state.observer = new IntersectionObserver(entries => {
+  #|       for (const entry of entries) {
+  #|         if (!entry.isIntersecting) continue
+  #|         state.observer.unobserve(entry.target)
+  #|         schedule(entry.target)
+  #|       }
+  #|     }, { rootMargin: '900px 0px' })
+  #|   }
+  #|
+  #|   if (!customElements.get('yoorkin-shiki-code')) {
+  #|     customElements.define('yoorkin-shiki-code', class extends HTMLElement {
+  #|       static get observedAttributes() {
+  #|         return ['data-lang', 'data-light-theme', 'data-dark-theme']
+  #|       }
+  #|
+  #|       connectedCallback() {
+  #|         if (!this.__yoorkinShikiObserver) {
+  #|           this.__yoorkinShikiObserver = new MutationObserver(() => highlight(this))
+  #|           this.__yoorkinShikiObserver.observe(this, {
+  #|             childList: true,
+  #|             characterData: true,
+  #|             subtree: true,
+  #|           })
+  #|         }
+  #|         if (state.observer) state.observer.observe(this)
+  #|         else schedule(this)
+  #|       }
+  #|
+  #|       attributeChangedCallback(_name, previous, next) {
+  #|         if (this.isConnected && previous !== next) highlight(this)
+  #|       }
+  #|
+  #|       disconnectedCallback() {
+  #|         state.observer?.unobserve(this)
+  #|         state.pending.delete(this)
+  #|         this.__yoorkinShikiObserver?.disconnect()
+  #|         this.__yoorkinShikiObserver = null
+  #|       }
+  #|     })
+  #|   }
+  #| }
+
+///|
 using @rabbita {type Cmd}
 
 ///|
@@ -122,10 +261,76 @@ pub fn initialize(langs~ : Array[String], themes~ : Array[String]) -> Unit {
       for theme in themes {
         singleton.loaded_themes.add(theme)
       }
+      install_static_code_element(singleton.highlighter)
     } catch {
       e => println(e)
     }
   })
+}
+
+///|
+/// Load a reusable Shiki highlighter before constructing static HTML.
+///
+/// This is useful for renderers whose component tree must stay synchronous:
+/// await this once at the application boundary, then call `static_code` from
+/// any number of otherwise ordinary `Html` functions.
+pub async fn initialize_static(
+  langs~ : Array[String],
+  themes~ : Array[String],
+) -> Unit {
+  let singleton = match global_shiki_hl.val {
+    Some(s) => s
+    None => {
+      let highlighter = load_shiki().wait()
+      guard is_highlighter(highlighter) else {
+        fail("shiki highlighter init failed: invalid object")
+      }
+      let singleton = {
+        highlighter,
+        loaded_langs: Set([]),
+        loaded_themes: Set([]),
+        config: None,
+      }
+      global_shiki_hl.val = Some(singleton)
+      singleton
+    }
+  }
+  try load_langs(singleton.highlighter, langs).wait() |> ignore catch {
+    e => fail("shiki load langs failed: \{e}")
+  }
+  for lang in langs {
+    singleton.loaded_langs.add(lang)
+  }
+  try load_themes(singleton.highlighter, themes).wait() |> ignore catch {
+    e => fail("shiki load themes failed: \{e}")
+  }
+  for theme in themes {
+    singleton.loaded_themes.add(theme)
+  }
+  install_static_code_element(singleton.highlighter)
+}
+
+///|
+/// Render source with two preloaded Shiki themes. The generated foreground
+/// colors use CSS `light-dark()`, so a containing `color-scheme` switch updates
+/// existing code blocks without rebuilding the Rabbita tree.
+#warnings("-alert_xss_vulnerable")
+pub fn static_code(
+  code : String,
+  lang~ : String,
+  light_theme~ : String,
+  dark_theme~ : String,
+) -> @html.Html {
+  let attrs = @html.Attrs::build()
+    .data_set("shiki-code", "")
+    .data_set("lang", lang)
+    .data_set("light-theme", light_theme)
+    .data_set("dark-theme", dark_theme)
+  @html.node(
+    "yoorkin-shiki-code",
+    attrs,
+    @html.pre(@html.code(@html.text(code))),
+  )
 }
 
 ///|

--- a/utils/shiki/shiki_test.mbt
+++ b/utils/shiki/shiki_test.mbt
@@ -1,0 +1,25 @@
+///|
+#warnings("-alert_unstable")
+test "static code keeps an escaped fallback before preload" {
+  let html = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      static_code(
+        "fn main { println(\"<ready>\") }",
+        lang="moonbit",
+        light_theme="github-light",
+        dark_theme="github-dark-default",
+      ),
+    )
+  })
+  for
+    expected in [
+      "<yoorkin-shiki-code", "data-lang=\"moonbit\"", "data-light-theme=\"github-light\"",
+      "data-dark-theme=\"github-dark-default\"", "&lt;ready&gt;",
+    ] {
+    if !html.contains(expected) {
+      fail(
+        "expected static Shiki fallback to contain `\{expected}`; got `\{html}`",
+      )
+    }
+  }
+}

--- a/website/homepage/README.md
+++ b/website/homepage/README.md
@@ -16,6 +16,8 @@ moon run --target native scripts/assets.mbtx
 warren dev main --public-dir public
 ```
 
+The component showcase is served by the same application at `/components/`.
+
 ## Build
 
 ```sh

--- a/website/homepage/components/calendar_showcase.mbt
+++ b/website/homepage/components/calendar_showcase.mbt
@@ -1,0 +1,116 @@
+///|
+const CalendarShowcaseSingleCode : String =
+  #|@rui.calendar(
+  #|  id="forms-gallery-calendar-single",
+  #|  default_month=@rui.calendar_date(year=2026, month=7, day=1),
+  #|  default_selected=@rui.calendar_date(year=2026, month=7, day=15),
+  #|  today=@rui.calendar_date(year=2026, month=7, day=16),
+  #|  aria_label="Choose a launch date",
+  #|  style=["margin-inline:auto"],
+  #|)
+  #|
+
+///|
+const CalendarShowcaseRangeCode : String =
+  #|@rui.calendar_range(
+  #|  id="forms-gallery-calendar-range",
+  #|  default_month=@rui.calendar_date(year=2026, month=7, day=1),
+  #|  default_selected=@rui.date_range(
+  #|    start=@rui.calendar_date(year=2026, month=7, day=10),
+  #|    end=@rui.calendar_date(year=2026, month=7, day=17),
+  #|  ),
+  #|  today=@rui.calendar_date(year=2026, month=7, day=16),
+  #|  aria_label="Choose a release window",
+  #|  style=["margin-inline:auto"],
+  #|)
+  #|
+
+///|
+const CalendarShowcaseMultipleCode : String =
+  #|@rui.calendar_multiple(
+  #|  id="forms-gallery-calendar-multiple",
+  #|  default_month=@rui.calendar_date(year=2026, month=7, day=1),
+  #|  default_selected=[
+  #|    @rui.calendar_date(year=2026, month=7, day=8),
+  #|    @rui.calendar_date(year=2026, month=7, day=16),
+  #|    @rui.calendar_date(year=2026, month=7, day=23),
+  #|  ],
+  #|  today=@rui.calendar_date(year=2026, month=7, day=16),
+  #|  aria_label="Choose available dates",
+  #|  style=["margin-inline:auto"],
+  #|)
+  #|
+
+///|
+fn calendar_showcase() -> @rabbita.Val[@html.Html] {
+  let today = @rui.calendar_date(year=2026, month=7, day=16)
+  let single = @rui.calendar(
+    id="forms-gallery-calendar-single",
+    default_month=@rui.calendar_date(year=2026, month=7, day=1),
+    default_selected=@rui.calendar_date(year=2026, month=7, day=15),
+    today~,
+    aria_label="Choose a launch date",
+    style=["margin-inline:auto"],
+  )
+  let range = @rui.calendar_range(
+    id="forms-gallery-calendar-range",
+    default_month=@rui.calendar_date(year=2026, month=7, day=1),
+    default_selected=@rui.date_range(
+      start=@rui.calendar_date(year=2026, month=7, day=10),
+      end=@rui.calendar_date(year=2026, month=7, day=17),
+    ),
+    today~,
+    aria_label="Choose a release window",
+    style=["margin-inline:auto"],
+  )
+  let multiple = @rui.calendar_multiple(
+    id="forms-gallery-calendar-multiple",
+    default_month=@rui.calendar_date(year=2026, month=7, day=1),
+    default_selected=[
+      @rui.calendar_date(year=2026, month=7, day=8),
+      today,
+      @rui.calendar_date(year=2026, month=7, day=23),
+    ],
+    today~,
+    aria_label="Choose available dates",
+    style=["margin-inline:auto"],
+  )
+  single.view3(range, multiple, (single, range, multiple) => {
+    showcase_component_demos(
+      "Calendar",
+      "Single, range, and multiple selection keep month navigation, keyboard focus, and selected values inside the component.",
+      [
+        showcase_demo_section(
+          "Single selection",
+          "Choose one date while the calendar owns its visible month and selection.",
+          showcase_demo_stage(
+            single,
+            CalendarShowcaseSingleCode,
+            variant=ShowcaseStageSurface,
+            tall=true,
+          ),
+        ),
+        showcase_demo_section(
+          "Range selection",
+          "The first activation starts a range; the second completes and normalizes it.",
+          showcase_demo_stage(
+            range,
+            CalendarShowcaseRangeCode,
+            variant=ShowcaseStageSurface,
+            tall=true,
+          ),
+        ),
+        showcase_demo_section(
+          "Multiple selection",
+          "Toggle independent dates without moving the selection state into the showcase.",
+          showcase_demo_stage(
+            multiple,
+            CalendarShowcaseMultipleCode,
+            variant=ShowcaseStageSurface,
+            tall=true,
+          ),
+        ),
+      ],
+    )
+  })
+}

--- a/website/homepage/components/date_picker_showcase.mbt
+++ b/website/homepage/components/date_picker_showcase.mbt
@@ -1,0 +1,250 @@
+///|
+const DatePickerShowcaseGroupStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.625rem"
+
+///|
+const DatePickerShowcaseSingleCode : String =
+  #|fn single_date_picker_demo() -> @rabbita.Val[@html.Html] {
+  #|  let today = @rui.calendar_date(year=2026, month=7, day=16)
+  #|  let picker = @rui.date_picker(
+  #|    id="forms-gallery-date-picker-single",
+  #|    default_value=today,
+  #|    today~,
+  #|    presets=[
+  #|      @rui.date_picker_preset(label="Today", value=today),
+  #|      @rui.date_picker_preset(
+  #|        label="Tomorrow",
+  #|        value=@rui.calendar_date(year=2026, month=7, day=17),
+  #|      ),
+  #|      @rui.date_picker_preset(
+  #|        label="Next week",
+  #|        value=@rui.calendar_date(year=2026, month=7, day=23),
+  #|      ),
+  #|      @rui.date_picker_preset(
+  #|        label="Release",
+  #|        value=@rui.calendar_date(year=2026, month=8, day=4),
+  #|      ),
+  #|    ],
+  #|    trigger_style=["width:100%"],
+  #|  )
+  #|  picker.view(picker => {
+  #|    @html.div(style=["width:min(100%,22rem);margin-inline:auto"], [
+  #|      @html.div(
+  #|        style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|        [
+  #|          @rui.label(
+  #|            for_="forms-gallery-date-picker-single-trigger",
+  #|            "Release date",
+  #|          ),
+  #|          picker,
+  #|        ],
+  #|      ),
+  #|    ])
+  #|  })
+  #|}
+  #|
+
+///|
+const DatePickerShowcaseRangeCode : String =
+  #|fn date_range_picker_demo() -> @rabbita.Val[@html.Html] {
+  #|  let picker = @rui.date_range_picker(
+  #|    id="forms-gallery-date-picker-range",
+  #|    default_value=@rui.date_range(
+  #|      start=@rui.calendar_date(year=2026, month=7, day=20),
+  #|      end=@rui.calendar_date(year=2026, month=8, day=9),
+  #|    ),
+  #|    today=@rui.calendar_date(year=2026, month=7, day=16),
+  #|    trigger_style=["width:100%"],
+  #|  )
+  #|  picker.view(picker => {
+  #|    @html.div(style=["width:min(100%,22rem);margin-inline:auto"], [
+  #|      @html.div(
+  #|        style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|        [
+  #|          @rui.label(
+  #|            for_="forms-gallery-date-picker-range-trigger",
+  #|            "Release window",
+  #|          ),
+  #|          picker,
+  #|        ],
+  #|      ),
+  #|    ])
+  #|  })
+  #|}
+  #|
+
+///|
+const DatePickerShowcaseDisabledCode : String =
+  #|fn disabled_date_picker_demo() -> @rabbita.Val[@html.Html] {
+  #|  let disabled = @rui.date_picker(
+  #|    id="forms-gallery-date-picker-disabled",
+  #|    disabled=true,
+  #|    placeholder="No dates available",
+  #|    trigger_style=["width:100%"],
+  #|  )
+  #|  disabled.view(disabled => {
+  #|    @html.div(
+  #|      style=["width:min(100%,22rem);margin-inline:auto"],
+  #|      @html.div(
+  #|        style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|        [
+  #|          @rui.label(
+  #|            for_="forms-gallery-date-picker-disabled-trigger",
+  #|            "Disabled",
+  #|          ),
+  #|          disabled,
+  #|        ],
+  #|      ),
+  #|    )
+  #|  })
+  #|}
+  #|
+
+///|
+const DatePickerShowcaseInvalidCode : String =
+  #|fn invalid_date_picker_demo() -> @rabbita.Val[@html.Html] {
+  #|  let invalid = @rui.date_picker(
+  #|    id="forms-gallery-date-picker-invalid",
+  #|    invalid=true,
+  #|    placeholder="Required date",
+  #|    trigger_style=["width:100%"],
+  #|  )
+  #|  invalid.view(invalid => {
+  #|    @html.div(
+  #|      style=["width:min(100%,22rem);margin-inline:auto"],
+  #|      @html.div(
+  #|        style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|        [
+  #|          @rui.label(
+  #|            for_="forms-gallery-date-picker-invalid-trigger",
+  #|            "Invalid",
+  #|          ),
+  #|          invalid,
+  #|        ],
+  #|      ),
+  #|    )
+  #|  })
+  #|}
+  #|
+
+///|
+fn date_picker_showcase_group(
+  label : String,
+  trigger_id : String,
+  picker : @html.Html,
+) -> @html.Html {
+  @html.div(style=[DatePickerShowcaseGroupStyle], [
+    @rui.label(for_=trigger_id, label),
+    picker,
+  ])
+}
+
+///|
+fn date_picker_showcase() -> @rabbita.Val[@html.Html] {
+  let today = @rui.calendar_date(year=2026, month=7, day=16)
+  let single = @rui.date_picker(
+    id="forms-gallery-date-picker-single",
+    default_value=today,
+    today~,
+    presets=[
+      @rui.date_picker_preset(label="Today", value=today),
+      @rui.date_picker_preset(
+        label="Tomorrow",
+        value=@rui.calendar_date(year=2026, month=7, day=17),
+      ),
+      @rui.date_picker_preset(
+        label="Next week",
+        value=@rui.calendar_date(year=2026, month=7, day=23),
+      ),
+      @rui.date_picker_preset(
+        label="Release",
+        value=@rui.calendar_date(year=2026, month=8, day=4),
+      ),
+    ],
+    trigger_style=["width:100%"],
+  )
+  let range = @rui.date_range_picker(
+    id="forms-gallery-date-picker-range",
+    default_value=@rui.date_range(
+      start=@rui.calendar_date(year=2026, month=7, day=20),
+      end=@rui.calendar_date(year=2026, month=8, day=9),
+    ),
+    today~,
+    trigger_style=["width:100%"],
+  )
+  let disabled = @rui.date_picker(
+    id="forms-gallery-date-picker-disabled",
+    disabled=true,
+    placeholder="No dates available",
+    trigger_style=["width:100%"],
+  )
+  let invalid = @rui.date_picker(
+    id="forms-gallery-date-picker-invalid",
+    invalid=true,
+    placeholder="Required date",
+    trigger_style=["width:100%"],
+  )
+  single.view4(range, disabled, invalid, (single, range, disabled, invalid) => {
+    showcase_component_demos(
+      "Date Picker",
+      "Single dates, presets, and ranges own their popup and calendar state. Disabled and invalid variants keep the same public API.",
+      [
+        showcase_demo_section(
+          "Single date with presets",
+          "Preset actions and the calendar share one component-owned value and popup.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,22rem);margin-inline:auto"],
+              date_picker_showcase_group(
+                "Release date", "forms-gallery-date-picker-single-trigger", single,
+              ),
+            ),
+            DatePickerShowcaseSingleCode,
+            tall=true,
+          ),
+        ),
+        showcase_demo_section(
+          "Date range",
+          "Two activations produce a normalized start and end while the trigger remains black-box.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,22rem);margin-inline:auto"],
+              date_picker_showcase_group(
+                "Release window", "forms-gallery-date-picker-range-trigger", range,
+              ),
+            ),
+            DatePickerShowcaseRangeCode,
+            tall=true,
+          ),
+        ),
+        showcase_demo_section(
+          "Disabled",
+          "The unavailable picker keeps the same trigger geometry while leaving the tab order.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,22rem);margin-inline:auto"],
+              date_picker_showcase_group(
+                "Disabled", "forms-gallery-date-picker-disabled-trigger", disabled,
+              ),
+            ),
+            DatePickerShowcaseDisabledCode,
+            variant=ShowcaseStagePlain,
+          ),
+        ),
+        showcase_demo_section(
+          "Invalid",
+          "Validation treatment keeps the date picker interactive and its popup component-owned.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,22rem);margin-inline:auto"],
+              date_picker_showcase_group(
+                "Invalid", "forms-gallery-date-picker-invalid-trigger", invalid,
+              ),
+            ),
+            DatePickerShowcaseInvalidCode,
+            variant=ShowcaseStagePlain,
+          ),
+        ),
+      ],
+    )
+  })
+}

--- a/website/homepage/components/forms_gallery.mbt
+++ b/website/homepage/components/forms_gallery.mbt
@@ -1,0 +1,786 @@
+///|
+const FormsGallerySectionStyle : String = "grid-column:1 / -1;display:flex;min-width:0;flex-direction:column"
+
+///|
+const FormsGalleryComponentsStyle : String = "display:flex;min-width:0;flex-direction:column;gap:4rem"
+
+///|
+const FormsGalleryFormGridStyle : String = "display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,18rem),1fr));gap:1.25rem"
+
+///|
+const FormsGalleryChoiceStyle : String = "display:flex;align-items:center;gap:0.625rem"
+
+///|
+const FormsInputTextCode : String =
+  #|let (name, set_name) = @rabbita.create_variable("Ada Lovelace")
+  #|name.view(name => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input(
+  #|        id="forms-gallery-input-name",
+  #|        name="standalone-display-name",
+  #|        value=name,
+  #|        placeholder="Ada Lovelace",
+  #|        on_input=set_name.map(value => _ => value),
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsInputEmailCode : String =
+  #|let (email, set_email) = @rabbita.create_variable("ada@example.com")
+  #|email.view(email => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input(
+  #|        id="forms-gallery-input-email",
+  #|        input_type=@html.Email,
+  #|        value=email,
+  #|        invalid=email == "invalid",
+  #|        placeholder="ada@example.com",
+  #|        on_input=set_email.map(value => _ => value),
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsInputDisabledCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input(
+  #|        id="forms-gallery-input-disabled",
+  #|        value="Inherited workspace",
+  #|        disabled=true,
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsTextareaDefaultCode : String =
+  #|let (note, set_note) = @rabbita.create_variable(
+  #|  "Ship the first programmable workspace.",
+  #|)
+  #|note.view(note => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.textarea(
+  #|      id="forms-gallery-textarea-default",
+  #|      value=note,
+  #|      rows=4,
+  #|      placeholder="What should collaborators know?",
+  #|      on_input=set_note.map(value => _ => value),
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsTextareaInvalidCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.textarea(
+  #|      id="forms-gallery-textarea-invalid",
+  #|      rows=4,
+  #|      invalid=true,
+  #|      placeholder="Explain what failed…",
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsTextareaDisabledCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.textarea(
+  #|      id="forms-gallery-textarea-disabled",
+  #|      rows=4,
+  #|      value="Managed by your organization",
+  #|      disabled=true,
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsRadioHorizontalCode : String =
+  #|let (plan, set_plan) = @rabbita.create_variable("monthly")
+  #|let horizontal = @rui.radio_group(
+  #|  default_value="monthly",
+  #|  name="forms-gallery-billing",
+  #|  orientation=@rui.RadioHorizontal,
+  #|  aria_label="Billing cycle",
+  #|  on_value_change=set_plan.map(value => _ => value),
+  #|  scope => @html.div(
+  #|    style=["display:flex;flex-wrap:wrap;align-items:center;gap:0.75rem"],
+  #|    [
+  #|      @html.div(style=["display:flex;align-items:center;gap:0.625rem"], [
+  #|        @rui.radio_group_item(
+  #|          scope~,
+  #|          value="monthly",
+  #|          id="forms-gallery-monthly",
+  #|          aria_label="Monthly",
+  #|        ),
+  #|        @rui.label(for_="forms-gallery-monthly", "Monthly"),
+  #|      ]),
+  #|      @html.div(style=["display:flex;align-items:center;gap:0.625rem"], [
+  #|        @rui.radio_group_item(
+  #|          scope~,
+  #|          value="annual",
+  #|          id="forms-gallery-annual",
+  #|          aria_label="Annual",
+  #|        ),
+  #|        @rui.label(for_="forms-gallery-annual", "Annual"),
+  #|      ]),
+  #|    ],
+  #|  ),
+  #|)
+  #|plan.view2(horizontal, (plan, horizontal_html) => @html.div(
+  #|  style=["display:flex;width:min(100%,32rem);margin-inline:auto;flex-direction:column;gap:1rem"],
+  #|  [
+  #|    horizontal_html,
+  #|    @html.output(
+  #|      style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|      "Billing value: \{plan}",
+  #|    ),
+  #|  ],
+  #|))
+  #|
+
+///|
+const FormsRadioVerticalCode : String =
+  #|let vertical = @rui.radio_group(
+  #|  default_value="automatic",
+  #|  name="forms-gallery-sync",
+  #|  orientation=@rui.RadioVertical,
+  #|  aria_label="Sync strategy",
+  #|  scope => @html.div(
+  #|    style=["display:flex;flex-direction:column;gap:1rem", "gap:0.625rem"],
+  #|    [
+  #|      @html.div(style=["display:flex;align-items:center;gap:0.625rem"], [
+  #|        @rui.radio_group_item(
+  #|          scope~,
+  #|          value="automatic",
+  #|          id="forms-gallery-sync-automatic",
+  #|          aria_label="Automatic sync",
+  #|        ),
+  #|        @rui.label(for_="forms-gallery-sync-automatic", "Automatic"),
+  #|      ]),
+  #|      @html.div(style=["display:flex;align-items:center;gap:0.625rem"], [
+  #|        @rui.radio_group_item(
+  #|          scope~,
+  #|          value="manual",
+  #|          id="forms-gallery-sync-manual",
+  #|          aria_label="Manual sync",
+  #|        ),
+  #|        @rui.label(for_="forms-gallery-sync-manual", "Manual"),
+  #|      ]),
+  #|    ],
+  #|  ),
+  #|)
+  #|vertical.view(vertical_html => @html.div(
+  #|  style=["width:min(100%,32rem);margin-inline:auto"],
+  #|  vertical_html,
+  #|))
+  #|
+
+///|
+fn forms_input_component(
+  text_html : @html.Html,
+  email_html : @html.Html,
+  disabled_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Input",
+    "Text, email, validation, and disabled variants use the native input while sharing the same control surface.",
+    [
+      showcase_demo_section(
+        "Text",
+        "A parent-controlled text value remains live inside its own example.",
+        showcase_demo_stage(
+          text_html,
+          FormsInputTextCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:13rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Email",
+        "Type “invalid” to reveal validation styling without replacing native editing.",
+        showcase_demo_stage(
+          email_html,
+          FormsInputEmailCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:13rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Disabled",
+        "An inherited value stays readable but unavailable.",
+        showcase_demo_stage(
+          disabled_html,
+          FormsInputDisabledCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:13rem",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn forms_textarea_component(
+  default_html : @html.Html,
+  invalid_html : @html.Html,
+  disabled_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Textarea",
+    "Default, validation, and disabled variants preserve native multiline editing and resizing behavior.",
+    [
+      showcase_demo_section(
+        "Default",
+        "A parent-controlled launch note remains editable and resizable.",
+        showcase_demo_stage(
+          default_html,
+          FormsTextareaDefaultCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:16rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Invalid",
+        "Validation styling keeps the multiline input editable.",
+        showcase_demo_stage(
+          invalid_html,
+          FormsTextareaInvalidCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:16rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Disabled",
+        "Managed copy remains readable without becoming editable.",
+        showcase_demo_stage(
+          disabled_html,
+          FormsTextareaDisabledCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:16rem",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn forms_radio_component(
+  horizontal_html : @html.Html,
+  vertical_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Radio Group",
+    "Horizontal and vertical orientations retain component-owned selection and native radio semantics.",
+    [
+      showcase_demo_section(
+        "Horizontal",
+        "Choose a billing cycle and observe the component-owned selection value.",
+        showcase_demo_stage(
+          horizontal_html,
+          FormsRadioHorizontalCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:15rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Vertical",
+        "Stack the same native radio semantics for a sync strategy.",
+        showcase_demo_stage(
+          vertical_html,
+          FormsRadioVerticalCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:15rem",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+const FormsSliderDefaultCode : String =
+  #|let (density_value, set_density) = @rabbita.create_variable(64)
+  #|let density_slider = @rui.slider(
+  #|  id="forms-gallery-density",
+  #|  default_value=64,
+  #|  min=0,
+  #|  max=100,
+  #|  step=4,
+  #|  aria_label="Interface density",
+  #|  on_value_change=set_density.map(value => _ => value),
+  #|)
+  #|density_value.view2(density_slider, (density_value, density_html) => {
+  #|  @html.div(
+  #|    style=["display:flex;width:min(100%,32rem);margin-inline:auto;flex-direction:column;gap:1rem"],
+  #|    [
+  #|      @html.div(
+  #|        style=["display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem"],
+  #|        [
+  #|          @rui.label(for_="forms-gallery-density", "Interface density"),
+  #|          @html.output(
+  #|            style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|            "\{density_value}%",
+  #|          ),
+  #|        ],
+  #|      ),
+  #|      density_html,
+  #|    ],
+  #|  )
+  #|})
+  #|
+
+///|
+const FormsSliderRangeCode : String =
+  #|let range_slider = @rui.slider_values(
+  #|  id="forms-gallery-budget-range",
+  #|  default_values=[28, 72],
+  #|  min=0,
+  #|  max=100,
+  #|  step=4,
+  #|  large_step=12,
+  #|  min_steps_between_values=3,
+  #|  aria_label="Budget range",
+  #|)
+  #|range_slider.view(range_html => {
+  #|  @html.div(
+  #|    style=["width:min(100%,32rem);margin-inline:auto"],
+  #|    range_html,
+  #|  )
+  #|})
+  #|
+
+///|
+const FormsSliderVerticalCode : String =
+  #|let vertical_slider = @rui.slider(
+  #|  id="forms-gallery-volume",
+  #|  default_value=68,
+  #|  orientation=@rui.Vertical,
+  #|  aria_label="Preview volume",
+  #|  style=["height:10rem"],
+  #|)
+  #|vertical_slider.view(vertical_html => {
+  #|  @html.div(
+  #|    style=["display:flex;min-height:12rem;align-items:center;justify-content:center"],
+  #|    vertical_html,
+  #|  )
+  #|})
+  #|
+
+///|
+fn forms_slider_component(
+  default_html : @html.Html,
+  range_html : @html.Html,
+  vertical_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Slider",
+    "Single-value, range, and vertical controls remain independently interactive.",
+    [
+      showcase_demo_section(
+        "Default",
+        "A single thumb updates the interface density value.",
+        showcase_demo_stage(
+          default_html,
+          FormsSliderDefaultCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:15rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Range",
+        "Two constrained thumbs select a bounded budget range.",
+        showcase_demo_stage(
+          range_html,
+          FormsSliderRangeCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:15rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Vertical",
+        "The same keyboard and pointer interaction works on a vertical track.",
+        showcase_demo_stage(
+          vertical_html,
+          FormsSliderVerticalCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:20rem",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn forms_gallery() -> @rabbita.Val[@html.Html] {
+  let (form_state, set_form_state) = @rabbita.create_variable(
+    (
+      "Ada Lovelace", "ada@example.com", "analytical-engine", "Ship the first programmable workspace.",
+      false,
+    ),
+  )
+  let (input_name, set_input_name) = @rabbita.create_variable("Ada Lovelace")
+  let (input_email, set_input_email) = @rabbita.create_variable(
+    "ada@example.com",
+  )
+  let input_text_view = input_name.view(name => {
+    @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.input(
+        id="forms-gallery-input-name",
+        name="standalone-display-name",
+        value=name,
+        placeholder="Ada Lovelace",
+        on_input=set_input_name.map(value => _ => value),
+      ),
+    )
+  })
+  let input_email_view = input_email.view(email => {
+    @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.input(
+        id="forms-gallery-input-email",
+        input_type=@html.Email,
+        value=email,
+        invalid=email == "invalid",
+        placeholder="ada@example.com",
+        on_input=set_input_email.map(value => _ => value),
+      ),
+    )
+  })
+  let input_disabled = @html.div(
+    style=["width:min(100%,24rem);margin-inline:auto"],
+    @rui.input(
+      id="forms-gallery-input-disabled",
+      value="Inherited workspace",
+      disabled=true,
+    ),
+  )
+  let input_view = input_text_view.view2(input_email_view, (
+    text_html,
+    email_html,
+  ) => forms_input_component(text_html, email_html, input_disabled))
+  let (textarea_note, set_textarea_note) = @rabbita.create_variable(
+    "Ship the first programmable workspace.",
+  )
+  let textarea_view = textarea_note.view(note => {
+    let default_html = @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.textarea(
+        id="forms-gallery-textarea-default",
+        value=note,
+        rows=4,
+        placeholder="What should collaborators know?",
+        on_input=set_textarea_note.map(value => _ => value),
+      ),
+    )
+    let invalid_html = @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.textarea(
+        id="forms-gallery-textarea-invalid",
+        rows=4,
+        invalid=true,
+        placeholder="Explain what failed…",
+      ),
+    )
+    let disabled_html = @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.textarea(
+        id="forms-gallery-textarea-disabled",
+        rows=4,
+        value="Managed by your organization",
+        disabled=true,
+      ),
+    )
+    forms_textarea_component(default_html, invalid_html, disabled_html)
+  })
+  let (plan, set_plan) = @rabbita.create_variable("monthly")
+  let radio_horizontal_view = @rui.radio_group(
+    default_value="monthly",
+    name="forms-gallery-billing",
+    orientation=@rui.RadioHorizontal,
+    aria_label="Billing cycle",
+    on_value_change=set_plan.map(value => _ => value),
+    scope => {
+      @html.div(style=[RowStyle], [
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="monthly",
+            id="forms-gallery-monthly",
+            aria_label="Monthly",
+          ),
+          @rui.label(for_="forms-gallery-monthly", "Monthly"),
+        ]),
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="annual",
+            id="forms-gallery-annual",
+            aria_label="Annual",
+          ),
+          @rui.label(for_="forms-gallery-annual", "Annual"),
+        ]),
+      ])
+    },
+  )
+  let radio_vertical_view = @rui.radio_group(
+    default_value="automatic",
+    name="forms-gallery-sync",
+    orientation=@rui.RadioVertical,
+    aria_label="Sync strategy",
+    scope => {
+      @html.div(style=[StackStyle, "gap:0.625rem"], [
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="automatic",
+            id="forms-gallery-sync-automatic",
+            aria_label="Automatic sync",
+          ),
+          @rui.label(for_="forms-gallery-sync-automatic", "Automatic"),
+        ]),
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="manual",
+            id="forms-gallery-sync-manual",
+            aria_label="Manual sync",
+          ),
+          @rui.label(for_="forms-gallery-sync-manual", "Manual"),
+        ]),
+      ])
+    },
+  )
+  let radio_horizontal_stage = plan.view2(radio_horizontal_view, (
+    plan,
+    horizontal_html,
+  ) => {
+    @html.div(
+      style=[
+        "display:flex;width:min(100%,32rem);margin-inline:auto;flex-direction:column;gap:1rem",
+      ],
+      [
+        horizontal_html,
+        @html.output(style=[MutedStyle], "Billing value: \{plan}"),
+      ],
+    )
+  })
+  let radio_vertical_stage = radio_vertical_view.view(vertical_html => {
+    @html.div(style=["width:min(100%,32rem);margin-inline:auto"], vertical_html)
+  })
+  let radio_view = radio_horizontal_stage.view2(
+    radio_vertical_stage, forms_radio_component,
+  )
+  let calendar_view = calendar_showcase()
+  let date_picker_view = date_picker_showcase()
+  let dates_view = calendar_view.view2(date_picker_view, (
+    calendar_html,
+    date_picker_html,
+  ) => @html.div(style=["display:contents"], [calendar_html, date_picker_html]))
+  let (density_value, set_density) = @rabbita.create_variable(64)
+  let density_slider_view = @rui.slider(
+    id="forms-gallery-density",
+    default_value=64,
+    min=0,
+    max=100,
+    step=4,
+    aria_label="Interface density",
+    on_value_change=set_density.map(value => _ => value),
+  )
+  let range_slider_view = @rui.slider_values(
+    id="forms-gallery-budget-range",
+    default_values=[28, 72],
+    min=0,
+    max=100,
+    step=4,
+    large_step=12,
+    min_steps_between_values=3,
+    aria_label="Budget range",
+  )
+  let vertical_slider_view = @rui.slider(
+    id="forms-gallery-volume",
+    default_value=68,
+    orientation=@rui.Vertical,
+    aria_label="Preview volume",
+    style=["height:10rem"],
+  )
+  let default_slider_stage = density_value.view2(density_slider_view, (
+    density_value,
+    density_html,
+  ) => {
+    @html.div(
+      style=[
+        "display:flex;width:min(100%,32rem);margin-inline:auto;flex-direction:column;gap:1rem",
+      ],
+      [
+        @html.div(style=[ControlRowStyle], [
+          @rui.label(for_="forms-gallery-density", "Interface density"),
+          @html.output(style=[MutedStyle], "\{density_value}%"),
+        ]),
+        density_html,
+      ],
+    )
+  })
+  let range_slider_stage = range_slider_view.view(range_html => {
+    @html.div(style=["width:min(100%,32rem);margin-inline:auto"], range_html)
+  })
+  let vertical_slider_stage = vertical_slider_view.view(vertical_html => {
+    @html.div(
+      style=[
+        "display:flex;min-height:12rem;align-items:center;justify-content:center",
+      ],
+      vertical_html,
+    )
+  })
+  let slider_view = default_slider_stage.view3(
+    range_slider_stage, vertical_slider_stage, forms_slider_component,
+  )
+  let field_view = form_state.view(state => {
+    let (name, email, website, note, submitted) = state
+    let email_invalid = email == "invalid"
+    let field_composition = @rui.form(
+      id="forms-gallery-profile-form",
+      name="workspace-profile",
+      on_submit=set_form_state(state => {
+        (state.0, state.1, state.2, state.3, true)
+      }),
+      @rui.field_set([
+        @rui.field_legend("Create a workspace"),
+        @rui.field_group(style=[FormsGalleryFormGridStyle], [
+          @rui.form_field(
+            name="display-name",
+            required=true,
+            describedby="forms-gallery-name-description",
+            [
+              @rui.form_label(for_="forms-gallery-name", "Display name"),
+              @rui.form_control(
+                @rui.input(
+                  id="forms-gallery-name",
+                  name="display-name",
+                  value=name,
+                  required=true,
+                  auto_complete=@html.On,
+                  placeholder="Ada Lovelace",
+                  on_input=set_form_state.map(value => {
+                    state => (value, state.1, state.2, state.3, false)
+                  }),
+                ),
+              ),
+              @rui.form_description(
+                id="forms-gallery-name-description",
+                "Shown to collaborators across the workspace.",
+              ),
+            ],
+          ),
+          @rui.form_field(
+            name="email",
+            invalid=email_invalid,
+            required=true,
+            describedby="forms-gallery-email-description",
+            errormessage="forms-gallery-email-error",
+            [
+              @rui.form_label(for_="forms-gallery-email", "Email"),
+              @rui.form_control(
+                @rui.input(
+                  input_type=@html.Email,
+                  id="forms-gallery-email",
+                  name="email",
+                  value=email,
+                  required=true,
+                  invalid=email_invalid,
+                  auto_complete=@html.On,
+                  placeholder="ada@example.com",
+                  on_input=set_form_state.map(value => {
+                    state => (state.0, value, state.2, state.3, false)
+                  }),
+                ),
+              ),
+              @rui.form_description(
+                id="forms-gallery-email-description",
+                "Type “invalid” to preview the destructive state.",
+              ),
+              if email_invalid {
+                @rui.form_message(
+                  id="forms-gallery-email-error",
+                  "Enter a valid email address.",
+                )
+              } else {
+                @html.nothing
+              },
+            ],
+          ),
+          @rui.field([
+            @rui.field_label(for_="forms-gallery-site", "Workspace URL"),
+            @rui.input_group([
+              @rui.input_group_addon(
+                for_="forms-gallery-site",
+                @rui.input_group_text("https://"),
+              ),
+              @rui.input_group_input(
+                id="forms-gallery-site",
+                name="workspace-url",
+                value=website,
+                placeholder="project-name",
+                on_input=set_form_state.map(value => {
+                  state => (state.0, state.1, value, state.3, false)
+                }),
+              ),
+              @rui.input_group_addon(
+                align=@rui.InputInlineEnd,
+                @rui.input_group_text(".moonbit.app"),
+              ),
+            ]),
+            @rui.field_description(
+              "Input Group keeps prefixes and suffixes on one control surface.",
+            ),
+          ]),
+          @rui.field([
+            @rui.field_label(for_="forms-gallery-note", "Launch note"),
+            @rui.textarea(
+              id="forms-gallery-note",
+              name="launch-note",
+              value=note,
+              rows=4,
+              placeholder="What should collaborators know?",
+              on_input=set_form_state.map(value => {
+                state => (state.0, state.1, state.2, value, false)
+              }),
+            ),
+            @rui.field_description(
+              "Textarea remains a native, parent-controlled value.",
+            ),
+          ]),
+        ]),
+        @html.div(style=[ControlRowStyle], [
+          @html.output(
+            style=[MutedStyle],
+            if submitted {
+              "Saved locally — submit default was prevented."
+            } else {
+              "Edit a field, then submit the native form."
+            },
+          ),
+          @rui.button(type_="submit", "Save workspace"),
+        ]),
+      ]),
+    )
+    forms_field_variants(field_composition)
+  })
+  let core_view = input_view.view6(
+    textarea_view,
+    field_view,
+    radio_view,
+    slider_view,
+    dates_view,
+    (input_html, textarea_html, field_html, radio_html, slider_html, dates_html) => {
+      @html.section(id="forms-gallery", style=[FormsGallerySectionStyle], [
+        @html.div(style=[FormsGalleryComponentsStyle], [
+          input_html, textarea_html, field_html, radio_html, slider_html, dates_html,
+        ]),
+      ])
+    },
+  )
+  core_view
+}

--- a/website/homepage/components/forms_input_group_variants.mbt
+++ b/website/homepage/components/forms_input_group_variants.mbt
@@ -1,0 +1,1502 @@
+///|
+fn forms_input_group_star_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "m12 2 3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01Z",
+  )
+}
+
+///|
+fn forms_input_group_info_icon() -> @html.Html {
+  showcase_stroke_icon("M12 16v-4M12 8h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0")
+}
+
+///|
+fn forms_input_group_chevron_down_icon() -> @html.Html {
+  showcase_stroke_icon("m6 9 6 6 6-6")
+}
+
+///|
+const FormsInputGroupBasicCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-basic",
+    #|      placeholder="Search...",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-basic",
+    #|      stroke_icon("M21 21l-4.35-4.35M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0"),
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineEnd,
+    #|      for_="forms-variants-input-group-basic",
+    #|      @rui.input_group_text("12 results"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupInlineStartCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-inline-start",
+    #|      placeholder="Search...",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-inline-start",
+    #|      stroke_icon("M21 21l-4.35-4.35M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupInlineEndCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      input_type=@html.Password,
+    #|      id="forms-variants-input-group-inline-end",
+    #|      placeholder="Enter password",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineEnd,
+    #|      for_="forms-variants-input-group-inline-end",
+    #|      stroke_icon("m2 2 20 20M6.71 6.71C4.9 8.02 3.5 9.76 3 12c1.2 5.4 7.2 8.2 12.4 5.5M10.73 5.08A10.9 10.9 0 0 1 12 5c5 0 8.5 3 9 7a11.1 11.1 0 0 1-2.1 4.2M14.12 14.12A3 3 0 0 1 9.88 9.88"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupBlockStartCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-block-start",
+  #|      placeholder="Enter your name",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputBlockStart,
+  #|      for_="forms-variants-input-group-block-start",
+  #|      @rui.input_group_text("Full name"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupBlockStartTextareaCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,26rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_textarea(
+    #|      id="forms-variants-input-group-block-start-textarea",
+    #|      rows=5,
+    #|      placeholder="println(\"Hello, world!\")",
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputBlockStart, [
+    #|      @rui.input_group_text([
+    #|        stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6"),
+    #|        @html.span("script.mbt"),
+    #|      ]),
+    #|      @rui.input_group_button(
+    #|        size=@rui.InputButtonIconXs,
+    #|        title="Copy script",
+    #|        attrs=@html.Attrs::build().aria_label("Copy script"),
+    #|        style=["margin-inline-start:auto"],
+    #|        on_click=@clipboard.copy(@clipboard.Text("println(\"Hello, world!\")")),
+    #|        stroke_icon("M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2ZM4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2"),
+    #|      ),
+    #|    ]),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupBlockEndCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,26rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_textarea(
+  #|      id="forms-variants-input-group-block-end",
+  #|      rows=4,
+  #|      placeholder="Write a comment...",
+  #|    ),
+  #|    @rui.input_group_addon(align=@rui.InputBlockEnd, [
+  #|      @rui.input_group_text(style=["flex:1"], "0/280"),
+  #|      @rui.input_group_button(
+  #|        size=@rui.InputButtonSm,
+  #|        variant=@rui.Default,
+  #|        "Post",
+  #|      ),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupBlockEndInputCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-block-end-input",
+  #|      placeholder="Enter amount",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputBlockEnd,
+  #|      @rui.input_group_text("USD"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupIconSearchCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-icon-search",
+    #|      placeholder="Search...",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-icon-search",
+    #|      stroke_icon("M21 21l-4.35-4.35M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupIconEmailCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      input_type=@html.Email,
+    #|      id="forms-variants-input-group-icon-email",
+    #|      placeholder="Enter your email",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-icon-email",
+    #|      stroke_icon("m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupIconsCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-icons",
+    #|      placeholder="Card number",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-icons",
+    #|      stroke_icon("M2 10h20M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z"),
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineEnd,
+    #|      for_="forms-variants-input-group-icons",
+    #|      stroke_icon("M20 6 9 17l-5-5"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupIconMetadataCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-icon-metadata",
+    #|      placeholder="Card number",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineEnd,
+    #|      for_="forms-variants-input-group-icon-metadata",
+    #|      [
+    #|        stroke_icon("m12 2 3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01Z"),
+    #|        stroke_icon("M12 16v-4M12 8h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0"),
+    #|      ],
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupTextCurrencyCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-text-currency",
+  #|      placeholder="0.00",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineStart,
+  #|      for_="forms-variants-input-group-text-currency",
+  #|      @rui.input_group_text("$"),
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineEnd,
+  #|      for_="forms-variants-input-group-text-currency",
+  #|      @rui.input_group_text("USD"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupTextCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-text",
+  #|      placeholder="example",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineStart,
+  #|      for_="forms-variants-input-group-text",
+  #|      @rui.input_group_text("https://"),
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineEnd,
+  #|      for_="forms-variants-input-group-text",
+  #|      @rui.input_group_text(".com"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupTextUsernameCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-text-username",
+  #|      placeholder="Enter your username",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineEnd,
+  #|      for_="forms-variants-input-group-text-username",
+  #|      @rui.input_group_text("@company.com"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupTextCountCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,26rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_textarea(
+  #|      id="forms-variants-input-group-text-count",
+  #|      rows=4,
+  #|      placeholder="Enter your message",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputBlockEnd,
+  #|      @rui.input_group_text("120 characters left"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupButtonsCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-button",
+    #|      value="https://rabbit-tea.dev",
+    #|      read_only=true,
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputInlineEnd, [
+    #|      @rui.input_group_button(
+    #|        size=@rui.InputButtonIconXs,
+    #|        title="Copy URL",
+    #|        attrs=@html.Attrs::build().aria_label("Copy URL"),
+    #|        on_click=@clipboard.copy(@clipboard.Text("https://rabbit-tea.dev")),
+    #|        stroke_icon("M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2ZM4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2"),
+    #|      ),
+    #|    ]),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupConnectionButtonsCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|let info = @rui.popover(
+    #|  id="forms-variants-input-group-connection-info",
+    #|  side=@rui.Bottom,
+    #|  align=@rui.Start,
+    #|  side_offset=8,
+    #|  trigger_variant=@rui.Secondary,
+    #|  trigger_size=@rui.IconXs,
+    #|  trigger_attrs=@html.Attrs::build().aria_label("Connection information"),
+    #|  trigger_style=["border-radius:9999px"],
+    #|  stroke_icon("M12 16v-4M12 8h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0"),
+    #|  @html.div(style=["display:flex;width:16rem;flex-direction:column;gap:0.25rem"], [
+    #|    @html.strong("Your connection is not secure."),
+    #|    @html.p(
+    #|      style=["margin:0;color:var(--rui-muted-foreground);font-size:0.8125rem"],
+    #|      "Do not enter sensitive information on this site.",
+    #|    ),
+    #|  ]),
+    #|)
+    #|let favorite = @rui.toggle(
+    #|  id="forms-variants-input-group-favorite",
+    #|  size=@rui.Sm,
+    #|  aria_label="Favorite connection",
+    #|  style=["width:1.5rem;height:1.5rem;min-width:1.5rem;padding:0;border-radius:9999px"],
+    #|  stroke_icon("m12 2 3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01Z"),
+    #|)
+    #|info.view2(favorite, (info_html, favorite_html) => @html.div(
+    #|  style=["width:min(100%,26rem);margin-inline:auto"],
+    #|  @rui.input_group(style=["--rui-radius:9999px"], [
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-secure",
+    #|      value="rabbit-tea.dev",
+    #|      read_only=true,
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputInlineStart, info_html),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-secure",
+    #|      @rui.input_group_text("https://"),
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputInlineEnd, favorite_html),
+    #|  ]),
+    #|))
+    #|
+  )
+
+///|
+const FormsInputGroupSearchButtonCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-search-button",
+  #|      placeholder="Type to search...",
+  #|    ),
+  #|    @rui.input_group_addon(align=@rui.InputInlineEnd, [
+  #|      @rui.input_group_button(
+  #|        size=@rui.InputButtonXs,
+  #|        variant=@rui.Secondary,
+  #|        "Search",
+  #|      ),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupKbdCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-kbd",
+    #|      placeholder="Search...",
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineStart,
+    #|      for_="forms-variants-input-group-kbd",
+    #|      stroke_icon("M21 21l-4.35-4.35M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0"),
+    #|    ),
+    #|    @rui.input_group_addon(
+    #|      align=@rui.InputInlineEnd,
+    #|      for_="forms-variants-input-group-kbd",
+    #|      @rui.kbd("⌘K"),
+    #|    ),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupDropdownCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|let menu = @rui.dropdown_menu(id="forms-variants-input-group-dropdown-menu", scope => {
+    #|  @html.fragment([
+    #|    @rui.dropdown_menu_trigger(
+    #|      scope,
+    #|      variant=@rui.Ghost,
+    #|      size=@rui.IconXs,
+    #|      aria_label="More file actions",
+    #|      stroke_icon("M5 12h.01M12 12h.01M19 12h.01"),
+    #|    ),
+    #|    @rui.dropdown_menu_portal([
+    #|      @rui.dropdown_menu_content(scope, align=@rui.End, side_offset=8, [
+    #|        @rui.dropdown_menu_item(scope, "Settings"),
+    #|        @rui.dropdown_menu_item(scope, "Copy path"),
+    #|        @rui.dropdown_menu_item(scope, "Open location"),
+    #|      ]),
+    #|    ]),
+    #|  ])
+    #|})
+    #|menu.view(menu_html => @html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-dropdown",
+    #|      placeholder="Enter file name",
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputInlineEnd, menu_html),
+    #|  ]),
+    #|))
+    #|
+  )
+
+///|
+const FormsInputGroupDropdownQueryCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|let menu = @rui.dropdown_menu(id="forms-variants-input-group-query-menu", scope => {
+    #|  @html.fragment([
+    #|    @rui.dropdown_menu_trigger(
+    #|      scope,
+    #|      variant=@rui.Ghost,
+    #|      size=@rui.Xs,
+    #|      aria_label="Choose search scope",
+    #|      style=["gap:0.25rem;padding-inline:0.375rem;font-size:0.75rem"],
+    #|      [
+    #|        @html.span("Search in"),
+    #|        stroke_icon("m6 9 6 6 6-6"),
+    #|      ],
+    #|    ),
+    #|    @rui.dropdown_menu_portal([
+    #|      @rui.dropdown_menu_content(
+    #|        scope,
+    #|        align=@rui.End,
+    #|        side_offset=8,
+    #|        align_offset=-4,
+    #|        [
+    #|          @rui.dropdown_menu_item(scope, "Documentation"),
+    #|          @rui.dropdown_menu_item(scope, "Blog posts"),
+    #|          @rui.dropdown_menu_item(scope, "Changelog"),
+    #|        ],
+    #|      ),
+    #|    ]),
+    #|  ])
+    #|})
+    #|menu.view(menu_html => @html.div(
+    #|  style=["width:min(100%,24rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_input(
+    #|      id="forms-variants-input-group-query",
+    #|      placeholder="Enter search query",
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputInlineEnd, menu_html),
+    #|  ]),
+    #|))
+    #|
+  )
+
+///|
+const FormsInputGroupSpinnerTrailingCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-spinner-trailing",
+  #|      placeholder="Searching...",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineEnd,
+  #|      @rui.spinner(label="Searching"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupSpinnerLeadingCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-spinner-leading",
+  #|      placeholder="Processing...",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineStart,
+  #|      @rui.spinner(label="Processing"),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupLoadingCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-loading",
+  #|      placeholder="Saving changes...",
+  #|    ),
+  #|    @rui.input_group_addon(align=@rui.InputInlineEnd, [
+  #|      @rui.input_group_text("Saving..."),
+  #|      @rui.spinner(label="Saving changes"),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupSpinnerStatusCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_input(
+  #|      id="forms-variants-input-group-spinner-status",
+  #|      placeholder="Refreshing data...",
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineStart,
+  #|      @rui.spinner(label="Refreshing data"),
+  #|    ),
+  #|    @rui.input_group_addon(
+  #|      align=@rui.InputInlineEnd,
+  #|      @rui.input_group_text("Please wait..."),
+  #|    ),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsInputGroupTextareaToolbarCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|@html.div(
+    #|  style=["width:min(100%,30rem);margin-inline:auto"],
+    #|  @rui.input_group([
+    #|    @rui.input_group_textarea(
+    #|      id="forms-variants-input-group-editor",
+    #|      rows=7,
+    #|      placeholder="println(\"Hello, world!\")",
+    #|    ),
+    #|    @rui.input_group_addon(align=@rui.InputBlockStart, [
+    #|      @rui.input_group_text([
+    #|        stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6"),
+    #|        @html.span("main.mbt"),
+    #|      ]),
+    #|      @rui.input_group_button(
+    #|        size=@rui.InputButtonIconXs,
+    #|        title="Refresh",
+    #|        attrs=@html.Attrs::build().aria_label("Refresh"),
+    #|        style=["margin-inline-start:auto"],
+    #|        stroke_icon("M20 6v6h-6M4 18v-6h6M5.1 9A7 7 0 0 1 16.5 5.5L20 9M4 15l3.5 3.5A7 7 0 0 0 18.9 15"),
+    #|      ),
+    #|      @rui.input_group_button(
+    #|        size=@rui.InputButtonIconXs,
+    #|        title="Copy editor content",
+    #|        attrs=@html.Attrs::build().aria_label("Copy editor content"),
+    #|        on_click=@clipboard.copy(@clipboard.Text("println(\"Hello, world!\")")),
+    #|        stroke_icon("M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2ZM4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2"),
+    #|      ),
+    #|    ]),
+    #|    @rui.input_group_addon(align=@rui.InputBlockEnd, [
+    #|      @rui.input_group_text(style=["flex:1"], "Line 1, Column 1"),
+    #|      @rui.input_group_button(
+    #|        size=@rui.InputButtonSm,
+    #|        variant=@rui.Default,
+    #|        [@html.span("Run"), stroke_icon("M9 10 4 15l5 5M20 4v7a4 4 0 0 1-4 4H4")],
+    #|      ),
+    #|    ]),
+    #|  ]),
+    #|)
+    #|
+  )
+
+///|
+const FormsInputGroupCustomControlCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @rui.input_group([
+  #|    @rui.input_group_control(
+  #|      style=["field-sizing:content;min-height:4rem;max-height:10rem;resize:none"],
+  #|      (attrs, style) => @html.textarea(
+  #|        id="forms-variants-input-group-custom",
+  #|        rows=1,
+  #|        placeholder="Autoresize textarea...",
+  #|        attrs=attrs,
+  #|        style=style,
+  #|        ([] : Array[@html.Html]),
+  #|      ),
+  #|    ),
+  #|    @rui.input_group_addon(align=@rui.InputBlockEnd, [
+  #|      @rui.input_group_button(
+  #|        size=@rui.InputButtonSm,
+  #|        variant=@rui.Default,
+  #|        style=["margin-inline-start:auto"],
+  #|        "Submit",
+  #|      ),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|
+
+///|
+fn forms_input_group_variants() -> @rabbita.Val[@html.Html] {
+  let connection_info = @rui.popover(
+    id="forms-variants-input-group-connection-info",
+    side=@rui.Bottom,
+    align=@rui.Start,
+    side_offset=8,
+    trigger_variant=@rui.Secondary,
+    trigger_size=@rui.IconXs,
+    trigger_attrs=@html.Attrs::build().aria_label("Connection information"),
+    trigger_style=["border-radius:9999px"],
+    forms_input_group_info_icon(),
+    @html.div(
+      style=["display:flex;width:16rem;flex-direction:column;gap:0.25rem"],
+      [
+        @html.strong("Your connection is not secure."),
+        @html.p(
+          style=[
+            "margin:0;color:var(--rui-muted-foreground);font-size:0.8125rem",
+          ],
+          "Do not enter sensitive information on this site.",
+        ),
+      ],
+    ),
+  )
+  let favorite = @rui.toggle(
+    id="forms-variants-input-group-favorite",
+    size=@rui.Sm,
+    aria_label="Favorite connection",
+    style=[
+      "width:1.5rem;height:1.5rem;min-width:1.5rem;padding:0;border-radius:9999px",
+    ],
+    forms_input_group_star_icon(),
+  )
+  let dropdown = @rui.dropdown_menu(
+    id="forms-variants-input-group-dropdown-menu",
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(
+          scope,
+          variant=@rui.Ghost,
+          size=@rui.IconXs,
+          aria_label="More file actions",
+          showcase_more_horizontal_icon(),
+        ),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(scope, align=@rui.End, side_offset=8, [
+            @rui.dropdown_menu_item(scope, "Settings"),
+            @rui.dropdown_menu_item(scope, "Copy path"),
+            @rui.dropdown_menu_item(scope, "Open location"),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let query_dropdown = @rui.dropdown_menu(
+    id="forms-variants-input-group-query-menu",
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(
+          scope,
+          variant=@rui.Ghost,
+          size=@rui.Xs,
+          aria_label="Choose search scope",
+          style=["gap:0.25rem;padding-inline:0.375rem;font-size:0.75rem"],
+          [@html.span("Search in"), forms_input_group_chevron_down_icon()],
+        ),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(
+            scope,
+            align=@rui.End,
+            side_offset=8,
+            align_offset=-4,
+            [
+              @rui.dropdown_menu_item(scope, "Documentation"),
+              @rui.dropdown_menu_item(scope, "Blog posts"),
+              @rui.dropdown_menu_item(scope, "Changelog"),
+            ],
+          ),
+        ]),
+      ])
+    },
+  )
+  connection_info.view4(favorite, dropdown, query_dropdown, (
+    info_html,
+    favorite_html,
+    dropdown_html,
+    query_dropdown_html,
+  ) => {
+    showcase_component_demos(
+      "Input Group",
+      "Add-ons, text, actions, loading feedback, and custom controls share one focused control surface.",
+      [
+        showcase_demo_section(
+          "Basic",
+          "A leading search icon and trailing result count share the input surface.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-basic",
+                  placeholder="Search...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-basic",
+                  showcase_search_icon(),
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-basic",
+                  @rui.input_group_text("12 results"),
+                ),
+              ]),
+            ),
+            FormsInputGroupBasicCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Inline start",
+          "The add-on is first visually while the input remains first in focus order.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-inline-start",
+                  placeholder="Search...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-inline-start",
+                  showcase_search_icon(),
+                ),
+              ]),
+            ),
+            FormsInputGroupInlineStartCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Inline end",
+          "A trailing password affordance aligns without changing DOM order.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  input_type=@html.Password,
+                  id="forms-variants-input-group-inline-end",
+                  placeholder="Enter password",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-inline-end",
+                  showcase_eye_off_icon(),
+                ),
+              ]),
+            ),
+            FormsInputGroupInlineEndCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Block start · input",
+          "The group owns its stacked header layout without caller flex overrides.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-block-start",
+                  placeholder="Enter your name",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputBlockStart,
+                  for_="forms-variants-input-group-block-start",
+                  @rui.input_group_text("Full name"),
+                ),
+              ]),
+            ),
+            FormsInputGroupBlockStartCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Block start · textarea",
+          "A file toolbar sits above the editable source without becoming a second card.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,26rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_textarea(
+                  id="forms-variants-input-group-block-start-textarea",
+                  rows=5,
+                  placeholder="println(\"Hello, world!\")",
+                ),
+                @rui.input_group_addon(align=@rui.InputBlockStart, [
+                  @rui.input_group_text([
+                    showcase_file_icon(),
+                    @html.span("script.mbt"),
+                  ]),
+                  @rui.input_group_button(
+                    size=@rui.InputButtonIconXs,
+                    title="Copy script",
+                    attrs=@html.Attrs::build().aria_label("Copy script"),
+                    style=["margin-inline-start:auto"],
+                    on_click=@clipboard.copy(
+                      @clipboard.Text("println(\"Hello, world!\")"),
+                    ),
+                    showcase_copy_icon(),
+                  ),
+                ]),
+              ]),
+            ),
+            FormsInputGroupBlockStartTextareaCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Block end · input",
+          "A unit label occupies the full-width footer row below a compact amount input.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-block-end-input",
+                  placeholder="Enter amount",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputBlockEnd,
+                  @rui.input_group_text("USD"),
+                ),
+              ]),
+            ),
+            FormsInputGroupBlockEndInputCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Block end · textarea",
+          "A textarea footer keeps its count and action on one row.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,26rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_textarea(
+                  id="forms-variants-input-group-block-end",
+                  rows=4,
+                  placeholder="Write a comment...",
+                ),
+                @rui.input_group_addon(align=@rui.InputBlockEnd, [
+                  @rui.input_group_text(style=["flex:1"], "0/280"),
+                  @rui.input_group_button(
+                    size=@rui.InputButtonSm,
+                    variant=@rui.Default,
+                    "Post",
+                  ),
+                ]),
+              ]),
+            ),
+            FormsInputGroupBlockEndCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Icon · search",
+          "A leading search icon identifies the input without competing with its placeholder.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-icon-search",
+                  placeholder="Search...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-icon-search",
+                  showcase_search_icon(),
+                ),
+              ]),
+            ),
+            FormsInputGroupIconSearchCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Icon · email",
+          "The mail icon preserves the native email field while sharing its focus ring.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  input_type=@html.Email,
+                  id="forms-variants-input-group-icon-email",
+                  placeholder="Enter your email",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-icon-email",
+                  showcase_mail_icon(),
+                ),
+              ]),
+            ),
+            FormsInputGroupIconEmailCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Icons · card validation",
+          "Leading and trailing SVG icons communicate input type and validity.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-icons",
+                  placeholder="Card number",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-icons",
+                  showcase_credit_card_icon(),
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-icons",
+                  showcase_check_icon(),
+                ),
+              ]),
+            ),
+            FormsInputGroupIconsCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Icons · metadata",
+          "Trailing metadata icons can be grouped without creating extra focus targets.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-icon-metadata",
+                  placeholder="Card number",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-icon-metadata",
+                  [forms_input_group_star_icon(), forms_input_group_info_icon()],
+                ),
+              ]),
+            ),
+            FormsInputGroupIconMetadataCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Text · currency",
+          "Currency and unit labels frame a single amount field.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-text-currency",
+                  placeholder="0.00",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-text-currency",
+                  @rui.input_group_text("$"),
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-text-currency",
+                  @rui.input_group_text("USD"),
+                ),
+              ]),
+            ),
+            FormsInputGroupTextCurrencyCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Text · URL",
+          "Protocol and domain suffixes stay selectable as one URL control.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-text",
+                  placeholder="example",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-text",
+                  @rui.input_group_text("https://"),
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-text",
+                  @rui.input_group_text(".com"),
+                ),
+              ]),
+            ),
+            FormsInputGroupTextCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Text · username suffix",
+          "A fixed organization suffix clarifies the account name being entered.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-text-username",
+                  placeholder="Enter your username",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-text-username",
+                  @rui.input_group_text("@company.com"),
+                ),
+              ]),
+            ),
+            FormsInputGroupTextUsernameCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Text · character count",
+          "A textarea footer communicates the remaining character allowance.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,26rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_textarea(
+                  id="forms-variants-input-group-text-count",
+                  rows=4,
+                  placeholder="Enter your message",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputBlockEnd,
+                  @rui.input_group_text("120 characters left"),
+                ),
+              ]),
+            ),
+            FormsInputGroupTextCountCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Button · copy",
+          "An icon-only action uses the compact input-group button recipe.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-button",
+                  value="https://rabbit-tea.dev",
+                  read_only=true,
+                ),
+                @rui.input_group_addon(align=@rui.InputInlineEnd, [
+                  @rui.input_group_button(
+                    size=@rui.InputButtonIconXs,
+                    title="Copy URL",
+                    attrs=@html.Attrs::build().aria_label("Copy URL"),
+                    on_click=@clipboard.copy(
+                      @clipboard.Text("https://rabbit-tea.dev"),
+                    ),
+                    showcase_copy_icon(),
+                  ),
+                ]),
+              ]),
+            ),
+            FormsInputGroupButtonsCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Buttons · connection actions",
+          "Rounded info and favorite controls remain independently interactive inside the field.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,26rem);margin-inline:auto"],
+              @rui.input_group(style=["--rui-radius:9999px"], [
+                @rui.input_group_input(
+                  id="forms-variants-input-group-secure",
+                  value="rabbit-tea.dev",
+                  read_only=true,
+                ),
+                @rui.input_group_addon(align=@rui.InputInlineStart, info_html),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-secure",
+                  @rui.input_group_text("https://"),
+                ),
+                @rui.input_group_addon(align=@rui.InputInlineEnd, favorite_html),
+              ]),
+            ),
+            FormsInputGroupConnectionButtonsCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:14rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Button · search",
+          "A compact text button submits the adjacent query without leaving the control surface.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-search-button",
+                  placeholder="Type to search...",
+                ),
+                @rui.input_group_addon(align=@rui.InputInlineEnd, [
+                  @rui.input_group_button(
+                    size=@rui.InputButtonXs,
+                    variant=@rui.Secondary,
+                    "Search",
+                  ),
+                ]),
+              ]),
+            ),
+            FormsInputGroupSearchButtonCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Keyboard shortcut",
+          "The search input keeps a visible keyboard hint at its trailing edge.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-kbd",
+                  placeholder="Search...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  for_="forms-variants-input-group-kbd",
+                  showcase_search_icon(),
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  for_="forms-variants-input-group-kbd",
+                  @rui.kbd("⌘K"),
+                ),
+              ]),
+            ),
+            FormsInputGroupKbdCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Dropdown · icon trigger",
+          "A compact trailing menu keeps popup state inside Dropdown Menu.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-dropdown",
+                  placeholder="Enter file name",
+                ),
+                @rui.input_group_addon(align=@rui.InputInlineEnd, dropdown_html),
+              ]),
+            ),
+            FormsInputGroupDropdownCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:14rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Dropdown · text trigger",
+          "A labelled scope menu provides a wider target while staying inside the group.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-query",
+                  placeholder="Enter search query",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  query_dropdown_html,
+                ),
+              ]),
+            ),
+            FormsInputGroupDropdownQueryCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:14rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Spinner · trailing",
+          "A trailing spinner reports a search without displacing the input text.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-spinner-trailing",
+                  placeholder="Searching...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  @rui.spinner(label="Searching"),
+                ),
+              ]),
+            ),
+            FormsInputGroupSpinnerTrailingCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Spinner · leading",
+          "A leading spinner communicates processing before the editable value.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-spinner-leading",
+                  placeholder="Processing...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  @rui.spinner(label="Processing"),
+                ),
+              ]),
+            ),
+            FormsInputGroupSpinnerLeadingCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Spinner · status text",
+          "Status text and the animated spinner remain aligned at the end.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-loading",
+                  placeholder="Saving changes...",
+                ),
+                @rui.input_group_addon(align=@rui.InputInlineEnd, [
+                  @rui.input_group_text("Saving..."),
+                  @rui.spinner(label="Saving changes"),
+                ]),
+              ]),
+            ),
+            FormsInputGroupLoadingCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Spinner · dual status",
+          "Leading activity and trailing status text can describe one long-running operation.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_input(
+                  id="forms-variants-input-group-spinner-status",
+                  placeholder="Refreshing data...",
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineStart,
+                  @rui.spinner(label="Refreshing data"),
+                ),
+                @rui.input_group_addon(
+                  align=@rui.InputInlineEnd,
+                  @rui.input_group_text("Please wait..."),
+                ),
+              ]),
+            ),
+            FormsInputGroupSpinnerStatusCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:12rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Textarea toolbar",
+          "A code textarea owns separate file and action toolbars.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,30rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_textarea(
+                  id="forms-variants-input-group-editor",
+                  rows=7,
+                  placeholder="println(\"Hello, world!\")",
+                ),
+                @rui.input_group_addon(align=@rui.InputBlockStart, [
+                  @rui.input_group_text([
+                    showcase_file_icon(),
+                    @html.span("main.mbt"),
+                  ]),
+                  @rui.input_group_button(
+                    size=@rui.InputButtonIconXs,
+                    title="Refresh",
+                    attrs=@html.Attrs::build().aria_label("Refresh"),
+                    style=["margin-inline-start:auto"],
+                    showcase_refresh_icon(),
+                  ),
+                  @rui.input_group_button(
+                    size=@rui.InputButtonIconXs,
+                    title="Copy editor content",
+                    attrs=@html.Attrs::build().aria_label("Copy editor content"),
+                    on_click=@clipboard.copy(
+                      @clipboard.Text("println(\"Hello, world!\")"),
+                    ),
+                    showcase_copy_icon(),
+                  ),
+                ]),
+                @rui.input_group_addon(align=@rui.InputBlockEnd, [
+                  @rui.input_group_text(style=["flex:1"], "Line 1, Column 1"),
+                  @rui.input_group_button(
+                    size=@rui.InputButtonSm,
+                    variant=@rui.Default,
+                    [@html.span("Run"), showcase_corner_down_left_icon()],
+                  ),
+                ]),
+              ]),
+            ),
+            FormsInputGroupTextareaToolbarCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:22rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Custom control",
+          "A native content-sized textarea joins the group through the control slot.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @rui.input_group([
+                @rui.input_group_control(
+                  style=[
+                    "field-sizing:content;min-height:4rem;max-height:10rem;resize:none",
+                  ],
+                  (attrs, style) => {
+                    @html.textarea(
+                      id="forms-variants-input-group-custom",
+                      rows=1,
+                      placeholder="Autoresize textarea...",
+                      attrs~,
+                      style~,
+                      ([] : Array[@html.Html]),
+                    )
+                  },
+                ),
+                @rui.input_group_addon(align=@rui.InputBlockEnd, [
+                  @rui.input_group_button(
+                    size=@rui.InputButtonSm,
+                    variant=@rui.Default,
+                    style=["margin-inline-start:auto"],
+                    "Submit",
+                  ),
+                ]),
+              ]),
+            ),
+            FormsInputGroupCustomControlCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+      ],
+    )
+  })
+}

--- a/website/homepage/components/forms_variants.mbt
+++ b/website/homepage/components/forms_variants.mbt
@@ -1,0 +1,2046 @@
+///|
+const FormsVariantsStackStyle : String = "display:flex;min-width:0;flex-direction:column;gap:4rem"
+
+///|
+const FormsVariantControlStyle : String = "display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"
+
+///|
+const FormsVariantColumnStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.625rem"
+
+///|
+const FormsCheckboxMixedCode : String =
+  #|let mixed = @rui.checkbox(
+  #|  id="forms-variants-checkbox-mixed",
+  #|  default_indeterminate=true,
+  #|  aria_label="Select all projects",
+  #|)
+  #|mixed.view(mixed_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|    [@rui.label(for_="forms-variants-checkbox-mixed", "All projects"), mixed_html],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsCheckboxInvalidCode : String =
+  #|let invalid = @rui.checkbox(
+  #|  id="forms-variants-checkbox-invalid",
+  #|  invalid=true,
+  #|  aria_label="Accept the workspace policy",
+  #|)
+  #|invalid.view(invalid_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|    [@rui.label(for_="forms-variants-checkbox-invalid", "Workspace policy"), invalid_html],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsCheckboxDisabledCode : String =
+  #|let disabled = @rui.checkbox(
+  #|  id="forms-variants-checkbox-disabled",
+  #|  default_checked=true,
+  #|  disabled=true,
+  #|  aria_label="Inherited organization policy",
+  #|)
+  #|disabled.view(disabled_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|    [
+  #|      @rui.label(for_="forms-variants-checkbox-disabled", disabled=true, "Organization policy"),
+  #|      disabled_html,
+  #|    ],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsSwitchDefaultCode : String =
+  #|let previews = @rui.switch(
+  #|  id="forms-variants-switch-default",
+  #|  default_checked=true,
+  #|  aria_label="Enable live previews",
+  #|)
+  #|previews.view(previews_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|    [@rui.label(for_="forms-variants-switch-default", "Live previews"), previews_html],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsSwitchSmallCode : String =
+  #|let activity = @rui.switch(
+  #|  id="forms-variants-switch-small",
+  #|  size=@rui.Sm,
+  #|  aria_label="Enable compact activity",
+  #|)
+  #|activity.view(activity_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|      [@rui.label(for_="forms-variants-switch-small", "Compact activity"), activity_html],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsSwitchInvalidCode : String =
+  #|let approval = @rui.switch(
+  #|  id="forms-variants-switch-invalid",
+  #|  invalid=true,
+  #|  aria_label="Enable required approval",
+  #|)
+  #|approval.view(approval_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|    [@rui.label(for_="forms-variants-switch-invalid", "Approval required"), approval_html],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsSwitchDisabledCode : String =
+  #|let backups = @rui.switch(
+  #|  id="forms-variants-switch-disabled",
+  #|  default_checked=true,
+  #|  disabled=true,
+  #|  aria_label="Organization-managed backups",
+  #|)
+  #|backups.view(backups_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex:1;align-items:center;justify-content:space-between;gap:1rem"],
+  #|    [
+  #|      @rui.label(for_="forms-variants-switch-disabled", disabled=true, "Managed backups"),
+  #|      backups_html,
+  #|    ],
+  #|  ),
+  #|))
+  #|
+
+///|
+const FormsComboboxMultipleCode : String =
+  #|let options = [
+  #|  @rui.combobox_option(value="moonbit", label="MoonBit"),
+  #|  @rui.combobox_option(value="rabbita", label="Rabbita"),
+  #|  @rui.combobox_option(value="typescript", label="TypeScript"),
+  #|  @rui.combobox_option(value="rust", label="Rust"),
+  #|  @rui.combobox_option(value="legacy", label="Legacy runtime", disabled=true),
+  #|]
+  #|let multiple = @rui.combobox(
+  #|  id="forms-variants-combobox-multiple",
+  #|  options=options,
+  #|  multiple=true,
+  #|  default_values=["moonbit", "rabbita"],
+  #|  placeholder="Add a runtime…",
+  #|  empty_text="No matching runtimes.",
+  #|  name="supported-runtimes",
+  #|)
+  #|multiple.view(multiple_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  multiple_html,
+  #|))
+  #|
+
+///|
+const FormsComboboxGroupedCode : String =
+  #|let options = [
+  #|  @rui.combobox_option(value="moonbit", label="MoonBit"),
+  #|  @rui.combobox_option(value="rabbita", label="Rabbita"),
+  #|  @rui.combobox_option(value="typescript", label="TypeScript"),
+  #|  @rui.combobox_option(value="rust", label="Rust"),
+  #|  @rui.combobox_option(value="legacy", label="Legacy runtime", disabled=true),
+  #|]
+  #|let grouped = @rui.combobox(
+  #|  id="forms-variants-combobox-grouped",
+  #|  options=options,
+  #|  default_value="rabbita",
+  #|  render=scope => @html.fragment([
+  #|    @rui.combobox_trigger(scope~, aria_label="Choose a runtime by group"),
+  #|    @rui.combobox_content(scope~, @rui.combobox_list([
+  #|      @rui.combobox_group(label_id="forms-variants-combobox-group-core-label", [
+  #|        @rui.combobox_label(id="forms-variants-combobox-group-core-label", "Core"),
+  #|        @rui.combobox_item(scope~, value="moonbit", "MoonBit"),
+  #|        @rui.combobox_item(scope~, value="rabbita", "Rabbita"),
+  #|      ]),
+  #|      @rui.combobox_separator(),
+  #|      @rui.combobox_group(label_id="forms-variants-combobox-group-host-label", [
+  #|        @rui.combobox_label(id="forms-variants-combobox-group-host-label", "Host languages"),
+  #|        @rui.combobox_item(scope~, value="typescript", "TypeScript"),
+  #|        @rui.combobox_item(scope~, value="rust", "Rust"),
+  #|        @rui.combobox_item(scope~, value="legacy", disabled=true, "Legacy runtime"),
+  #|      ]),
+  #|    ])),
+  #|  ]),
+  #|)
+  #|grouped.view(grouped_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  grouped_html,
+  #|))
+  #|
+
+///|
+const FormsComboboxEmptyCode : String =
+  #|let empty = @rui.combobox(
+  #|  id="forms-variants-combobox-empty",
+  #|  options=[
+  #|    @rui.combobox_option(value="alpha", label="Alpha workspace"),
+  #|    @rui.combobox_option(value="beta", label="Beta workspace"),
+  #|  ],
+  #|  placeholder="Search workspaces…",
+  #|  empty_text="No workspace matches this search.",
+  #|)
+  #|empty.view(empty_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  empty_html,
+  #|))
+  #|
+
+///|
+const FormsComboboxInvalidCode : String =
+  #|let options = [
+  #|  @rui.combobox_option(value="moonbit", label="MoonBit"),
+  #|  @rui.combobox_option(value="rabbita", label="Rabbita"),
+  #|  @rui.combobox_option(value="typescript", label="TypeScript"),
+  #|  @rui.combobox_option(value="rust", label="Rust"),
+  #|  @rui.combobox_option(value="legacy", label="Legacy runtime", disabled=true),
+  #|]
+  #|let invalid = @rui.combobox(
+  #|  id="forms-variants-combobox-invalid",
+  #|  options=options,
+  #|  placeholder="Choose a required runtime…",
+  #|  empty_text="No matching runtimes.",
+  #|  invalid=true,
+  #|  required=true,
+  #|)
+  #|invalid.view(invalid_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  invalid_html,
+  #|))
+  #|
+
+///|
+const FormsComboboxDisabledCode : String =
+  #|let options = [
+  #|  @rui.combobox_option(value="moonbit", label="MoonBit"),
+  #|  @rui.combobox_option(value="rabbita", label="Rabbita"),
+  #|  @rui.combobox_option(value="typescript", label="TypeScript"),
+  #|  @rui.combobox_option(value="rust", label="Rust"),
+  #|  @rui.combobox_option(value="legacy", label="Legacy runtime", disabled=true),
+  #|]
+  #|let disabled = @rui.combobox(
+  #|  id="forms-variants-combobox-disabled",
+  #|  options=options,
+  #|  default_value="moonbit",
+  #|  disabled=true,
+  #|)
+  #|disabled.view(disabled_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  disabled_html,
+  #|))
+  #|
+
+///|
+const FormsSelectCompoundCode : String =
+  #|let options = [
+  #|  @rui.select_option(value="iad", label="Washington, D.C."),
+  #|  @rui.select_option(value="ord", label="Chicago"),
+  #|  @rui.select_option(value="dfw", label="Dallas"),
+  #|  @rui.select_option(value="sfo", label="San Francisco"),
+  #|  @rui.select_option(value="fra", label="Frankfurt"),
+  #|  @rui.select_option(value="lhr", label="London"),
+  #|  @rui.select_option(value="sin", label="Singapore"),
+  #|  @rui.select_option(value="nrt", label="Tokyo"),
+  #|  @rui.select_option(value="syd", label="Sydney"),
+  #|  @rui.select_option(value="legacy-region", label="Legacy region", disabled=true),
+  #|]
+  #|let grouped = @rui.select(
+  #|  id="forms-variants-select-grouped",
+  #|  options=options,
+  #|  default_value="sfo",
+  #|  render=scope => @html.fragment([
+  #|    @rui.select_trigger(scope~, aria_label="Choose a deployment region"),
+  #|    @rui.select_content(scope~, style=["max-height:13rem"], [
+  #|      @rui.select_scroll_up_button(scope~, label="Scroll regions up"),
+  #|      @rui.select_group(label_id="forms-variants-select-americas-label", [
+  #|        @rui.select_label(id="forms-variants-select-americas-label", "Americas"),
+  #|        @rui.select_item(scope~, value="iad", "Washington, D.C."),
+  #|        @rui.select_item(scope~, value="ord", "Chicago"),
+  #|        @rui.select_item(scope~, value="dfw", "Dallas"),
+  #|        @rui.select_item(scope~, value="sfo", "San Francisco"),
+  #|      ]),
+  #|      @rui.select_separator(),
+  #|      @rui.select_group(label_id="forms-variants-select-emea-label", [
+  #|        @rui.select_label(id="forms-variants-select-emea-label", "Europe"),
+  #|        @rui.select_item(scope~, value="fra", "Frankfurt"),
+  #|        @rui.select_item(scope~, value="lhr", "London"),
+  #|      ]),
+  #|      @rui.select_separator(),
+  #|      @rui.select_group(label_id="forms-variants-select-apac-label", [
+  #|        @rui.select_label(id="forms-variants-select-apac-label", "Asia Pacific"),
+  #|        @rui.select_item(scope~, value="sin", "Singapore"),
+  #|        @rui.select_item(scope~, value="nrt", "Tokyo"),
+  #|        @rui.select_item(scope~, value="syd", "Sydney"),
+  #|        @rui.select_item(scope~, value="legacy-region", disabled=true, "Legacy region"),
+  #|      ]),
+  #|      @rui.select_scroll_down_button(scope~, label="Scroll regions down"),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|grouped.view(grouped_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  grouped_html,
+  #|))
+  #|
+
+///|
+const FormsSelectInvalidCode : String =
+  #|let options = [
+  #|  @rui.select_option(value="iad", label="Washington, D.C."),
+  #|  @rui.select_option(value="ord", label="Chicago"),
+  #|  @rui.select_option(value="dfw", label="Dallas"),
+  #|  @rui.select_option(value="sfo", label="San Francisco"),
+  #|  @rui.select_option(value="fra", label="Frankfurt"),
+  #|  @rui.select_option(value="lhr", label="London"),
+  #|  @rui.select_option(value="sin", label="Singapore"),
+  #|  @rui.select_option(value="nrt", label="Tokyo"),
+  #|  @rui.select_option(value="syd", label="Sydney"),
+  #|  @rui.select_option(value="legacy-region", label="Legacy region", disabled=true),
+  #|]
+  #|let invalid = @rui.select(
+  #|  id="forms-variants-select-invalid",
+  #|  options=options,
+  #|  placeholder="Choose a required region…",
+  #|  invalid=true,
+  #|  required=true,
+  #|)
+  #|invalid.view(invalid_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  invalid_html,
+  #|))
+  #|
+
+///|
+const FormsSelectDisabledCode : String =
+  #|let options = [
+  #|  @rui.select_option(value="iad", label="Washington, D.C."),
+  #|  @rui.select_option(value="ord", label="Chicago"),
+  #|  @rui.select_option(value="dfw", label="Dallas"),
+  #|  @rui.select_option(value="sfo", label="San Francisco"),
+  #|  @rui.select_option(value="fra", label="Frankfurt"),
+  #|  @rui.select_option(value="lhr", label="London"),
+  #|  @rui.select_option(value="sin", label="Singapore"),
+  #|  @rui.select_option(value="nrt", label="Tokyo"),
+  #|  @rui.select_option(value="syd", label="Sydney"),
+  #|  @rui.select_option(value="legacy-region", label="Legacy region", disabled=true),
+  #|]
+  #|let disabled = @rui.select(
+  #|  id="forms-variants-select-disabled",
+  #|  options=options,
+  #|  default_value="fra",
+  #|  disabled=true,
+  #|)
+  #|disabled.view(disabled_html => @html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  disabled_html,
+  #|))
+  #|
+
+///|
+const FormsFieldHorizontalCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,30rem);margin-inline:auto"],
+  #|  @rui.field(
+  #|      orientation=@rui.FieldHorizontal,
+  #|      [
+  #|        @rui.field_label(
+  #|          for_="forms-variants-field-horizontal",
+  #|          style=["width:7rem;flex:none"],
+  #|          "Project",
+  #|        ),
+  #|        @rui.field_content([
+  #|          @rui.input(id="forms-variants-field-horizontal", placeholder="rabbit-tea"),
+  #|          @rui.field_description("Used in generated workspace URLs."),
+  #|        ]),
+  #|      ],
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsFieldResponsiveCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,30rem);margin-inline:auto"],
+  #|  @rui.field(
+  #|      orientation=@rui.FieldResponsive,
+  #|      [
+  #|        @rui.field_label(for_="forms-variants-field-responsive", "Repository"),
+  #|        @rui.field_content([
+  #|          @rui.input(
+  #|            id="forms-variants-field-responsive",
+  #|            placeholder="moonbit-community/rabbita",
+  #|          ),
+  #|          @rui.field_description("Paste a repository path or URL."),
+  #|        ]),
+  #|      ],
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsFieldsetCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,34rem);margin-inline:auto"],
+  #|  @rui.field_set([
+  #|    @rui.field_legend(variant=@rui.FieldLabelLegend, "Delivery settings"),
+  #|    @rui.field_group(style=["gap:1rem"], [
+  #|      @rui.field([
+  #|        @rui.field_label(for_="forms-variants-field-region", "Region"),
+  #|        @rui.input(
+  #|          id="forms-variants-field-region",
+  #|          placeholder="Asia Pacific",
+  #|        ),
+  #|      ]),
+  #|      @rui.field([
+  #|        @rui.field_label(
+  #|          for_="forms-variants-field-channel",
+  #|          "Release channel",
+  #|        ),
+  #|        @rui.input(
+  #|          id="forms-variants-field-channel",
+  #|          placeholder="Stable",
+  #|        ),
+  #|      ]),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FormsFieldCompositionCode : String =
+  #|let (state, set_state) = @rabbita.create_variable((
+  #|  "Ada Lovelace",
+  #|  "ada@example.com",
+  #|  "analytical-engine",
+  #|  "Ship the first programmable workspace.",
+  #|  false,
+  #|))
+  #|state.view(state => {
+  #|  let (name, email, website, note, submitted) = state
+  #|  let email_invalid = email == "invalid"
+  #|  @html.div(
+  #|    style=["width:min(100%,54rem);margin-inline:auto"],
+  #|    @rui.form(
+  #|      id="forms-gallery-profile-form",
+  #|      name="workspace-profile",
+  #|      on_submit=set_state(state => (
+  #|        state.0,
+  #|        state.1,
+  #|        state.2,
+  #|        state.3,
+  #|        true,
+  #|      )),
+  #|      @rui.field_set([
+  #|        @rui.field_legend("Create a workspace"),
+  #|        @rui.field_group(
+  #|          style=["display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,18rem),1fr));gap:1.25rem"],
+  #|          [
+  #|            @rui.form_field(
+  #|              name="display-name",
+  #|              required=true,
+  #|              describedby="forms-gallery-name-description",
+  #|              [
+  #|                @rui.form_label(for_="forms-gallery-name", "Display name"),
+  #|                @rui.form_control(@rui.input(
+  #|                  id="forms-gallery-name",
+  #|                  name="display-name",
+  #|                  value=name,
+  #|                  required=true,
+  #|                  auto_complete=@html.On,
+  #|                  placeholder="Ada Lovelace",
+  #|                  on_input=set_state.map(value => state => (
+  #|                    value,
+  #|                    state.1,
+  #|                    state.2,
+  #|                    state.3,
+  #|                    false,
+  #|                  )),
+  #|                )),
+  #|                @rui.form_description(
+  #|                  id="forms-gallery-name-description",
+  #|                  "Shown to collaborators across the workspace.",
+  #|                ),
+  #|              ],
+  #|            ),
+  #|            @rui.form_field(
+  #|              name="email",
+  #|              invalid=email_invalid,
+  #|              required=true,
+  #|              describedby="forms-gallery-email-description",
+  #|              errormessage="forms-gallery-email-error",
+  #|              [
+  #|                @rui.form_label(for_="forms-gallery-email", "Email"),
+  #|                @rui.form_control(@rui.input(
+  #|                  input_type=@html.Email,
+  #|                  id="forms-gallery-email",
+  #|                  name="email",
+  #|                  value=email,
+  #|                  required=true,
+  #|                  invalid=email_invalid,
+  #|                  auto_complete=@html.On,
+  #|                  placeholder="ada@example.com",
+  #|                  on_input=set_state.map(value => state => (
+  #|                    state.0,
+  #|                    value,
+  #|                    state.2,
+  #|                    state.3,
+  #|                    false,
+  #|                  )),
+  #|                )),
+  #|                @rui.form_description(
+  #|                  id="forms-gallery-email-description",
+  #|                  "Type “invalid” to preview the destructive state.",
+  #|                ),
+  #|                if email_invalid {
+  #|                  @rui.form_message(
+  #|                    id="forms-gallery-email-error",
+  #|                    "Enter a valid email address.",
+  #|                  )
+  #|                } else {
+  #|                  @html.nothing
+  #|                },
+  #|              ],
+  #|            ),
+  #|            @rui.field([
+  #|              @rui.field_label(for_="forms-gallery-site", "Workspace URL"),
+  #|              @rui.input_group([
+  #|                @rui.input_group_addon(
+  #|                  for_="forms-gallery-site",
+  #|                  @rui.input_group_text("https://"),
+  #|                ),
+  #|                @rui.input_group_input(
+  #|                  id="forms-gallery-site",
+  #|                  name="workspace-url",
+  #|                  value=website,
+  #|                  placeholder="project-name",
+  #|                  on_input=set_state.map(value => state => (
+  #|                    state.0,
+  #|                    state.1,
+  #|                    value,
+  #|                    state.3,
+  #|                    false,
+  #|                  )),
+  #|                ),
+  #|                @rui.input_group_addon(
+  #|                  align=@rui.InputInlineEnd,
+  #|                  @rui.input_group_text(".moonbit.app"),
+  #|                ),
+  #|              ]),
+  #|              @rui.field_description(
+  #|                "Input Group keeps prefixes and suffixes on one control surface.",
+  #|              ),
+  #|            ]),
+  #|            @rui.field([
+  #|              @rui.field_label(for_="forms-gallery-note", "Launch note"),
+  #|              @rui.textarea(
+  #|                id="forms-gallery-note",
+  #|                name="launch-note",
+  #|                value=note,
+  #|                rows=4,
+  #|                placeholder="What should collaborators know?",
+  #|                on_input=set_state.map(value => state => (
+  #|                  state.0,
+  #|                  state.1,
+  #|                  state.2,
+  #|                  value,
+  #|                  false,
+  #|                )),
+  #|              ),
+  #|              @rui.field_description(
+  #|                "Textarea remains a native, parent-controlled value.",
+  #|              ),
+  #|            ]),
+  #|          ],
+  #|        ),
+  #|        @html.div(
+  #|          style=["display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem"],
+  #|          [
+  #|            @html.output(
+  #|              style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|              if submitted {
+  #|                "Saved locally — submit default was prevented."
+  #|              } else {
+  #|                "Edit a field, then submit the native form."
+  #|              },
+  #|            ),
+  #|            @rui.button(type_="submit", "Save workspace"),
+  #|          ],
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|  )
+  #|})
+  #|
+
+///|
+const FormsNativeSelectInvalidCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|      style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|      [
+  #|        @rui.label(for_="forms-variants-native-invalid", "Access level"),
+  #|        @rui.native_select(
+  #|          id="forms-variants-native-invalid",
+  #|          invalid=true,
+  #|          required=true,
+  #|          aria_label="Choose an access level",
+  #|          [
+  #|            @rui.native_select_option(value="", selected=true, "Choose access"),
+  #|            @rui.native_select_option(value="viewer", "Viewer"),
+  #|            @rui.native_select_option(value="editor", "Editor"),
+  #|          ],
+  #|        ),
+  #|      ],
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsNativeSelectDisabledCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|      style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|      [
+  #|        @rui.label(for_="forms-variants-native-disabled", disabled=true, "Environment"),
+  #|        @rui.native_select(
+  #|          id="forms-variants-native-disabled",
+  #|          disabled=true,
+  #|          aria_label="Inherited environment",
+  #|          [
+  #|            @rui.native_select_option(value="production", selected=true, "Production"),
+  #|            @rui.native_select_option(value="preview", "Preview"),
+  #|          ],
+  #|        ),
+  #|      ],
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsNativeSelectDefaultGroupsCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|      style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|      [
+  #|        @rui.label(for_="forms-variants-native-default", "Access scope"),
+  #|        @rui.native_select(id="forms-variants-native-default", [
+  #|          @rui.native_select_optgroup(label="Workspace", [
+  #|            @rui.native_select_option(value="personal", "Personal"),
+  #|            @rui.native_select_option(value="team", selected=true, "Team"),
+  #|          ]),
+  #|          @rui.native_select_optgroup(label="Advanced", [
+  #|            @rui.native_select_option(value="organization", "Organization"),
+  #|          ]),
+  #|        ]),
+  #|      ],
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsNativeSelectSmallCode : String =
+  #|@html.div(
+  #|  style=["width:min(100%,24rem);margin-inline:auto"],
+  #|  @html.div(
+  #|      style=["display:flex;min-width:0;flex-direction:column;gap:0.625rem"],
+  #|      [
+  #|        @rui.label(for_="forms-variants-native-small", "Release channel"),
+  #|        @rui.native_select(id="forms-variants-native-small", size=@rui.NativeSelectSm, [
+  #|          @rui.native_select_option(value="stable", selected=true, "Stable"),
+  #|          @rui.native_select_option(value="preview", "Preview"),
+  #|        ]),
+  #|      ],
+  #|  ),
+  #|)
+  #|
+
+///|
+const FormsOtpContinuousCode : String =
+  #|let continuous = @rui.input_otp(
+  #|  id="forms-variants-otp-continuous",
+  #|  max_length=6,
+  #|  aria_label="Verification code",
+  #|)
+  #|continuous.view(continuous_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  continuous_html,
+  #|))
+  #|
+
+///|
+const FormsOtpPatternCode : String =
+  #|let digits = @rui.input_otp(
+  #|  id="forms-variants-otp-pattern",
+  #|  max_length=6,
+  #|  pattern="[0-9]*",
+  #|  aria_label="Digits only",
+  #|)
+  #|digits.view(digits_html => @rui.field(
+  #|  style=["width:fit-content;margin-inline:auto"],
+  #|  [
+  #|    @rui.field_label(for_="forms-variants-otp-pattern", "Digits Only"),
+  #|    digits_html,
+  #|  ],
+  #|))
+  #|
+
+///|
+const FormsOtpSeparatorCode : String =
+  #|let paired = @rui.input_otp(
+  #|  id="forms-variants-otp-separator",
+  #|  max_length=6,
+  #|  aria_label="Paired verification code",
+  #|  render=scope => @html.fragment([
+  #|    @rui.input_otp_group([
+  #|      @rui.input_otp_slot(scope~, index=0),
+  #|      @rui.input_otp_slot(scope~, index=1),
+  #|    ]),
+  #|    @rui.input_otp_separator(),
+  #|    @rui.input_otp_group([
+  #|      @rui.input_otp_slot(scope~, index=2),
+  #|      @rui.input_otp_slot(scope~, index=3),
+  #|    ]),
+  #|    @rui.input_otp_separator(),
+  #|    @rui.input_otp_group([
+  #|      @rui.input_otp_slot(scope~, index=4),
+  #|      @rui.input_otp_slot(scope~, index=5),
+  #|    ]),
+  #|  ]),
+  #|)
+  #|paired.view(paired_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  paired_html,
+  #|))
+  #|
+
+///|
+const FormsOtpDefaultCode : String =
+  #|let verification = @rui.input_otp(
+  #|  id="forms-variants-otp-default",
+  #|  max_length=6,
+  #|  separator_after=3,
+  #|  aria_label="Verification code",
+  #|)
+  #|verification.view(verification_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  verification_html,
+  #|))
+  #|
+
+///|
+const FormsOtpCustomCode : String =
+  #|let recovery = @rui.input_otp(
+  #|  id="forms-variants-otp-custom",
+  #|  max_length=8,
+  #|  separator_after=4,
+  #|  aria_label="Eight-digit recovery code",
+  #|)
+  #|recovery.view(recovery_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  recovery_html,
+  #|))
+  #|
+
+///|
+const FormsOtpFourDigitsCode : String =
+  #|let pin = @rui.input_otp(
+  #|  id="forms-variants-otp-four-digits",
+  #|  max_length=4,
+  #|  pattern="[0-9]*",
+  #|  aria_label="Four-digit PIN",
+  #|)
+  #|pin.view(pin_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  pin_html,
+  #|))
+  #|
+
+///|
+const FormsOtpAlphanumericCode : String =
+  #|let code = @rui.input_otp(
+  #|  id="forms-variants-otp-alphanumeric",
+  #|  max_length=6,
+  #|  default_value="A1B2C3",
+  #|  separator_after=3,
+  #|  inputmode="text",
+  #|  pattern="[A-Za-z0-9]*",
+  #|  aria_label="Alphanumeric verification code",
+  #|)
+  #|code.view(code_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  code_html,
+  #|))
+  #|
+
+///|
+const FormsOtpInvalidCode : String =
+  #|let invalid = @rui.input_otp(
+  #|  id="forms-variants-otp-invalid",
+  #|  max_length=6,
+  #|  separator_after=3,
+  #|  invalid=true,
+  #|  aria_label="Invalid verification code",
+  #|)
+  #|invalid.view(invalid_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  invalid_html,
+  #|))
+  #|
+
+///|
+const FormsOtpDisabledCode : String =
+  #|let verified = @rui.input_otp(
+  #|  id="forms-variants-otp-disabled",
+  #|  max_length=6,
+  #|  default_value="482931",
+  #|  separator_after=3,
+  #|  disabled=true,
+  #|  aria_label="Previously verified code",
+  #|)
+  #|verified.view(verified_html => @html.div(
+  #|  style=["display:flex;justify-content:center"],
+  #|  verified_html,
+  #|))
+  #|
+
+///|
+const FormsOtpFormCode : String = FoundationsStrokeIconCode +
+  (
+    #|
+    #|let verification = @rui.input_otp(
+    #|  id="forms-variants-otp-form",
+    #|  max_length=6,
+    #|  aria_label="Verification code",
+    #|  input_attrs=@html.Attrs::build().required(true),
+    #|  render=scope => {
+    #|    let slot_style = ["width:2.75rem;height:3rem;font-size:1.25rem;line-height:1.75rem"]
+    #|    @html.fragment([
+    #|      @rui.input_otp_group([
+    #|        @rui.input_otp_slot(scope~, index=0, style=slot_style),
+    #|        @rui.input_otp_slot(scope~, index=1, style=slot_style),
+    #|        @rui.input_otp_slot(scope~, index=2, style=slot_style),
+    #|      ]),
+    #|      @rui.input_otp_separator(style=["margin-inline:0.5rem"]),
+    #|      @rui.input_otp_group([
+    #|        @rui.input_otp_slot(scope~, index=3, style=slot_style),
+    #|        @rui.input_otp_slot(scope~, index=4, style=slot_style),
+    #|        @rui.input_otp_slot(scope~, index=5, style=slot_style),
+    #|      ]),
+    #|    ])
+    #|  },
+    #|)
+    #|verification.view(verification_html => @rui.card(
+    #|  style=["width:min(100%,28rem);margin-inline:auto"],
+    #|  [
+    #|    @rui.card_header([
+    #|      @rui.card_title("Verify your login"),
+    #|      @rui.card_description([
+    #|        @html.span("Enter the verification code we sent to your email address: "),
+    #|        @html.span(style=["font-weight:500;color:var(--rui-foreground)"], "m@example.com"),
+    #|        @html.span("."),
+    #|      ]),
+    #|    ]),
+    #|    @rui.card_content(@rui.field([
+    #|      @html.div(
+    #|        style=["display:flex;align-items:center;justify-content:space-between;gap:0.75rem"],
+    #|        [
+    #|          @rui.field_label(for_="forms-variants-otp-form", "Verification code"),
+    #|          @rui.button(
+    #|            variant=@rui.Outline,
+    #|            size=@rui.Xs,
+    #|            [
+    #|              stroke_icon("M20 6v6h-6M4 18v-6h6M5.1 9A7 7 0 0 1 16.5 5.5L20 9M4 15l3.5 3.5A7 7 0 0 0 18.9 15"),
+    #|              @html.span("Resend Code"),
+    #|            ],
+    #|          ),
+    #|        ],
+    #|      ),
+    #|      verification_html,
+    #|      @rui.field_description(@html.a(
+    #|        href="#component-Input-OTP",
+    #|        style=["color:inherit;text-underline-offset:4px"],
+    #|        "I no longer have access to this email address.",
+    #|      )),
+    #|    ])),
+    #|    @rui.card_footer(
+    #|      style=["flex-direction:column;align-items:stretch;gap:0.75rem"],
+    #|      @rui.field([
+    #|        @rui.button(style=["width:100%"], "Verify"),
+    #|        @html.div(
+    #|          style=["color:var(--rui-muted-foreground);font-size:0.875rem;line-height:1.25rem;text-align:center"],
+    #|          [
+    #|            @html.span("Having trouble signing in? "),
+    #|            @html.a(
+    #|              href="#component-Input-OTP",
+    #|              style=["color:inherit;text-decoration:underline;text-underline-offset:4px"],
+    #|              "Contact support",
+    #|            ),
+    #|          ],
+    #|        ),
+    #|      ]),
+    #|    ),
+    #|  ],
+    #|))
+    #|
+  )
+
+///|
+fn forms_checkbox_variants() -> @rabbita.Val[@html.Html] {
+  let checkbox_mixed = @rui.checkbox(
+    id="forms-variants-checkbox-mixed",
+    default_indeterminate=true,
+    aria_label="Select all projects",
+  )
+  let checkbox_invalid = @rui.checkbox(
+    id="forms-variants-checkbox-invalid",
+    invalid=true,
+    aria_label="Accept the workspace policy",
+  )
+  let checkbox_disabled = @rui.checkbox(
+    id="forms-variants-checkbox-disabled",
+    default_checked=true,
+    disabled=true,
+    aria_label="Inherited organization policy",
+  )
+  checkbox_mixed.view3(checkbox_invalid, checkbox_disabled, (
+    mixed_html,
+    invalid_html,
+    disabled_html,
+  ) => {
+    showcase_component_demos(
+      "Checkbox",
+      "Mixed, validation, and managed-disabled variants keep their semantics and component-owned interaction.",
+      [
+        showcase_demo_section(
+          "Mixed",
+          "Starts indeterminate, then resolves through normal activation.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(for_="forms-variants-checkbox-mixed", "All projects"),
+                mixed_html,
+              ]),
+            ),
+            FormsCheckboxMixedCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Invalid",
+          "Validation styling leaves pointer and keyboard behavior intact.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(
+                  for_="forms-variants-checkbox-invalid",
+                  "Workspace policy",
+                ),
+                invalid_html,
+              ]),
+            ),
+            FormsCheckboxInvalidCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Disabled",
+          "A managed value remains visible without entering the tab order.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(
+                  for_="forms-variants-checkbox-disabled",
+                  disabled=true,
+                  "Organization policy",
+                ),
+                disabled_html,
+              ]),
+            ),
+            FormsCheckboxDisabledCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+      ],
+    )
+  })
+}
+
+///|
+fn forms_switch_variants() -> @rabbita.Val[@html.Html] {
+  let switch_default = @rui.switch(
+    id="forms-variants-switch-default",
+    default_checked=true,
+    aria_label="Enable live previews",
+  )
+  let switch_small = @rui.switch(
+    id="forms-variants-switch-small",
+    size=@rui.Sm,
+    aria_label="Enable compact activity",
+  )
+  let switch_invalid = @rui.switch(
+    id="forms-variants-switch-invalid",
+    invalid=true,
+    aria_label="Enable required approval",
+  )
+  let switch_disabled = @rui.switch(
+    id="forms-variants-switch-disabled",
+    default_checked=true,
+    disabled=true,
+    aria_label="Organization-managed backups",
+  )
+  switch_default.view4(switch_small, switch_invalid, switch_disabled, (
+    default_html,
+    small_html,
+    invalid_html,
+    disabled_html,
+  ) => {
+    showcase_component_demos(
+      "Switch",
+      "Default and compact sizes stay interactive; validation and managed settings use the same black-box component.",
+      [
+        showcase_demo_section(
+          "Default",
+          "The standard control for a settings row.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(
+                  for_="forms-variants-switch-default",
+                  "Live previews",
+                ),
+                default_html,
+              ]),
+            ),
+            FormsSwitchDefaultCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Small",
+          "A compact control for denser preference lists.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(
+                  for_="forms-variants-switch-small",
+                  "Compact activity",
+                ),
+                small_html,
+              ]),
+            ),
+            FormsSwitchSmallCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Invalid",
+          "Required-choice styling keeps normal switch interaction.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(
+                  for_="forms-variants-switch-invalid",
+                  "Approval required",
+                ),
+                invalid_html,
+              ]),
+            ),
+            FormsSwitchInvalidCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Disabled",
+          "The organization owns this setting.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              @html.div(style=[FormsVariantControlStyle], [
+                @rui.label(
+                  for_="forms-variants-switch-disabled",
+                  disabled=true,
+                  "Managed backups",
+                ),
+                disabled_html,
+              ]),
+            ),
+            FormsSwitchDisabledCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:13rem",
+          ),
+        ),
+      ],
+    )
+  })
+}
+
+///|
+fn forms_combobox_variants() -> @rabbita.Val[@html.Html] {
+  let framework_options = [
+    @rui.combobox_option(value="moonbit", label="MoonBit"),
+    @rui.combobox_option(value="rabbita", label="Rabbita"),
+    @rui.combobox_option(value="typescript", label="TypeScript"),
+    @rui.combobox_option(value="rust", label="Rust"),
+    @rui.combobox_option(value="legacy", label="Legacy runtime", disabled=true),
+  ]
+  let multiple = @rui.combobox(
+    id="forms-variants-combobox-multiple",
+    options=framework_options,
+    multiple=true,
+    default_values=["moonbit", "rabbita"],
+    placeholder="Add a runtime…",
+    empty_text="No matching runtimes.",
+    name="supported-runtimes",
+  )
+  let grouped = @rui.combobox(
+    id="forms-variants-combobox-grouped",
+    options=framework_options,
+    default_value="rabbita",
+    render=scope => {
+      @html.fragment([
+        @rui.combobox_trigger(scope~, aria_label="Choose a runtime by group"),
+        @rui.combobox_content(
+          scope~,
+          @rui.combobox_list([
+            @rui.combobox_group(
+              label_id="forms-variants-combobox-group-core-label",
+              [
+                @rui.combobox_label(
+                  id="forms-variants-combobox-group-core-label",
+                  "Core",
+                ),
+                @rui.combobox_item(scope~, value="moonbit", "MoonBit"),
+                @rui.combobox_item(scope~, value="rabbita", "Rabbita"),
+              ],
+            ),
+            @rui.combobox_separator(),
+            @rui.combobox_group(
+              label_id="forms-variants-combobox-group-host-label",
+              [
+                @rui.combobox_label(
+                  id="forms-variants-combobox-group-host-label",
+                  "Host languages",
+                ),
+                @rui.combobox_item(scope~, value="typescript", "TypeScript"),
+                @rui.combobox_item(scope~, value="rust", "Rust"),
+                @rui.combobox_item(
+                  scope~,
+                  value="legacy",
+                  disabled=true,
+                  "Legacy runtime",
+                ),
+              ],
+            ),
+          ]),
+        ),
+      ])
+    },
+  )
+  let empty = @rui.combobox(
+    id="forms-variants-combobox-empty",
+    options=[
+      @rui.combobox_option(value="alpha", label="Alpha workspace"),
+      @rui.combobox_option(value="beta", label="Beta workspace"),
+    ],
+    placeholder="Search workspaces…",
+    empty_text="No workspace matches this search.",
+  )
+  let invalid = @rui.combobox(
+    id="forms-variants-combobox-invalid",
+    options=framework_options,
+    placeholder="Choose a required runtime…",
+    empty_text="No matching runtimes.",
+    invalid=true,
+    required=true,
+  )
+  let disabled = @rui.combobox(
+    id="forms-variants-combobox-disabled",
+    options=framework_options,
+    default_value="moonbit",
+    disabled=true,
+  )
+  multiple.view5(grouped, empty, invalid, disabled, (
+    multiple_html,
+    grouped_html,
+    empty_html,
+    invalid_html,
+    disabled_html,
+  ) => {
+    showcase_component_demos(
+      "Combobox",
+      "Single and multiple selection, compound collections, validation, and availability all retain component-owned popup state.",
+      [
+        showcase_demo_section(
+          "Multiple",
+          "Remove chips, clear the value, or type to add another runtime.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              multiple_html,
+            ),
+            FormsComboboxMultipleCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:17rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Grouped",
+          "Core and host-language options share one searchable popup.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              grouped_html,
+            ),
+            FormsComboboxGroupedCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:17rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Empty result",
+          "Type an unmatched query to reveal the component's empty message.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              empty_html,
+            ),
+            FormsComboboxEmptyCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Invalid",
+          "A required choice keeps search and keyboard interaction available.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              invalid_html,
+            ),
+            FormsComboboxInvalidCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Disabled",
+          "The selected runtime remains readable in a locked control.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              disabled_html,
+            ),
+            FormsComboboxDisabledCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+      ],
+    )
+  })
+}
+
+///|
+fn forms_select_variants() -> @rabbita.Val[@html.Html] {
+  let deployment_options = [
+    @rui.select_option(value="iad", label="Washington, D.C."),
+    @rui.select_option(value="ord", label="Chicago"),
+    @rui.select_option(value="dfw", label="Dallas"),
+    @rui.select_option(value="sfo", label="San Francisco"),
+    @rui.select_option(value="fra", label="Frankfurt"),
+    @rui.select_option(value="lhr", label="London"),
+    @rui.select_option(value="sin", label="Singapore"),
+    @rui.select_option(value="nrt", label="Tokyo"),
+    @rui.select_option(value="syd", label="Sydney"),
+    @rui.select_option(
+      value="legacy-region",
+      label="Legacy region",
+      disabled=true,
+    ),
+  ]
+  let grouped = @rui.select(
+    id="forms-variants-select-grouped",
+    options=deployment_options,
+    default_value="sfo",
+    render=scope => {
+      @html.fragment([
+        @rui.select_trigger(scope~, aria_label="Choose a deployment region"),
+        @rui.select_content(scope~, style=["max-height:13rem"], [
+          @rui.select_scroll_up_button(scope~, label="Scroll regions up"),
+          @rui.select_group(label_id="forms-variants-select-americas-label", [
+            @rui.select_label(
+              id="forms-variants-select-americas-label",
+              "Americas",
+            ),
+            @rui.select_item(scope~, value="iad", "Washington, D.C."),
+            @rui.select_item(scope~, value="ord", "Chicago"),
+            @rui.select_item(scope~, value="dfw", "Dallas"),
+            @rui.select_item(scope~, value="sfo", "San Francisco"),
+          ]),
+          @rui.select_separator(),
+          @rui.select_group(label_id="forms-variants-select-emea-label", [
+            @rui.select_label(id="forms-variants-select-emea-label", "Europe"),
+            @rui.select_item(scope~, value="fra", "Frankfurt"),
+            @rui.select_item(scope~, value="lhr", "London"),
+          ]),
+          @rui.select_separator(),
+          @rui.select_group(label_id="forms-variants-select-apac-label", [
+            @rui.select_label(
+              id="forms-variants-select-apac-label",
+              "Asia Pacific",
+            ),
+            @rui.select_item(scope~, value="sin", "Singapore"),
+            @rui.select_item(scope~, value="nrt", "Tokyo"),
+            @rui.select_item(scope~, value="syd", "Sydney"),
+            @rui.select_item(
+              scope~,
+              value="legacy-region",
+              disabled=true,
+              "Legacy region",
+            ),
+          ]),
+          @rui.select_scroll_down_button(scope~, label="Scroll regions down"),
+        ]),
+      ])
+    },
+  )
+  let invalid = @rui.select(
+    id="forms-variants-select-invalid",
+    options=deployment_options,
+    placeholder="Choose a required region…",
+    invalid=true,
+    required=true,
+  )
+  let disabled = @rui.select(
+    id="forms-variants-select-disabled",
+    options=deployment_options,
+    default_value="fra",
+    disabled=true,
+  )
+  grouped.view3(invalid, disabled, (grouped_html, invalid_html, disabled_html) => {
+    showcase_component_demos(
+      "Select",
+      "The compound API adds groups, separators, disabled options, and scroll controls without moving popup state into the showcase.",
+      [
+        showcase_demo_section(
+          "Compound collection",
+          "Open the list to browse labeled regions, separators, a disabled option, and scroll controls.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              grouped_html,
+            ),
+            FormsSelectCompoundCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:16rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Invalid",
+          "A required Select keeps normal pointer and keyboard behavior.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              invalid_html,
+            ),
+            FormsSelectInvalidCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:14rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Disabled",
+          "The selected region remains legible in a locked control.",
+          showcase_demo_stage(
+            @html.div(
+              style=["width:min(100%,24rem);margin-inline:auto"],
+              disabled_html,
+            ),
+            FormsSelectDisabledCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:14rem",
+          ),
+        ),
+      ],
+    )
+  })
+}
+
+///|
+fn forms_field_variants(form_composition : @html.Html) -> @html.Html {
+  showcase_component_demos(
+    "Field",
+    "Semantic form fields, responsive layouts, Fieldset, and Legend keep labels, descriptions, validation, and grouping explicit.",
+    [
+      showcase_demo_section(
+        "Complete form composition",
+        "A real submitted form composes Form Field, labels, controls, descriptions, validation messages, and grouped fields.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,54rem);margin-inline:auto"],
+            form_composition,
+          ),
+          FormsFieldCompositionCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:34rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Horizontal",
+        "A compact label and control share one row.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,30rem);margin-inline:auto"],
+            @rui.field(orientation=@rui.FieldHorizontal, [
+              @rui.field_label(
+                for_="forms-variants-field-horizontal",
+                style=["width:7rem;flex:none"],
+                "Project",
+              ),
+              @rui.field_content([
+                @rui.input(
+                  id="forms-variants-field-horizontal",
+                  placeholder="rabbit-tea",
+                ),
+                @rui.field_description("Used in generated workspace URLs."),
+              ]),
+            ]),
+          ),
+          FormsFieldHorizontalCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:16rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Responsive",
+        "The label stacks when the field container becomes narrow.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,30rem);margin-inline:auto"],
+            @rui.field(orientation=@rui.FieldResponsive, [
+              @rui.field_label(
+                for_="forms-variants-field-responsive",
+                "Repository",
+              ),
+              @rui.field_content([
+                @rui.input(
+                  id="forms-variants-field-responsive",
+                  placeholder="moonbit-community/rabbita",
+                ),
+                @rui.field_description("Paste a repository path or URL."),
+              ]),
+            ]),
+          ),
+          FormsFieldResponsiveCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:16rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Fieldset and legend",
+        "Related delivery settings share a native legend and field group.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,34rem);margin-inline:auto"],
+            @rui.field_set([
+              @rui.field_legend(
+                variant=@rui.FieldLabelLegend,
+                "Delivery settings",
+              ),
+              @rui.field_group(style=["gap:1rem"], [
+                @rui.field([
+                  @rui.field_label(for_="forms-variants-field-region", "Region"),
+                  @rui.input(
+                    id="forms-variants-field-region",
+                    placeholder="Asia Pacific",
+                  ),
+                ]),
+                @rui.field([
+                  @rui.field_label(
+                    for_="forms-variants-field-channel",
+                    "Release channel",
+                  ),
+                  @rui.input(
+                    id="forms-variants-field-channel",
+                    placeholder="Stable",
+                  ),
+                ]),
+              ]),
+            ]),
+          ),
+          FormsFieldsetCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:19rem",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn forms_native_select_variants() -> @html.Html {
+  showcase_component_demos(
+    "Native Select",
+    "Sizes, grouped options, validation, and managed-disabled variants keep the platform-native menu while matching the shared control surface.",
+    [
+      showcase_demo_section(
+        "Default with groups",
+        "Native option groups preserve the platform menu and semantics.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,24rem);margin-inline:auto"],
+            @html.div(style=[FormsVariantColumnStyle], [
+              @rui.label(for_="forms-variants-native-default", "Access scope"),
+              @rui.native_select(id="forms-variants-native-default", [
+                @rui.native_select_optgroup(label="Workspace", [
+                  @rui.native_select_option(value="personal", "Personal"),
+                  @rui.native_select_option(value="team", selected=true, "Team"),
+                ]),
+                @rui.native_select_optgroup(label="Advanced", [
+                  @rui.native_select_option(
+                    value="organization",
+                    "Organization",
+                  ),
+                ]),
+              ]),
+            ]),
+          ),
+          FormsNativeSelectDefaultGroupsCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:14rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Small",
+        "A compact native control for dense settings.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,24rem);margin-inline:auto"],
+            @html.div(style=[FormsVariantColumnStyle], [
+              @rui.label(for_="forms-variants-native-small", "Release channel"),
+              @rui.native_select(
+                id="forms-variants-native-small",
+                size=@rui.NativeSelectSm,
+                [
+                  @rui.native_select_option(
+                    value="stable",
+                    selected=true,
+                    "Stable",
+                  ),
+                  @rui.native_select_option(value="preview", "Preview"),
+                ],
+              ),
+            ]),
+          ),
+          FormsNativeSelectSmallCode,
+          variant=ShowcaseStageSurface,
+          stage_style="--rui-showcase-stage-min-height:14rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Invalid",
+        "A required platform select uses the shared destructive border.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,24rem);margin-inline:auto"],
+            @html.div(style=[FormsVariantColumnStyle], [
+              @rui.label(for_="forms-variants-native-invalid", "Access level"),
+              @rui.native_select(
+                id="forms-variants-native-invalid",
+                invalid=true,
+                required=true,
+                aria_label="Choose an access level",
+                [
+                  @rui.native_select_option(
+                    value="",
+                    selected=true,
+                    "Choose access",
+                  ),
+                  @rui.native_select_option(value="viewer", "Viewer"),
+                  @rui.native_select_option(value="editor", "Editor"),
+                ],
+              ),
+            ]),
+          ),
+          FormsNativeSelectInvalidCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:14rem",
+        ),
+      ),
+      showcase_demo_section(
+        "Disabled",
+        "The inherited environment stays visible but cannot be changed.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,24rem);margin-inline:auto"],
+            @html.div(style=[FormsVariantColumnStyle], [
+              @rui.label(
+                for_="forms-variants-native-disabled",
+                disabled=true,
+                "Environment",
+              ),
+              @rui.native_select(
+                id="forms-variants-native-disabled",
+                disabled=true,
+                aria_label="Inherited environment",
+                [
+                  @rui.native_select_option(
+                    value="production",
+                    selected=true,
+                    "Production",
+                  ),
+                  @rui.native_select_option(value="preview", "Preview"),
+                ],
+              ),
+            ]),
+          ),
+          FormsNativeSelectDisabledCode,
+          variant=ShowcaseStagePlain,
+          stage_style="--rui-showcase-stage-min-height:14rem",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+priv struct FormsOtpStageViews {
+  continuous : @html.Html
+  pattern : @html.Html
+  separator : @html.Html
+  default : @html.Html
+  custom : @html.Html
+  four_digits : @html.Html
+  alphanumeric : @html.Html
+  invalid : @html.Html
+  disabled : @html.Html
+} derive(Eq)
+
+///|
+fn forms_otp_variants() -> @rabbita.Val[@html.Html] {
+  let continuous = @rui.input_otp(
+    id="forms-variants-otp-continuous",
+    max_length=6,
+    aria_label="Verification code",
+  )
+  let pattern = @rui.input_otp(
+    id="forms-variants-otp-pattern",
+    max_length=6,
+    pattern="[0-9]*",
+    aria_label="Digits only",
+  )
+  let separator = @rui.input_otp(
+    id="forms-variants-otp-separator",
+    max_length=6,
+    aria_label="Paired verification code",
+    render=scope => {
+      @html.fragment([
+        @rui.input_otp_group([
+          @rui.input_otp_slot(scope~, index=0),
+          @rui.input_otp_slot(scope~, index=1),
+        ]),
+        @rui.input_otp_separator(),
+        @rui.input_otp_group([
+          @rui.input_otp_slot(scope~, index=2),
+          @rui.input_otp_slot(scope~, index=3),
+        ]),
+        @rui.input_otp_separator(),
+        @rui.input_otp_group([
+          @rui.input_otp_slot(scope~, index=4),
+          @rui.input_otp_slot(scope~, index=5),
+        ]),
+      ])
+    },
+  )
+  let default = @rui.input_otp(
+    id="forms-variants-otp-default",
+    max_length=6,
+    separator_after=3,
+    aria_label="Verification code",
+  )
+  let custom = @rui.input_otp(
+    id="forms-variants-otp-custom",
+    max_length=8,
+    separator_after=4,
+    aria_label="Eight-digit recovery code",
+  )
+  let four_digits = @rui.input_otp(
+    id="forms-variants-otp-four-digits",
+    max_length=4,
+    pattern="[0-9]*",
+    aria_label="Four-digit PIN",
+  )
+  let alphanumeric = @rui.input_otp(
+    id="forms-variants-otp-alphanumeric",
+    max_length=6,
+    default_value="A1B2C3",
+    separator_after=3,
+    inputmode="text",
+    pattern="[A-Za-z0-9]*",
+    aria_label="Alphanumeric verification code",
+  )
+  let invalid = @rui.input_otp(
+    id="forms-variants-otp-invalid",
+    max_length=6,
+    separator_after=3,
+    invalid=true,
+    aria_label="Invalid verification code",
+  )
+  let disabled = @rui.input_otp(
+    id="forms-variants-otp-disabled",
+    max_length=6,
+    default_value="482931",
+    separator_after=3,
+    disabled=true,
+    aria_label="Previously verified code",
+  )
+  let form = @rui.input_otp(
+    id="forms-variants-otp-form",
+    max_length=6,
+    aria_label="Verification code",
+    input_attrs=@html.Attrs::build().required(true),
+    render=scope => {
+      let slot_style = [
+        "width:2.75rem;height:3rem;font-size:1.25rem;line-height:1.75rem",
+      ]
+      @html.fragment([
+        @rui.input_otp_group([
+          @rui.input_otp_slot(scope~, index=0, style=slot_style),
+          @rui.input_otp_slot(scope~, index=1, style=slot_style),
+          @rui.input_otp_slot(scope~, index=2, style=slot_style),
+        ]),
+        @rui.input_otp_separator(style=["margin-inline:0.5rem"]),
+        @rui.input_otp_group([
+          @rui.input_otp_slot(scope~, index=3, style=slot_style),
+          @rui.input_otp_slot(scope~, index=4, style=slot_style),
+          @rui.input_otp_slot(scope~, index=5, style=slot_style),
+        ]),
+      ])
+    },
+  )
+  let stages = continuous.map9(
+    pattern,
+    separator,
+    default,
+    custom,
+    four_digits,
+    alphanumeric,
+    invalid,
+    disabled,
+    (
+      continuous_html,
+      pattern_html,
+      separator_html,
+      default_html,
+      custom_html,
+      four_digits_html,
+      alphanumeric_html,
+      invalid_html,
+      disabled_html,
+    ) => {
+      continuous: continuous_html,
+      pattern: pattern_html,
+      separator: separator_html,
+      default: default_html,
+      custom: custom_html,
+      four_digits: four_digits_html,
+      alphanumeric: alphanumeric_html,
+      invalid: invalid_html,
+      disabled: disabled_html,
+    },
+  )
+  stages.view2(form, (stages, form_html) => {
+    showcase_component_demos(
+      "Input OTP",
+      "Patterns, lengths, grouping recipes, validation states, and a complete verification form all use the same incremental input component.",
+      [
+        showcase_demo_section(
+          "Default",
+          "Six editable digits stay in one continuous group.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.continuous,
+            ),
+            FormsOtpContinuousCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Pattern",
+          "A native input pattern constrains the field to digits.",
+          showcase_demo_stage(
+            @rui.field(style=["width:fit-content;margin-inline:auto"], [
+              @rui.field_label(for_="forms-variants-otp-pattern", "Digits Only"),
+              stages.pattern,
+            ]),
+            FormsOtpPatternCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "2 + 2 + 2 Separator",
+          "Two separators divide the code into three independently styled pairs.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.separator,
+            ),
+            FormsOtpSeparatorCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "3 + 3",
+          "A six-digit verification code split after the third slot.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.default,
+            ),
+            FormsOtpDefaultCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "4 + 4",
+          "An eight-digit recovery code uses a custom four-slot grouping.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.custom,
+            ),
+            FormsOtpCustomCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Four Digits",
+          "A compact four-digit PIN keeps the same input and focus behavior.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.four_digits,
+            ),
+            FormsOtpFourDigitsCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Alphanumeric",
+          "Letters and numbers share the same six slots and text keyboard mode.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.alphanumeric,
+            ),
+            FormsOtpAlphanumericCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Invalid and editable",
+          "Enter a replacement code using the same six live slots.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.invalid,
+            ),
+            FormsOtpInvalidCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Disabled",
+          "A previously verified value remains readable.",
+          showcase_demo_stage(
+            @html.div(
+              style=["display:flex;justify-content:center"],
+              stages.disabled,
+            ),
+            FormsOtpDisabledCode,
+            variant=ShowcaseStagePlain,
+            stage_style="--rui-showcase-stage-min-height:15rem",
+          ),
+        ),
+        showcase_demo_section(
+          "Form",
+          "A complete login-verification card composes the OTP with labels and actions.",
+          showcase_demo_stage(
+            @rui.card(style=["width:min(100%,28rem);margin-inline:auto"], [
+              @rui.card_header([
+                @rui.card_title("Verify your login"),
+                @rui.card_description([
+                  @html.span(
+                    "Enter the verification code we sent to your email address: ",
+                  ),
+                  @html.span(
+                    style=["font-weight:500;color:var(--rui-foreground)"],
+                    "m@example.com",
+                  ),
+                  @html.span("."),
+                ]),
+              ]),
+              @rui.card_content(
+                @rui.field([
+                  @html.div(
+                    style=[
+                      "display:flex;align-items:center;justify-content:space-between;gap:0.75rem",
+                    ],
+                    [
+                      @rui.field_label(
+                        for_="forms-variants-otp-form",
+                        "Verification code",
+                      ),
+                      @rui.button(variant=@rui.Outline, size=@rui.Xs, [
+                        showcase_refresh_icon(),
+                        @html.span("Resend Code"),
+                      ]),
+                    ],
+                  ),
+                  form_html,
+                  @rui.field_description(
+                    @html.a(
+                      href="#component-Input-OTP",
+                      style=["color:inherit;text-underline-offset:4px"],
+                      "I no longer have access to this email address.",
+                    ),
+                  ),
+                ]),
+              ),
+              @rui.card_footer(
+                style=["flex-direction:column;align-items:stretch;gap:0.75rem"],
+                @rui.field([
+                  @rui.button(style=["width:100%"], "Verify"),
+                  @html.div(
+                    style=[
+                      "color:var(--rui-muted-foreground);font-size:0.875rem;line-height:1.25rem;text-align:center",
+                    ],
+                    [
+                      @html.span("Having trouble signing in? "),
+                      @html.a(
+                        href="#component-Input-OTP",
+                        style=[
+                          "color:inherit;text-decoration:underline;text-underline-offset:4px",
+                        ],
+                        "Contact support",
+                      ),
+                    ],
+                  ),
+                ]),
+              ),
+            ]),
+            FormsOtpFormCode,
+            variant=ShowcaseStageSurface,
+            stage_style="--rui-showcase-stage-min-height:38rem",
+          ),
+        ),
+      ],
+    )
+  })
+}
+
+///|
+fn forms_choice_variants_gallery() -> @rabbita.Val[@html.Html] {
+  let checkbox_variants = forms_checkbox_variants()
+  let switch_variants = forms_switch_variants()
+  let combobox_variants = forms_combobox_variants()
+  let select_variants = forms_select_variants()
+  checkbox_variants.view4(switch_variants, combobox_variants, select_variants, (
+    checkbox_html,
+    switch_html,
+    combobox_html,
+    select_html,
+  ) => {
+    @html.div(style=[FormsVariantsStackStyle], [
+      checkbox_html, switch_html, combobox_html, select_html,
+    ])
+  })
+}
+
+///|
+fn forms_otp_and_native_select_variants() -> @rabbita.Val[@html.Html] {
+  forms_otp_variants().view(otp_html => {
+    @html.div(style=[FormsVariantsStackStyle], [
+      forms_native_select_variants(),
+      otp_html,
+    ])
+  })
+}
+
+///|
+fn forms_variants_gallery() -> @rabbita.Val[@html.Html] {
+  let checkbox_variants = forms_checkbox_variants()
+  let switch_variants = forms_switch_variants()
+  let combobox_variants = forms_combobox_variants()
+  let select_variants = forms_select_variants()
+  let otp_variants = forms_otp_variants()
+  let input_group_variants = forms_input_group_variants()
+  checkbox_variants.view6(
+    switch_variants,
+    combobox_variants,
+    select_variants,
+    otp_variants,
+    input_group_variants,
+    (
+      checkbox_html,
+      switch_html,
+      combobox_html,
+      select_html,
+      otp_html,
+      input_group_html,
+    ) => {
+      @html.div(style=[FormsVariantsStackStyle], [
+        checkbox_html,
+        switch_html,
+        combobox_html,
+        select_html,
+        input_group_html,
+        forms_native_select_variants(),
+        otp_html,
+      ])
+    },
+  )
+}

--- a/website/homepage/components/foundations_data_variants.mbt
+++ b/website/homepage/components/foundations_data_variants.mbt
@@ -1,0 +1,1334 @@
+///|
+const FdvAttachmentStageContentStyle : String = "display:flex;width:min(100%,24rem);min-width:0;margin-inline:auto;align-items:center;justify-content:center"
+
+///|
+const FdvAttachmentVerticalStyle : String = "width:7.5rem;--rui-attachment-content-width:auto"
+
+///|
+const FdvAttachmentImageStyle : String = "display:block;width:100%;height:100%;object-fit:cover"
+
+///|
+const FdvStrokeIconCode : String =
+  #|fn stroke_icon(path : String) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [@svg.path(
+  #|        d=path,
+  #|        fill="none",
+  #|        stroke="currentColor",
+  #|        stroke_width=2,
+  #|        attrs=line_attrs,
+  #|      )],
+  #|    ),
+  #|  )
+  #|}
+  #|
+
+///|
+const FdvAttachmentImageCode : String =
+  #|@rui.attachment_group(style=["width:100%"], [
+  #|  @rui.attachment(
+  #|    orientation=@rui.AttachmentVertical,
+  #|    style=["width:7.5rem;--rui-attachment-content-width:auto"],
+  #|    [
+  #|      @rui.attachment_media(
+  #|        variant=@rui.AttachmentImage,
+  #|        @html.img(
+  #|          src="https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=900&auto=format&fit=crop&q=80",
+  #|          alt="Workspace",
+  #|          style=["display:block;width:100%;height:100%;object-fit:cover"],
+  #|        ),
+  #|      ),
+  #|      @rui.attachment_content([
+  #|        @rui.attachment_title("workspace.png"),
+  #|        @rui.attachment_description("PNG · 820 KB"),
+  #|      ]),
+  #|    ],
+  #|  ),
+  #|  @rui.attachment(
+  #|    orientation=@rui.AttachmentVertical,
+  #|    style=["width:7.5rem;--rui-attachment-content-width:auto"],
+  #|    [
+  #|      @rui.attachment_media(
+  #|        variant=@rui.AttachmentImage,
+  #|        @html.img(
+  #|          src="https://images.unsplash.com/photo-1497215728101-856f4ea42174?w=900&auto=format&fit=crop&q=80",
+  #|          alt="Desk",
+  #|          style=["display:block;width:100%;height:100%;object-fit:cover"],
+  #|        ),
+  #|      ),
+  #|      @rui.attachment_content([
+  #|        @rui.attachment_title("desk-reference.jpg"),
+  #|        @rui.attachment_description("JPG · 1.1 MB"),
+  #|      ]),
+  #|    ],
+  #|  ),
+  #|  @rui.attachment(
+  #|    orientation=@rui.AttachmentVertical,
+  #|    style=["width:7.5rem;--rui-attachment-content-width:auto"],
+  #|    [
+  #|      @rui.attachment_media(
+  #|        variant=@rui.AttachmentImage,
+  #|        @html.img(
+  #|          src="https://images.unsplash.com/photo-1497366811353-6870744d04b2?w=900&auto=format&fit=crop&q=80",
+  #|          alt="Office",
+  #|          style=["display:block;width:100%;height:100%;object-fit:cover"],
+  #|        ),
+  #|      ),
+  #|      @rui.attachment_content([
+  #|        @rui.attachment_title("office-reference.jpg"),
+  #|        @rui.attachment_description("JPG · 940 KB"),
+  #|      ]),
+  #|    ],
+  #|  ),
+  #|])
+  #|
+
+///|
+const FdvAttachmentFileCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("message-renderer.mbt"),
+    #|    @rui.attachment_description("MoonBit · 12 KB"),
+    #|  ]),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentIdleCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(state=@rui.AttachmentIdle, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0M12 6v6h4",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("selected-file.pdf"),
+    #|    @rui.attachment_description("Ready to upload"),
+    #|  ]),
+    #|  @rui.attachment_actions(
+    #|    @rui.attachment_action(
+    #|      aria_label="Remove selected-file.pdf",
+    #|      stroke_icon("M18 6 6 18M6 6l12 12"),
+    #|    ),
+    #|  ),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentUploadingCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(state=@rui.AttachmentUploading, style=["width:100%"], [
+    #|  @rui.attachment_media(@rui.spinner(label="Uploading design system")),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("design-system.zip"),
+    #|    @rui.attachment_description("Uploading · 64%"),
+    #|  ]),
+    #|  @rui.attachment_actions(
+    #|    @rui.attachment_action(
+    #|      aria_label="Cancel upload",
+    #|      stroke_icon("M18 6 6 18M6 6l12 12"),
+    #|    ),
+    #|  ),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentProcessingCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(state=@rui.AttachmentProcessing, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2zM14 2v5a1 1 0 0 0 1 1h5M10 9H8M16 13H8M16 17H8",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("market-research.pdf"),
+    #|    @rui.attachment_description("Processing document"),
+    #|  ]),
+    #|  @rui.attachment_actions(
+    #|    @rui.attachment_action(
+    #|      aria_label="Remove market-research.pdf",
+    #|      stroke_icon("M18 6 6 18M6 6l12 12"),
+    #|    ),
+    #|  ),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentErrorCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(state=@rui.AttachmentError, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6M12 11v3M12 18h.01",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("financial-model.xlsx"),
+    #|    @rui.attachment_description("Upload failed. Try again."),
+    #|  ]),
+    #|  @rui.attachment_actions([
+    #|    @rui.attachment_action(
+    #|      aria_label="Retry upload",
+    #|      stroke_icon("M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8M21 3v5h-5M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16M8 16H3v5"),
+    #|    ),
+    #|    @rui.attachment_action(
+    #|      aria_label="Remove financial-model.xlsx",
+    #|      stroke_icon("M18 6 6 18M6 6l12 12"),
+    #|    ),
+    #|  ]),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentDoneCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(state=@rui.AttachmentDone, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon("M20 6 9 17l-5-5")),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("uploaded-report.pdf"),
+    #|    @rui.attachment_description("Uploaded · 1.8 MB"),
+    #|  ]),
+    #|  @rui.attachment_actions(
+    #|    @rui.attachment_action(
+    #|      aria_label="Remove uploaded-report.pdf",
+    #|      stroke_icon("M18 6 6 18M6 6l12 12"),
+    #|    ),
+    #|  ),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentDefaultSizeCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(size=@rui.AttachmentDefaultSize, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("Default attachment"),
+    #|    @rui.attachment_description("PDF · 2.4 MB"),
+    #|  ]),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentSmallCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(size=@rui.AttachmentSm, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("Small attachment"),
+    #|    @rui.attachment_description("PDF · 2.4 MB"),
+    #|  ]),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentExtraSmallCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(size=@rui.AttachmentXs, style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("Extra small attachment"),
+    #|    @rui.attachment_description("PDF · 2.4 MB"),
+    #|  ]),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentGroupCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment_group(style=["width:100%;max-width:24rem"], [
+    #|  @rui.attachment(style=["width:16rem"], [
+    #|    @rui.attachment_media(stroke_icon(
+    #|      "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|    )),
+    #|    @rui.attachment_content([
+    #|      @rui.attachment_title("briefing-notes.pdf"),
+    #|      @rui.attachment_description("PDF · 1.4 MB"),
+    #|    ]),
+    #|    @rui.attachment_trigger_link(
+    #|      href="#component-Attachment",
+    #|      aria_label="Open briefing notes in group",
+    #|      @html.nothing,
+    #|    ),
+    #|  ]),
+    #|  @rui.attachment(style=["width:16rem"], [
+    #|    @rui.attachment_media(stroke_icon(
+    #|      "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|    )),
+    #|    @rui.attachment_content([
+    #|      @rui.attachment_title("customers.csv"),
+    #|      @rui.attachment_description("CSV · 18 KB"),
+    #|    ]),
+    #|    @rui.attachment_trigger_link(
+    #|      href="#component-Attachment",
+    #|      aria_label="Open customers in group",
+    #|      @html.nothing,
+    #|    ),
+    #|  ]),
+    #|])
+    #|
+  )
+
+///|
+const FdvAttachmentTriggerCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.attachment(style=["width:100%"], [
+    #|  @rui.attachment_media(stroke_icon(
+    #|    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+    #|  )),
+    #|  @rui.attachment_content([
+    #|    @rui.attachment_title("briefing-notes.pdf"),
+    #|    @rui.attachment_description("PDF · 1.4 MB"),
+    #|  ]),
+    #|  @rui.attachment_trigger_link(
+    #|    href="#data-display",
+    #|    aria_label="Open briefing notes",
+    #|    @html.nothing,
+    #|  ),
+    #|])
+    #|
+  )
+
+///|
+priv struct FdvPayment {
+  id : String
+  status : String
+  email : String
+  amount : String
+  amount_sort : String
+}
+
+///|
+fn fdv_demo_section(
+  title : String,
+  description : String,
+  body : @html.Html,
+  code : String,
+  stage_variant? : ShowcaseStageVariant = ShowcaseStagePlain,
+  tall? : Bool = false,
+) -> ShowcaseDemoEntry {
+  showcase_demo_section(
+    title,
+    description,
+    showcase_demo_stage(body, code, variant=stage_variant, tall~),
+  )
+}
+
+///|
+fn fdv_attachment_content(title : String, description : String) -> @html.Html {
+  @rui.attachment_content([
+    @rui.attachment_title(title),
+    @rui.attachment_description(description),
+  ])
+}
+
+///|
+fn fdv_attachment_clock_icon() -> @html.Html {
+  showcase_stroke_icon("M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0M12 6v6h4")
+}
+
+///|
+fn fdv_attachment_processing_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2zM14 2v5a1 1 0 0 0 1 1h5M10 9H8M16 13H8M16 17H8",
+  )
+}
+
+///|
+fn fdv_attachment_error_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6M12 11v3M12 18h.01",
+  )
+}
+
+///|
+fn fdv_attachment_retry_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8M21 3v5h-5M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16M8 16H3v5",
+  )
+}
+
+///|
+fn fdv_attachment_stage(
+  body : @html.Html,
+  code : String,
+) -> ShowcasePreparedStage {
+  showcase_demo_stage(
+    @html.div(
+      class="rui-showcase-attachment-stage-content",
+      style=[FdvAttachmentStageContentStyle],
+      body,
+    ),
+    code,
+  )
+}
+
+///|
+fn fdv_attachments_demo() -> @html.Html {
+  showcase_component_demos(
+    "Attachment",
+    "Displays a file or image attachment with media, metadata, upload state, and actions.",
+    [
+      showcase_demo_section(
+        "Image attachment",
+        "A group of image attachments presents real media and metadata.",
+        fdv_attachment_stage(
+          @rui.attachment_group(style=["width:100%"], [
+            @rui.attachment(
+              orientation=@rui.AttachmentVertical,
+              style=[FdvAttachmentVerticalStyle],
+              [
+                @rui.attachment_media(
+                  variant=@rui.AttachmentImage,
+                  @html.img(
+                    src="https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=900&auto=format&fit=crop&q=80",
+                    alt="Workspace",
+                    style=[FdvAttachmentImageStyle],
+                  ),
+                ),
+                fdv_attachment_content("workspace.png", "PNG · 820 KB"),
+              ],
+            ),
+            @rui.attachment(
+              orientation=@rui.AttachmentVertical,
+              style=[FdvAttachmentVerticalStyle],
+              [
+                @rui.attachment_media(
+                  variant=@rui.AttachmentImage,
+                  @html.img(
+                    src="https://images.unsplash.com/photo-1497215728101-856f4ea42174?w=900&auto=format&fit=crop&q=80",
+                    alt="Desk",
+                    style=[FdvAttachmentImageStyle],
+                  ),
+                ),
+                fdv_attachment_content("desk-reference.jpg", "JPG · 1.1 MB"),
+              ],
+            ),
+            @rui.attachment(
+              orientation=@rui.AttachmentVertical,
+              style=[FdvAttachmentVerticalStyle],
+              [
+                @rui.attachment_media(
+                  variant=@rui.AttachmentImage,
+                  @html.img(
+                    src="https://images.unsplash.com/photo-1497366811353-6870744d04b2?w=900&auto=format&fit=crop&q=80",
+                    alt="Office",
+                    style=[FdvAttachmentImageStyle],
+                  ),
+                ),
+                fdv_attachment_content("office-reference.jpg", "JPG · 940 KB"),
+              ],
+            ),
+          ]),
+          FdvAttachmentImageCode,
+        ),
+      ),
+      showcase_demo_section(
+        "File attachment",
+        "A default horizontal file attachment.",
+        fdv_attachment_stage(
+          @rui.attachment(style=["width:100%"], [
+            @rui.attachment_media(showcase_file_icon()),
+            fdv_attachment_content("message-renderer.mbt", "MoonBit · 12 KB"),
+          ]),
+          FdvAttachmentFileCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Idle",
+        "A selected file waiting to upload.",
+        fdv_attachment_stage(
+          @rui.attachment(state=@rui.AttachmentIdle, style=["width:100%"], [
+            @rui.attachment_media(fdv_attachment_clock_icon()),
+            fdv_attachment_content("selected-file.pdf", "Ready to upload"),
+            @rui.attachment_actions(
+              @rui.attachment_action(
+                aria_label="Remove selected-file.pdf",
+                showcase_close_icon(),
+              ),
+            ),
+          ]),
+          FdvAttachmentIdleCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Uploading",
+        "An in-progress upload with a spinner.",
+        fdv_attachment_stage(
+          @rui.attachment(
+            state=@rui.AttachmentUploading,
+            style=["width:100%"],
+            [
+              @rui.attachment_media(
+                @rui.spinner(label="Uploading design system"),
+              ),
+              fdv_attachment_content("design-system.zip", "Uploading · 64%"),
+              @rui.attachment_actions(
+                @rui.attachment_action(
+                  aria_label="Cancel upload",
+                  showcase_close_icon(),
+                ),
+              ),
+            ],
+          ),
+          FdvAttachmentUploadingCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Processing",
+        "A file being processed after upload.",
+        fdv_attachment_stage(
+          @rui.attachment(
+            state=@rui.AttachmentProcessing,
+            style=["width:100%"],
+            [
+              @rui.attachment_media(fdv_attachment_processing_icon()),
+              fdv_attachment_content(
+                "market-research.pdf", "Processing document",
+              ),
+              @rui.attachment_actions(
+                @rui.attachment_action(
+                  aria_label="Remove market-research.pdf",
+                  showcase_close_icon(),
+                ),
+              ),
+            ],
+          ),
+          FdvAttachmentProcessingCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Error",
+        "A failed upload with destructive media treatment.",
+        fdv_attachment_stage(
+          @rui.attachment(state=@rui.AttachmentError, style=["width:100%"], [
+            @rui.attachment_media(fdv_attachment_error_icon()),
+            fdv_attachment_content(
+              "financial-model.xlsx", "Upload failed. Try again.",
+            ),
+            @rui.attachment_actions([
+              @rui.attachment_action(
+                aria_label="Retry upload",
+                fdv_attachment_retry_icon(),
+              ),
+              @rui.attachment_action(
+                aria_label="Remove financial-model.xlsx",
+                showcase_close_icon(),
+              ),
+            ]),
+          ]),
+          FdvAttachmentErrorCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Done",
+        "A completed upload with a success icon.",
+        fdv_attachment_stage(
+          @rui.attachment(state=@rui.AttachmentDone, style=["width:100%"], [
+            @rui.attachment_media(showcase_check_icon()),
+            fdv_attachment_content("uploaded-report.pdf", "Uploaded · 1.8 MB"),
+            @rui.attachment_actions(
+              @rui.attachment_action(
+                aria_label="Remove uploaded-report.pdf",
+                showcase_close_icon(),
+              ),
+            ),
+          ]),
+          FdvAttachmentDoneCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Default size",
+        "The default attachment size.",
+        fdv_attachment_stage(
+          @rui.attachment(
+            size=@rui.AttachmentDefaultSize,
+            style=["width:100%"],
+            [
+              @rui.attachment_media(showcase_file_icon()),
+              fdv_attachment_content("Default attachment", "PDF · 2.4 MB"),
+            ],
+          ),
+          FdvAttachmentDefaultSizeCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Small",
+        "A compact attachment row.",
+        fdv_attachment_stage(
+          @rui.attachment(size=@rui.AttachmentSm, style=["width:100%"], [
+            @rui.attachment_media(showcase_file_icon()),
+            fdv_attachment_content("Small attachment", "PDF · 2.4 MB"),
+          ]),
+          FdvAttachmentSmallCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Extra small",
+        "The most compact attachment row.",
+        fdv_attachment_stage(
+          @rui.attachment(size=@rui.AttachmentXs, style=["width:100%"], [
+            @rui.attachment_media(showcase_file_icon()),
+            fdv_attachment_content("Extra small attachment", "PDF · 2.4 MB"),
+          ]),
+          FdvAttachmentExtraSmallCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Group",
+        "A scrollable group keeps attachments as independent items.",
+        fdv_attachment_stage(
+          @rui.attachment_group(style=["width:100%;max-width:24rem"], [
+            @rui.attachment(style=["width:16rem"], [
+              @rui.attachment_media(showcase_file_icon()),
+              fdv_attachment_content("briefing-notes.pdf", "PDF · 1.4 MB"),
+              @rui.attachment_trigger_link(
+                href="#component-Attachment",
+                aria_label="Open briefing notes in group",
+                @html.nothing,
+              ),
+            ]),
+            @rui.attachment(style=["width:16rem"], [
+              @rui.attachment_media(showcase_file_icon()),
+              fdv_attachment_content("customers.csv", "CSV · 18 KB"),
+              @rui.attachment_trigger_link(
+                href="#component-Attachment",
+                aria_label="Open customers in group",
+                @html.nothing,
+              ),
+            ]),
+          ]),
+          FdvAttachmentGroupCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Full-card trigger",
+        "The attachment surface acts as a link without hiding its semantics.",
+        fdv_attachment_stage(
+          @rui.attachment(style=["width:100%"], [
+            @rui.attachment_media(showcase_file_icon()),
+            fdv_attachment_content("briefing-notes.pdf", "PDF · 1.4 MB"),
+            @rui.attachment_trigger_link(
+              href="#data-display",
+              aria_label="Open briefing notes",
+              @html.nothing,
+            ),
+          ]),
+          FdvAttachmentTriggerCode,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+const FdvTypographyH1Code : String =
+  #|@rui.typography_h1(style=["text-align:start"], "Taxing Laughter")
+  #|
+
+///|
+const FdvTypographyH2Code : String =
+  #|@rui.typography_h2("The Joke Tax Chronicles")
+  #|
+
+///|
+const FdvTypographyH3Code : String =
+  #|@rui.typography_h3("The people's response")
+  #|
+
+///|
+const FdvTypographyH4Code : String =
+  #|@rui.typography_h4("A compact heading")
+  #|
+
+///|
+const FdvTypographyParagraphCode : String =
+  #|@rui.typography_p(
+  #|  "Body copy stays readable without imposing application layout.",
+  #|)
+  #|
+
+///|
+const FdvTypographyLeadCode : String =
+  #|@rui.typography_lead(
+  #|  "A king, a court jester, and one very expensive sense of humor.",
+  #|)
+  #|
+
+///|
+const FdvTypographyLargeCode : String =
+  #|@rui.typography_large("Are you absolutely sure?")
+  #|
+
+///|
+const FdvTypographySmallCode : String =
+  #|@rui.typography_small("Email address")
+  #|
+
+///|
+const FdvTypographyMutedCode : String =
+  #|@rui.typography_muted("Enter the address associated with your account.")
+  #|
+
+///|
+const FdvTypographyBlockquoteCode : String =
+  #|@rui.typography_blockquote(
+  #|  "After all, everyone enjoys a good joke—so why not charge for it?",
+  #|)
+  #|
+
+///|
+const FdvTypographyListCode : String =
+  #|@rui.typography_list([
+  #|  @html.li("First-class jokes: one gold coin"),
+  #|  @html.li("Second-class jokes: one silver coin"),
+  #|  @html.li("Bad jokes: no charge"),
+  #|])
+  #|
+
+///|
+const FdvTypographyInlineCodeCode : String =
+  #|@rui.typography_p([
+  #|  @html.text("The rule was named "),
+  #|  @rui.typography_inline_code("joke_tax"),
+  #|  @html.text("."),
+  #|])
+  #|
+
+///|
+const FdvDataTableCode : String =
+  #|priv struct Payment {
+  #|  id : String
+  #|  status : String
+  #|  email : String
+  #|  amount : String
+  #|  amount_sort : String
+  #|}
+  #|
+  #|///|
+  #|fn payments_table() -> @rabbita.Val[@html.Html] {
+  #|  let rows : Array[Payment] = [
+  #|    {
+  #|      id: "pay-001",
+  #|      status: "Success",
+  #|      email: "ada@example.com",
+  #|      amount: "316.00",
+  #|      amount_sort: "0316.00",
+  #|    },
+  #|    {
+  #|      id: "pay-002",
+  #|      status: "Processing",
+  #|      email: "grace@example.com",
+  #|      amount: "242.00",
+  #|      amount_sort: "0242.00",
+  #|    },
+  #|    {
+  #|      id: "pay-003",
+  #|      status: "Failed",
+  #|      email: "linus@example.com",
+  #|      amount: "837.00",
+  #|      amount_sort: "0837.00",
+  #|    },
+  #|    {
+  #|      id: "pay-004",
+  #|      status: "Success",
+  #|      email: "margaret@example.com",
+  #|      amount: "874.00",
+  #|      amount_sort: "0874.00",
+  #|    },
+  #|    {
+  #|      id: "pay-005",
+  #|      status: "Success",
+  #|      email: "donald@example.com",
+  #|      amount: "721.00",
+  #|      amount_sort: "0721.00",
+  #|    },
+  #|    {
+  #|      id: "pay-006",
+  #|      status: "Processing",
+  #|      email: "barbara@example.com",
+  #|      amount: "450.00",
+  #|      amount_sort: "0450.00",
+  #|    },
+  #|  ]
+  #|  let columns : Array[@rui.DataTableColumn[Payment]] = [
+  #|    @rui.data_table_column(
+  #|      key="status",
+  #|      label="Status",
+  #|      value=row => row.status,
+  #|      render=row => {
+  #|        let variant : @rui.BadgeVariant = if row.status == "Failed" {
+  #|          @rui.BadgeVariant::Destructive
+  #|        } else if row.status == "Processing" {
+  #|          @rui.BadgeVariant::Secondary
+  #|        } else {
+  #|          @rui.BadgeVariant::Outline
+  #|        }
+  #|        @rui.badge(variant~, row.status)
+  #|      },
+  #|    ),
+  #|    @rui.data_table_column(
+  #|      key="email",
+  #|      label="Email",
+  #|      value=row => row.email,
+  #|    ),
+  #|    @rui.data_table_column(
+  #|      key="amount",
+  #|      label="Amount",
+  #|      value=row => row.amount_sort,
+  #|      numeric=true,
+  #|      render=row => @html.strong("$\{row.amount}"),
+  #|    ),
+  #|  ]
+  #|  @rui.data_table(
+  #|    id="showcase-payments",
+  #|    rows~,
+  #|    columns~,
+  #|    row_key=row => row.id,
+  #|    page_size=4,
+  #|    default_sort_key="amount",
+  #|    default_selected=["pay-002"],
+  #|    aria_label="Recent payments",
+  #|  ).map(table_html =>
+  #|    @html.div(
+  #|      style=["width:min(100%,58rem);margin-inline:auto"],
+  #|      table_html,
+  #|    ),
+  #|  )
+  #|}
+  #|
+
+///|
+const FdvItemDefaultCode : String =
+  #|@rui.item(variant=@rui.ItemDefault, size=@rui.ItemDefaultSize, [
+  #|  @rui.item_content([
+  #|    @rui.item_title("Release notes"),
+  #|    @rui.item_description("Documentation for the current release."),
+  #|  ]),
+  #|])
+  #|
+
+///|
+const FdvItemOutlineSmallCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.item(variant=@rui.ItemOutline, size=@rui.ItemSm, [
+    #|  @rui.item_media(
+    #|    variant=@rui.ItemMediaIcon,
+    #|    stroke_icon(
+    #|      "M9 3v2M15 3v2M9 19v2M15 19v2M3 9h2M3 15h2M19 9h2M19 15h2M7 7h10v10H7z",
+    #|    ),
+    #|  ),
+    #|  @rui.item_content([
+    #|    @rui.item_title("Runtime"),
+    #|    @rui.item_description("JS and native targets are healthy."),
+    #|  ]),
+    #|  @rui.item_actions(@rui.button(variant=@rui.Ghost, size=@rui.Xs, "Inspect")),
+    #|])
+    #|
+  )
+
+///|
+const FdvItemMutedImageCode : String =
+  #|@rui.item(variant=@rui.ItemMuted, size=@rui.ItemDefaultSize, [
+  #|  @rui.item_media(
+  #|    variant=@rui.ItemMediaImage,
+  #|    @html.div(
+  #|      style=["width:100%;height:100%;background:var(--rui-muted)"],
+  #|      @html.nothing,
+  #|    ),
+  #|  ),
+  #|  @rui.item_content([
+  #|    @rui.item_header("Preview build"),
+  #|    @rui.item_title("Vega surface"),
+  #|    @rui.item_description("Generated from the current token set."),
+  #|    @rui.item_footer("Updated moments ago"),
+  #|  ]),
+  #|])
+  #|
+
+///|
+const FdvEmptyDefaultCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.empty(style=["padding:1.5rem 1rem"], [
+    #|  @rui.empty_header([
+    #|    @rui.empty_media(
+    #|      variant=@rui.EmptyMediaDefault,
+    #|      stroke_icon("M21 8v13H3V8M1 3h22v5H1zM10 12h4"),
+    #|    ),
+    #|    @rui.empty_title("No archives"),
+    #|    @rui.empty_description("Archived projects will appear here."),
+    #|  ]),
+    #|  @rui.empty_content(@rui.button(size=@rui.Sm, "Browse projects")),
+    #|])
+    #|
+  )
+
+///|
+const FdvEmptyIconCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.empty(style=["padding:1.5rem 1rem"], [
+    #|  @rui.empty_header([
+    #|    @rui.empty_media(
+    #|      variant=@rui.EmptyMediaIcon,
+    #|      stroke_icon("M12 5v14M5 12h14"),
+    #|    ),
+    #|    @rui.empty_title("No release channels"),
+    #|    @rui.empty_description("Create a channel for preview builds."),
+    #|  ]),
+    #|  @rui.empty_content(@rui.button(size=@rui.Sm, "Create channel")),
+    #|])
+    #|
+  )
+
+///|
+const FdvMarkerDefaultCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.marker(variant=@rui.MarkerDefault, [
+    #|  @rui.marker_icon(stroke_icon("M3 12h4l2-8 4 16 2-8h6")),
+    #|  @rui.marker_content("Deployment started"),
+    #|])
+    #|
+  )
+
+///|
+const FdvMarkerSeparatorCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.marker(variant=@rui.MarkerSeparator, [
+    #|  @rui.marker_icon(stroke_icon("M12 12h.01")),
+    #|  @rui.marker_content("Today"),
+    #|])
+    #|
+  )
+
+///|
+const FdvMarkerBorderCode : String = FdvStrokeIconCode +
+  (
+    #|@rui.marker(variant=@rui.MarkerBorder, [
+    #|  @rui.marker_icon(stroke_icon("M20 6 9 17l-5-5")),
+    #|  @rui.marker_content("Validation complete"),
+    #|])
+    #|
+  )
+
+///|
+const FdvProgressIndeterminateCode : String =
+  #|@rui.progress(aria_label="Preparing release", children=[
+  #|  @rui.progress_label("Preparing release"),
+  #|  @rui.progress_value(text="Working"),
+  #|])
+  #|
+
+///|
+const FdvProgressDeterminateCode : String =
+  #|@rui.progress(value=54, aria_label="Build progress", children=[
+  #|  @rui.progress_label(value=54, "Build"),
+  #|  @rui.progress_value(value=54),
+  #|])
+  #|
+
+///|
+fn fdv_typography_demo() -> @html.Html {
+  showcase_component_demos(
+    "Typography",
+    "Semantic heading, body, list, quotation, code, and supporting-text recipes.",
+    [
+      fdv_demo_section(
+        "H1",
+        "Top-level page heading.",
+        @rui.typography_h1(style=["text-align:start"], "Taxing Laughter"),
+        FdvTypographyH1Code,
+      ),
+      fdv_demo_section(
+        "H2",
+        "Second-level section heading.",
+        @rui.typography_h2("The Joke Tax Chronicles"),
+        FdvTypographyH2Code,
+      ),
+      fdv_demo_section(
+        "H3",
+        "Third-level section heading.",
+        @rui.typography_h3("The people's response"),
+        FdvTypographyH3Code,
+      ),
+      fdv_demo_section(
+        "H4",
+        "Compact fourth-level heading.",
+        @rui.typography_h4("A compact heading"),
+        FdvTypographyH4Code,
+      ),
+      fdv_demo_section(
+        "Paragraph",
+        "Readable body copy.",
+        @rui.typography_p(
+          "Body copy stays readable without imposing application layout.",
+        ),
+        FdvTypographyParagraphCode,
+      ),
+      fdv_demo_section(
+        "Lead",
+        "Introductory copy with stronger presence.",
+        @rui.typography_lead(
+          "A king, a court jester, and one very expensive sense of humor.",
+        ),
+        FdvTypographyLeadCode,
+      ),
+      fdv_demo_section(
+        "Large",
+        "Large supporting text.",
+        @rui.typography_large("Are you absolutely sure?"),
+        FdvTypographyLargeCode,
+      ),
+      fdv_demo_section(
+        "Small",
+        "Compact supporting label.",
+        @rui.typography_small("Email address"),
+        FdvTypographySmallCode,
+      ),
+      fdv_demo_section(
+        "Muted",
+        "Low-emphasis supporting copy.",
+        @rui.typography_muted("Enter the address associated with your account."),
+        FdvTypographyMutedCode,
+      ),
+      fdv_demo_section(
+        "Blockquote",
+        "Quoted prose with a semantic border.",
+        @rui.typography_blockquote(
+          "After all, everyone enjoys a good joke—so why not charge for it?",
+        ),
+        FdvTypographyBlockquoteCode,
+      ),
+      fdv_demo_section(
+        "List",
+        "A semantic unordered list.",
+        @rui.typography_list([
+          @html.li("First-class jokes: one gold coin"),
+          @html.li("Second-class jokes: one silver coin"),
+          @html.li("Bad jokes: no charge"),
+        ]),
+        FdvTypographyListCode,
+      ),
+      fdv_demo_section(
+        "Inline code",
+        "Inline code embedded in a paragraph.",
+        @rui.typography_p([
+          @html.text("The rule was named "),
+          @rui.typography_inline_code("joke_tax"),
+          @html.text("."),
+        ]),
+        FdvTypographyInlineCodeCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn fdv_data_table_view() -> @rabbita.Val[@html.Html] {
+  let rows : Array[FdvPayment] = [
+    {
+      id: "pay-001",
+      status: "Success",
+      email: "ada@example.com",
+      amount: "316.00",
+      amount_sort: "0316.00",
+    },
+    {
+      id: "pay-002",
+      status: "Processing",
+      email: "grace@example.com",
+      amount: "242.00",
+      amount_sort: "0242.00",
+    },
+    {
+      id: "pay-003",
+      status: "Failed",
+      email: "linus@example.com",
+      amount: "837.00",
+      amount_sort: "0837.00",
+    },
+    {
+      id: "pay-004",
+      status: "Success",
+      email: "margaret@example.com",
+      amount: "874.00",
+      amount_sort: "0874.00",
+    },
+    {
+      id: "pay-005",
+      status: "Success",
+      email: "donald@example.com",
+      amount: "721.00",
+      amount_sort: "0721.00",
+    },
+    {
+      id: "pay-006",
+      status: "Processing",
+      email: "barbara@example.com",
+      amount: "450.00",
+      amount_sort: "0450.00",
+    },
+  ]
+  let columns : Array[@rui.DataTableColumn[FdvPayment]] = [
+    @rui.data_table_column(
+      key="status",
+      label="Status",
+      value=row => row.status,
+      render=row => {
+        let variant : @rui.BadgeVariant = if row.status == "Failed" {
+          @rui.BadgeVariant::Destructive
+        } else if row.status == "Processing" {
+          @rui.BadgeVariant::Secondary
+        } else {
+          @rui.BadgeVariant::Outline
+        }
+        @rui.badge(variant~, row.status)
+      },
+    ),
+    @rui.data_table_column(key="email", label="Email", value=row => row.email),
+    @rui.data_table_column(
+      key="amount",
+      label="Amount",
+      value=row => row.amount_sort,
+      numeric=true,
+      render=row => @html.strong("$\{row.amount}"),
+    ),
+  ]
+  @rui.data_table(
+    id="showcase-payments",
+    rows~,
+    columns~,
+    row_key=row => row.id,
+    page_size=4,
+    default_sort_key="amount",
+    default_selected=["pay-002"],
+    aria_label="Recent payments",
+  )
+}
+
+///|
+fn fdv_data_table_demo(data_table_html : @html.Html) -> @html.Html {
+  showcase_component_demos(
+    "Data Table",
+    "Filter, sort, paginate, select rows, and change visible columns in component-local state.",
+    [
+      showcase_demo_section(
+        "Filtering, columns, and pagination",
+        "The black-box table keeps search, sort, selection, visibility, and page state local.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,58rem);margin-inline:auto"],
+            data_table_html,
+          ),
+          FdvDataTableCode,
+          tall=true,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn fdv_items_demo() -> @html.Html {
+  showcase_component_demos(
+    "Item",
+    "Default, outline, and muted surfaces in complete item compositions.",
+    [
+      fdv_demo_section(
+        "Default",
+        "A default item with title and description.",
+        @rui.item(variant=@rui.ItemDefault, size=@rui.ItemDefaultSize, [
+          @rui.item_content([
+            @rui.item_title("Release notes"),
+            @rui.item_description("Documentation for the current release."),
+          ]),
+        ]),
+        FdvItemDefaultCode,
+        stage_variant=ShowcaseStageSurface,
+      ),
+      fdv_demo_section(
+        "Outline small",
+        "A compact outlined item with an action.",
+        @rui.item(variant=@rui.ItemOutline, size=@rui.ItemSm, [
+          @rui.item_media(variant=@rui.ItemMediaIcon, showcase_runtime_icon()),
+          @rui.item_content([
+            @rui.item_title("Runtime"),
+            @rui.item_description("JS and native targets are healthy."),
+          ]),
+          @rui.item_actions(
+            @rui.button(variant=@rui.Ghost, size=@rui.Xs, "Inspect"),
+          ),
+        ]),
+        FdvItemOutlineSmallCode,
+        stage_variant=ShowcaseStageSurface,
+      ),
+      fdv_demo_section(
+        "Muted image",
+        "A muted item with image media and metadata.",
+        @rui.item(variant=@rui.ItemMuted, size=@rui.ItemDefaultSize, [
+          @rui.item_media(
+            variant=@rui.ItemMediaImage,
+            @html.div(
+              style=["width:100%;height:100%;background:var(--rui-muted)"],
+              @html.nothing,
+            ),
+          ),
+          @rui.item_content([
+            @rui.item_header("Preview build"),
+            @rui.item_title("Vega surface"),
+            @rui.item_description("Generated from the current token set."),
+            @rui.item_footer("Updated moments ago"),
+          ]),
+        ]),
+        FdvItemMutedImageCode,
+        stage_variant=ShowcaseStageSurface,
+      ),
+    ],
+  )
+}
+
+///|
+fn fdv_empty_demo() -> @html.Html {
+  showcase_component_demos(
+    "Empty",
+    "Complete empty-state compositions for common actions.",
+    [
+      fdv_demo_section(
+        "Default media",
+        "A default media treatment and action.",
+        @rui.empty(style=["padding:1.5rem 1rem"], [
+          @rui.empty_header([
+            @rui.empty_media(
+              variant=@rui.EmptyMediaDefault,
+              showcase_archive_icon(),
+            ),
+            @rui.empty_title("No archives"),
+            @rui.empty_description("Archived projects will appear here."),
+          ]),
+          @rui.empty_content(@rui.button(size=@rui.Sm, "Browse projects")),
+        ]),
+        FdvEmptyDefaultCode,
+        tall=true,
+      ),
+      fdv_demo_section(
+        "Icon media",
+        "A framed icon treatment and action.",
+        @rui.empty(style=["padding:1.5rem 1rem"], [
+          @rui.empty_header([
+            @rui.empty_media(variant=@rui.EmptyMediaIcon, showcase_plus_icon()),
+            @rui.empty_title("No release channels"),
+            @rui.empty_description("Create a channel for preview builds."),
+          ]),
+          @rui.empty_content(@rui.button(size=@rui.Sm, "Create channel")),
+        ]),
+        FdvEmptyIconCode,
+        tall=true,
+      ),
+    ],
+  )
+}
+
+///|
+fn fdv_marker_demo() -> @html.Html {
+  showcase_component_demos(
+    "Marker",
+    "Default, separator, and border treatments in a release timeline.",
+    [
+      fdv_demo_section(
+        "Default",
+        "A default timeline marker.",
+        @rui.marker(variant=@rui.MarkerDefault, [
+          @rui.marker_icon(showcase_activity_icon()),
+          @rui.marker_content("Deployment started"),
+        ]),
+        FdvMarkerDefaultCode,
+        stage_variant=ShowcaseStageSurface,
+      ),
+      fdv_demo_section(
+        "Separator",
+        "A marker that divides timeline sections.",
+        @rui.marker(variant=@rui.MarkerSeparator, [
+          @rui.marker_icon(showcase_separator_dot_icon()),
+          @rui.marker_content("Today"),
+        ]),
+        FdvMarkerSeparatorCode,
+        stage_variant=ShowcaseStageSurface,
+      ),
+      fdv_demo_section(
+        "Border",
+        "A bordered marker for a completed event.",
+        @rui.marker(variant=@rui.MarkerBorder, [
+          @rui.marker_icon(showcase_check_icon()),
+          @rui.marker_content("Validation complete"),
+        ]),
+        FdvMarkerBorderCode,
+        stage_variant=ShowcaseStageSurface,
+      ),
+    ],
+  )
+}
+
+///|
+fn fdv_progress_demo() -> @html.Html {
+  showcase_component_demos(
+    "Progress",
+    "Indeterminate and determinate progress in complete labelled compositions.",
+    [
+      fdv_demo_section(
+        "Indeterminate",
+        "Progress without a known completion value.",
+        @rui.progress(aria_label="Preparing release", children=[
+          @rui.progress_label("Preparing release"),
+          @rui.progress_value(text="Working"),
+        ]),
+        FdvProgressIndeterminateCode,
+      ),
+      fdv_demo_section(
+        "Determinate",
+        "Progress with a readable completion value.",
+        @rui.progress(value=54, aria_label="Build progress", children=[
+          @rui.progress_label(value=54, "Build"),
+          @rui.progress_value(value=54),
+        ]),
+        FdvProgressDeterminateCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_data_variants(data_table_html : @html.Html) -> @html.Html {
+  @html.fragment([
+    fdv_attachments_demo(),
+    fdv_typography_demo(),
+    fdv_data_table_demo(data_table_html),
+    fdv_items_demo(),
+    fdv_empty_demo(),
+    fdv_marker_demo(),
+    fdv_progress_demo(),
+  ])
+}

--- a/website/homepage/components/foundations_gallery.mbt
+++ b/website/homepage/components/foundations_gallery.mbt
@@ -1,0 +1,1478 @@
+///|
+const FoundationsGalleryStyle : String = "display:flex;min-width:0;flex-direction:column;gap:4rem"
+
+///|
+const FoundationsSectionStyle : String = "display:flex;min-width:0;flex-direction:column;gap:4rem"
+
+///|
+const FoundationsCenteredRowStyle : String = "display:flex;min-width:0;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.75rem"
+
+///|
+const FoundationsNarrowStackStyle : String = "display:flex;width:min(100%,28rem);margin-inline:auto;flex-direction:column;gap:1rem"
+
+///|
+const FoundationsChartPlotStyle : String = "position:absolute;inset:1rem 0.75rem 1.5rem;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));align-items:end;gap:0.625rem;border-bottom:1px solid var(--rui-border)"
+
+///|
+const FoundationsTableNumberStyle : String = "text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums"
+
+///|
+const FoundationsStrokeIconCode : String =
+  #|fn stroke_icon(path : String) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [@svg.path(
+  #|        d=path,
+  #|        fill="none",
+  #|        stroke="currentColor",
+  #|        stroke_width=2,
+  #|        attrs=line_attrs,
+  #|      )],
+  #|    ),
+  #|  )
+  #|}
+  #|
+
+///|
+const FoundationsButtonDefaultCode : String =
+  #|@rui.button("Deploy")
+  #|
+
+///|
+const FoundationsButtonSecondaryCode : String =
+  #|@rui.button(variant=@rui.Secondary, "Duplicate")
+  #|
+
+///|
+const FoundationsButtonOutlineCode : String =
+  #|@rui.button(variant=@rui.Outline, "Preview")
+  #|
+
+///|
+const FoundationsButtonGhostCode : String =
+  #|@rui.button(variant=@rui.Ghost, "More")
+  #|
+
+///|
+const FoundationsButtonDestructiveCode : String =
+  #|@rui.button(variant=@rui.Destructive, "Remove")
+  #|
+
+///|
+const FoundationsButtonLinkCode : String =
+  #|@rui.button(variant=@rui.Link, "Documentation")
+  #|
+
+///|
+const FoundationsButtonLargeCode : String =
+  #|@rui.button(size=@rui.Lg, "Large")
+  #|
+
+///|
+const FoundationsButtonDefaultSizeCode : String =
+  #|@rui.button(size=@rui.Default, "Default")
+  #|
+
+///|
+const FoundationsButtonSmallCode : String =
+  #|@rui.button(size=@rui.Sm, "Small")
+  #|
+
+///|
+const FoundationsButtonExtraSmallCode : String =
+  #|@rui.button(size=@rui.Xs, "Extra small")
+  #|
+
+///|
+const FoundationsButtonIconLargeCode : String = FoundationsStrokeIconCode +
+  (
+    #|@rui.button(
+    #|  size=@rui.IconLg,
+    #|  attrs=@html.Attrs::build().aria_label("Add large item"),
+    #|  stroke_icon("M12 5v14M5 12h14"),
+    #|)
+    #|
+  )
+
+///|
+const FoundationsButtonIconCode : String = FoundationsStrokeIconCode +
+  (
+    #|@rui.button(
+    #|  size=@rui.Icon,
+    #|  attrs=@html.Attrs::build().aria_label("Open settings"),
+    #|  stroke_icon("M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"),
+    #|)
+    #|
+  )
+
+///|
+const FoundationsButtonIconSmallCode : String = FoundationsStrokeIconCode +
+  (
+    #|@rui.button(
+    #|  size=@rui.IconSm,
+    #|  attrs=@html.Attrs::build().aria_label("Change layout"),
+    #|  stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11"),
+    #|)
+    #|
+  )
+
+///|
+const FoundationsButtonIconExtraSmallCode : String = FoundationsStrokeIconCode +
+  (
+    #|@rui.button(
+    #|  size=@rui.IconXs,
+    #|  attrs=@html.Attrs::build().aria_label("Close"),
+    #|  stroke_icon("M18 6 6 18M6 6l12 12"),
+    #|)
+    #|
+  )
+
+///|
+const FoundationsBadgeDefaultCode : String =
+  #|@rui.badge("Ready")
+  #|
+
+///|
+const FoundationsBadgeSecondaryCode : String =
+  #|@rui.badge(variant=@rui.Secondary, "Draft")
+  #|
+
+///|
+const FoundationsBadgeOutlineCode : String =
+  #|@rui.badge(variant=@rui.Outline, "v0.2.0")
+  #|
+
+///|
+const FoundationsBadgeDestructiveCode : String =
+  #|@rui.badge(variant=@rui.Destructive, "Failed")
+  #|
+
+///|
+const FoundationsBadgeGhostCode : String =
+  #|@rui.badge(variant=@rui.Ghost, "Archived")
+  #|
+
+///|
+const FoundationsBadgeLinkCode : String =
+  #|@rui.badge_link(href="#forms", variant=@rui.Link, "Open forms")
+  #|
+
+///|
+const FoundationsButtonGroupHorizontalCode : String =
+  #|@html.div(
+  #|  style=[
+  #|    "display:flex;min-width:0;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.75rem",
+  #|  ],
+  #|  @rui.button_group(aria_label="Release actions", [
+  #|    @rui.button(variant=@rui.Outline, "Preview"),
+  #|    @rui.button(variant=@rui.Outline, "Publish"),
+  #|    @rui.button_group_separator(),
+  #|    @rui.button_group_text("v0.2"),
+  #|  ]),
+  #|)
+  #|
+
+///|
+const FoundationsButtonGroupVerticalCode : String =
+  #|fn stroke_icon(path : String) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=[
+  #|      "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none",
+  #|    ],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d=path,
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn vertical_button_group_demo() -> @html.Html {
+  #|  @html.div(
+  #|    style=[
+  #|      "display:flex;min-width:0;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.75rem",
+  #|    ],
+  #|    @rui.button_group(
+  #|      orientation=@rui.Vertical,
+  #|      aria_label="Canvas zoom",
+  #|      [
+  #|        @rui.button(
+  #|          variant=@rui.Outline,
+  #|          size=@rui.IconSm,
+  #|          attrs=@html.Attrs::build().aria_label("Zoom in"),
+  #|          stroke_icon("M12 5v14M5 12h14"),
+  #|        ),
+  #|        @rui.button(
+  #|          variant=@rui.Outline,
+  #|          size=@rui.IconSm,
+  #|          attrs=@html.Attrs::build().aria_label("Reset layout"),
+  #|          stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11"),
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+
+///|
+const FoundationsToggleOutlineLargeCode : String =
+  #|@rui.toggle(
+  #|  variant=@rui.Outline,
+  #|  size=@rui.Lg,
+  #|  aria_label="Pin release",
+  #|  "Pin release",
+  #|)
+  #|
+
+///|
+const FoundationsToggleDefaultSmallCode : String =
+  #|@rui.toggle(
+  #|  variant=@rui.Default,
+  #|  size=@rui.Sm,
+  #|  aria_label="Watch release",
+  #|  "Watch",
+  #|)
+  #|
+
+///|
+const FoundationsToggleGroupSingleCode : String =
+  #|fn layout_toggle_group() -> @rabbita.Val[@html.Html] {
+  #|  let group = @rui.toggle_group(
+  #|    default_values=["grid"],
+  #|    variant=@rui.Outline,
+  #|    size=@rui.Sm,
+  #|    aria_label="Preview layout",
+  #|    scope => @html.fragment([
+  #|      @rui.toggle_group_item(
+  #|        scope~,
+  #|        value="list",
+  #|        aria_label="List",
+  #|        "List",
+  #|      ),
+  #|      @rui.toggle_group_item(
+  #|        scope~,
+  #|        value="grid",
+  #|        aria_label="Grid",
+  #|        "Grid",
+  #|      ),
+  #|    ]),
+  #|  )
+  #|  group.view(group => {
+  #|    @html.div(
+  #|      style=[
+  #|        "display:flex;min-width:0;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.75rem",
+  #|      ],
+  #|      group,
+  #|    )
+  #|  })
+  #|}
+  #|
+
+///|
+const FoundationsToggleGroupMultipleCode : String =
+  #|fn stroke_icon(path : String) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=[
+  #|      "display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none",
+  #|    ],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d=path,
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn formatting_toggle_group() -> @rabbita.Val[@html.Html] {
+  #|  let group = @rui.toggle_group(
+  #|    default_values=["bold"],
+  #|    multiple=true,
+  #|    variant=@rui.Default,
+  #|    size=@rui.Lg,
+  #|    aria_label="Text formatting",
+  #|    scope => @html.fragment([
+  #|      @rui.toggle_group_item(
+  #|        scope~,
+  #|        value="bold",
+  #|        aria_label="Bold",
+  #|        stroke_icon("M6 4h8a4 4 0 0 1 0 8H6zM6 12h9a4 4 0 0 1 0 8H6z"),
+  #|      ),
+  #|      @rui.toggle_group_item(
+  #|        scope~,
+  #|        value="italic",
+  #|        aria_label="Italic",
+  #|        stroke_icon("M19 4h-9M14 20H5M15 4 9 20"),
+  #|      ),
+  #|      @rui.toggle_group_item(
+  #|        scope~,
+  #|        value="underline",
+  #|        aria_label="Underline",
+  #|        stroke_icon("M6 3v7a6 6 0 0 0 12 0V3M4 21h16"),
+  #|      ),
+  #|    ]),
+  #|  )
+  #|  group.view(group => {
+  #|    @html.div(
+  #|      style=[
+  #|        "display:flex;min-width:0;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.75rem",
+  #|      ],
+  #|      group,
+  #|    )
+  #|  })
+  #|}
+  #|
+
+///|
+const FoundationsLabelDefaultCode : String =
+  #|@rui.field([
+  #|  @rui.label(for_="workspace-name", "Workspace name"),
+  #|  @rui.input(id="workspace-name", placeholder="rabbit-tea"),
+  #|])
+  #|
+
+///|
+const FoundationsLabelDisabledCode : String =
+  #|@rui.field([
+  #|  @rui.label(for_="managed-name", disabled=true, "Managed name"),
+  #|  @rui.input(id="managed-name", disabled=true, value="Production"),
+  #|])
+  #|
+
+///|
+const FoundationsKbdKeyCode : String =
+  #|@rui.kbd("Escape")
+  #|
+
+///|
+const FoundationsKbdShortcutCode : String =
+  #|@rui.kbd_group([@rui.kbd("Ctrl"), @rui.kbd("K")])
+  #|
+
+///|
+const FoundationsSpinnerInlineCode : String =
+  #|@html.div(style=["display:flex;flex-wrap:wrap;align-items:center;gap:0.75rem"], [
+  #|  @rui.spinner(label="Saving release"),
+  #|  @html.span("Saving release metadata"),
+  #|])
+  #|
+
+///|
+const FoundationsSpinnerButtonCode : String =
+  #|@rui.button(disabled=true, [
+  #|  @rui.spinner(label="Publishing"),
+  #|  @html.span("Publishing"),
+  #|])
+  #|
+
+///|
+const FoundationsAlertDefaultCode : String =
+  #|@rui.alert([
+  #|  @rui.alert_title("Deployment is ready"),
+  #|  @rui.alert_description("The preview passed all required checks."),
+  #|  @rui.alert_action(@rui.button(variant=@rui.Ghost, size=@rui.Xs, "View")),
+  #|])
+  #|
+
+///|
+const FoundationsAlertDestructiveCode : String =
+  #|@rui.alert(variant=@rui.Destructive, [
+  #|  @rui.alert_title("Two checks need attention"),
+  #|  @rui.alert_description("Update the package lock before publishing."),
+  #|])
+  #|
+
+///|
+const FoundationsMessageStartCode : String =
+  #|@rui.message_group(
+  #|  style=[
+  #|    "display:flex;width:min(100%,42rem);min-width:0;margin-inline:auto;flex-direction:column",
+  #|  ],
+  #|  [
+  #|    @rui.message([
+  #|      @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("YO"))),
+  #|      @rui.message_content([
+  #|        @rui.message_header("You · 09:41"),
+  #|        @rui.bubble_group([
+  #|          @rui.bubble(@rui.bubble_content(
+  #|            "The native package is ready. Can you review the component gallery?",
+  #|          )),
+  #|        ]),
+  #|        @rui.message_footer("Delivered"),
+  #|      ]),
+  #|    ]),
+  #|  ],
+  #|)
+  #|
+
+///|
+const FoundationsMessageEndCode : String =
+  #|@rui.message_group(
+  #|  style=[
+  #|    "display:flex;width:min(100%,42rem);min-width:0;margin-inline:auto;flex-direction:column",
+  #|  ],
+  #|  [
+  #|    @rui.message(align=@rui.AlignEnd, [
+  #|      @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("RA"))),
+  #|      @rui.message_content([
+  #|        @rui.message_header("Rabbita · 09:42"),
+  #|        @rui.bubble_group([
+  #|          @rui.bubble(variant=@rui.BubbleSecondary, [
+  #|            @rui.bubble_content(
+  #|              "Reviewed. The inline styles and native semantics are both visible.",
+  #|            ),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ]),
+  #|  ],
+  #|)
+  #|
+
+///|
+const FoundationsBubbleDefaultCode : String =
+  #|@rui.bubble(align=@rui.AlignEnd, [
+  #|  @rui.bubble_content("Default · current-user emphasis"),
+  #|])
+  #|
+
+///|
+const FoundationsBubbleSecondaryCode : String =
+  #|@rui.bubble(variant=@rui.BubbleSecondary, [
+  #|  @rui.bubble_content("Secondary · neutral conversation"),
+  #|])
+  #|
+
+///|
+const FoundationsBubbleMutedCode : String =
+  #|@rui.bubble(variant=@rui.BubbleMuted, [
+  #|  @rui.bubble_content("Muted · quiet supporting text"),
+  #|])
+  #|
+
+///|
+const FoundationsBubbleTintedCode : String =
+  #|@rui.bubble(variant=@rui.BubbleTinted, [
+  #|  @rui.bubble_content("Tinted · primary-derived surface"),
+  #|])
+  #|
+
+///|
+const FoundationsBubbleOutlineCode : String =
+  #|@rui.bubble(variant=@rui.BubbleOutline, [
+  #|  @rui.bubble_content_link(href="#forms", "Open form controls"),
+  #|])
+  #|
+
+///|
+const FoundationsBubbleGhostCode : String =
+  #|@rui.bubble(variant=@rui.BubbleGhost, [
+  #|  @rui.bubble_content("Ghost · unframed assistant content."),
+  #|])
+  #|
+
+///|
+const FoundationsBubbleDestructiveCode : String =
+  #|@rui.bubble(variant=@rui.BubbleDestructive, [
+  #|  @rui.bubble_content("Destructive · an action failed."),
+  #|])
+  #|
+
+///|
+const FoundationsChartCode : String =
+  #|fn chart_bar(label : String, height : String, color : String) -> @html.Html {
+  #|  @html.div(
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    style=[
+  #|      "position:relative;height:\{height};min-height:1.25rem;border-radius:0.375rem 0.375rem 0 0;background:\{color}",
+  #|    ],
+  #|    @html.span(
+  #|      style=[
+  #|        "position:absolute;top:100%;left:50%;padding-top:0.375rem;color:var(--rui-muted-foreground);font-size:0.625rem;line-height:0.75rem;transform:translateX(-50%)",
+  #|      ],
+  #|      label,
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn chart_demo() -> @html.Html {
+  #|  @html.div(style=["display:flex;flex-direction:column;gap:1rem"], [
+  #|    @html.div(
+  #|      style=["display:flex;justify-content:flex-end"],
+  #|      @rui.badge(variant=@rui.Outline, "+18.4%"),
+  #|    ),
+  #|    @rui.chart_style(
+  #|      variables=[
+  #|        ("stable", "oklch(0.56 0.18 258)"),
+  #|        ("preview", "oklch(0.72 0.15 72)"),
+  #|      ],
+  #|      @html.div(
+  #|        style=[
+  #|          "display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr));gap:1rem;align-items:center",
+  #|        ],
+  #|        [
+  #|          @rui.chart_container(
+  #|            aria_label="Release downloads from Monday through Friday",
+  #|            aspect="5 / 2",
+  #|            style=[
+  #|              "position:relative;display:block;min-height:12rem;border:1px solid var(--rui-border);border-radius:0.625rem;background:linear-gradient(to bottom,color-mix(in oklab,var(--rui-muted) 42%,transparent) 1px,transparent 1px);background-size:100% 25%",
+  #|            ],
+  #|            [
+  #|              @html.div(
+  #|                style=[
+  #|                  "position:absolute;inset:1rem 0.75rem 1.5rem;display:grid;grid-template-columns:repeat(5,minmax(0,1fr));align-items:end;gap:0.625rem;border-bottom:1px solid var(--rui-border)",
+  #|                ],
+  #|                [
+  #|                  chart_bar("Mon", "42%", "var(--color-stable)"),
+  #|                  chart_bar("Tue", "58%", "var(--color-stable)"),
+  #|                  chart_bar("Wed", "51%", "var(--color-preview)"),
+  #|                  chart_bar("Thu", "76%", "var(--color-stable)"),
+  #|                  chart_bar("Fri", "88%", "var(--color-stable)"),
+  #|                ],
+  #|              ),
+  #|            ],
+  #|          ),
+  #|          @html.div(style=["display:flex;flex-direction:column;gap:1rem"], [
+  #|            @rui.chart_tooltip(@rui.chart_tooltip_content([
+  #|              @rui.chart_tooltip_label("Friday"),
+  #|              @rui.chart_tooltip_item(
+  #|                label="Stable",
+  #|                value="8,842",
+  #|                color="var(--color-stable)",
+  #|              ),
+  #|              @rui.chart_tooltip_item(
+  #|                label="Preview",
+  #|                value="1,204",
+  #|                color="var(--color-preview)",
+  #|                indicator=@rui.ChartDashed,
+  #|              ),
+  #|            ])),
+  #|            @rui.chart_legend_content(
+  #|              style=["justify-content:flex-start;padding:0"],
+  #|              [
+  #|                @rui.chart_legend_item(color="var(--color-stable)", "Stable"),
+  #|                @rui.chart_legend_item(color="var(--color-preview)", "Preview"),
+  #|              ],
+  #|            ),
+  #|          ]),
+  #|        ],
+  #|      ),
+  #|    ),
+  #|  ])
+  #|}
+  #|
+
+///|
+const FoundationsTableCode : String =
+  #|@rui.table([
+  #|  @rui.table_caption("Latest verified builds across supported targets"),
+  #|  @rui.table_header(@rui.table_row([
+  #|    @rui.table_head("Package"),
+  #|    @rui.table_head("Target"),
+  #|    @rui.table_head("Status"),
+  #|    @rui.table_head(
+  #|      style=["text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums"],
+  #|      "Tests",
+  #|    ),
+  #|  ])),
+  #|  @rui.table_body([
+  #|    @rui.table_row([
+  #|      @rui.table_cell("rui"),
+  #|      @rui.table_cell("JavaScript"),
+  #|      @rui.table_cell(@rui.badge("Passing")),
+  #|      @rui.table_cell(
+  #|        style=["text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums"],
+  #|        "Full suite",
+  #|      ),
+  #|    ]),
+  #|    @rui.table_row([
+  #|      @rui.table_cell("rui"),
+  #|      @rui.table_cell("Native"),
+  #|      @rui.table_cell(@rui.badge(variant=@rui.Secondary, "Passing")),
+  #|      @rui.table_cell(
+  #|        style=["text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums"],
+  #|        "Full suite",
+  #|      ),
+  #|    ]),
+  #|    @rui.table_row([
+  #|      @rui.table_cell("showcase"),
+  #|      @rui.table_cell("In-app browser"),
+  #|      @rui.table_cell(@rui.badge(variant=@rui.Outline, "Replayed")),
+  #|      @rui.table_cell(
+  #|        style=["text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums"],
+  #|        "Key flows",
+  #|      ),
+  #|    ]),
+  #|  ]),
+  #|  @rui.table_footer(@rui.table_row([
+  #|    @rui.table_cell(colspan=3, "Automated targets"),
+  #|    @rui.table_cell(
+  #|      style=["text-align:right;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums"],
+  #|      "JS + native",
+  #|    ),
+  #|  ])),
+  #|])
+  #|
+
+///|
+fn foundations_chart_bar(
+  label : String,
+  height : String,
+  color : String,
+) -> @html.Html {
+  @html.div(
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    style=[
+      "position:relative;height:\{height};min-height:1.25rem;border-radius:0.375rem 0.375rem 0 0;background:\{color}",
+    ],
+    @html.span(
+      style=[
+        "position:absolute;top:100%;left:50%;padding-top:0.375rem;color:var(--rui-muted-foreground);font-size:0.625rem;line-height:0.75rem;transform:translateX(-50%)",
+      ],
+      label,
+    ),
+  )
+}
+
+///|
+fn foundations_single_demo(
+  title : String,
+  description : String,
+  variant_title : String,
+  variant_description : String,
+  body : @html.Html,
+  code : String,
+  surface : Bool,
+  tall : Bool,
+) -> @html.Html {
+  let variant = if surface { ShowcaseStageSurface } else { ShowcaseStagePlain }
+  showcase_component_demos(title, description, [
+    showcase_demo_section(
+      variant_title,
+      variant_description,
+      showcase_demo_stage(body, code, variant~, tall~),
+    ),
+  ])
+}
+
+///|
+fn foundations_centered_section(
+  title : String,
+  description : String,
+  body : @html.Html,
+  code : String,
+  surface? : Bool = true,
+) -> ShowcaseDemoEntry {
+  let variant = if surface { ShowcaseStageSurface } else { ShowcaseStagePlain }
+  showcase_demo_section(
+    title,
+    description,
+    showcase_demo_stage(
+      @html.div(style=[FoundationsCenteredRowStyle], body),
+      code,
+      variant~,
+    ),
+  )
+}
+
+///|
+fn foundations_button_demo() -> @html.Html {
+  showcase_component_demos(
+    "Button",
+    "Action controls across the complete Vega variant and size set.",
+    [
+      foundations_centered_section(
+        "Default",
+        "Primary action.",
+        @rui.button("Deploy"),
+        FoundationsButtonDefaultCode,
+      ),
+      foundations_centered_section(
+        "Secondary",
+        "Lower-emphasis action.",
+        @rui.button(variant=@rui.Secondary, "Duplicate"),
+        FoundationsButtonSecondaryCode,
+      ),
+      foundations_centered_section(
+        "Outline",
+        "Bordered action.",
+        @rui.button(variant=@rui.Outline, "Preview"),
+        FoundationsButtonOutlineCode,
+      ),
+      foundations_centered_section(
+        "Ghost",
+        "Unframed action.",
+        @rui.button(variant=@rui.Ghost, "More"),
+        FoundationsButtonGhostCode,
+      ),
+      foundations_centered_section(
+        "Destructive",
+        "Destructive action.",
+        @rui.button(variant=@rui.Destructive, "Remove"),
+        FoundationsButtonDestructiveCode,
+      ),
+      foundations_centered_section(
+        "Link",
+        "Action styled as a link.",
+        @rui.button(variant=@rui.Link, "Documentation"),
+        FoundationsButtonLinkCode,
+      ),
+      foundations_centered_section(
+        "Large",
+        "Large text button.",
+        @rui.button(size=@rui.Lg, "Large"),
+        FoundationsButtonLargeCode,
+      ),
+      foundations_centered_section(
+        "Default size",
+        "Default text-button size.",
+        @rui.button(size=@rui.Default, "Default"),
+        FoundationsButtonDefaultSizeCode,
+      ),
+      foundations_centered_section(
+        "Small",
+        "Small text button.",
+        @rui.button(size=@rui.Sm, "Small"),
+        FoundationsButtonSmallCode,
+      ),
+      foundations_centered_section(
+        "Extra small",
+        "Extra-small text button.",
+        @rui.button(size=@rui.Xs, "Extra small"),
+        FoundationsButtonExtraSmallCode,
+      ),
+      foundations_centered_section(
+        "Large icon",
+        "Large icon-only button.",
+        @rui.button(
+          size=@rui.IconLg,
+          attrs=@html.Attrs::build().aria_label("Add large item"),
+          showcase_plus_icon(),
+        ),
+        FoundationsButtonIconLargeCode,
+      ),
+      foundations_centered_section(
+        "Default icon",
+        "Default icon-only button.",
+        @rui.button(
+          size=@rui.Icon,
+          attrs=@html.Attrs::build().aria_label("Open settings"),
+          showcase_settings_icon(),
+        ),
+        FoundationsButtonIconCode,
+      ),
+      foundations_centered_section(
+        "Small icon",
+        "Small icon-only button.",
+        @rui.button(
+          size=@rui.IconSm,
+          attrs=@html.Attrs::build().aria_label("Change layout"),
+          showcase_layout_icon(),
+        ),
+        FoundationsButtonIconSmallCode,
+      ),
+      foundations_centered_section(
+        "Extra-small icon",
+        "Extra-small icon-only button.",
+        @rui.button(
+          size=@rui.IconXs,
+          attrs=@html.Attrs::build().aria_label("Close"),
+          showcase_close_icon(),
+        ),
+        FoundationsButtonIconExtraSmallCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_badge_demo() -> @html.Html {
+  showcase_component_demos(
+    "Badge",
+    "Compact status labels and a semantic link treatment.",
+    [
+      foundations_centered_section(
+        "Default",
+        "Primary status label.",
+        @rui.badge("Ready"),
+        FoundationsBadgeDefaultCode,
+      ),
+      foundations_centered_section(
+        "Secondary",
+        "Lower-emphasis status label.",
+        @rui.badge(variant=@rui.Secondary, "Draft"),
+        FoundationsBadgeSecondaryCode,
+      ),
+      foundations_centered_section(
+        "Outline",
+        "Bordered status label.",
+        @rui.badge(variant=@rui.Outline, "v0.2.0"),
+        FoundationsBadgeOutlineCode,
+      ),
+      foundations_centered_section(
+        "Destructive",
+        "Failure status label.",
+        @rui.badge(variant=@rui.Destructive, "Failed"),
+        FoundationsBadgeDestructiveCode,
+      ),
+      foundations_centered_section(
+        "Ghost",
+        "Quiet status label.",
+        @rui.badge(variant=@rui.Ghost, "Archived"),
+        FoundationsBadgeGhostCode,
+      ),
+      foundations_centered_section(
+        "Link",
+        "Navigable badge.",
+        @rui.badge_link(href="#forms", variant=@rui.Link, "Open forms"),
+        FoundationsBadgeLinkCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_button_group_demo() -> @html.Html {
+  showcase_component_demos(
+    "Button Group",
+    "Related actions merge borders and corners while keeping native button behavior.",
+    [
+      showcase_demo_section(
+        "Horizontal",
+        "Actions, a separator, and supporting text share one contiguous row.",
+        showcase_demo_stage(
+          @html.div(
+            style=[FoundationsCenteredRowStyle],
+            @rui.button_group(aria_label="Release actions", [
+              @rui.button(variant=@rui.Outline, "Preview"),
+              @rui.button(variant=@rui.Outline, "Publish"),
+              @rui.button_group_separator(),
+              @rui.button_group_text("v0.2"),
+            ]),
+          ),
+          FoundationsButtonGroupHorizontalCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Vertical",
+        "Icon actions stack without duplicating their adjoining borders.",
+        showcase_demo_stage(
+          @html.div(
+            style=[FoundationsCenteredRowStyle],
+            @rui.button_group(
+              orientation=@rui.Vertical,
+              aria_label="Canvas zoom",
+              [
+                @rui.button(
+                  variant=@rui.Outline,
+                  size=@rui.IconSm,
+                  attrs=@html.Attrs::build().aria_label("Zoom in"),
+                  showcase_plus_icon(),
+                ),
+                @rui.button(
+                  variant=@rui.Outline,
+                  size=@rui.IconSm,
+                  attrs=@html.Attrs::build().aria_label("Reset layout"),
+                  showcase_layout_icon(),
+                ),
+              ],
+            ),
+          ),
+          FoundationsButtonGroupVerticalCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_toggle_demo(
+  pin_html : @html.Html,
+  watch_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Toggle",
+    "A black-box pressed control with default, outline, and size variants.",
+    [
+      foundations_centered_section(
+        "Outline large",
+        "A large outlined toggle owns its pressed state.",
+        pin_html,
+        FoundationsToggleOutlineLargeCode,
+      ),
+      foundations_centered_section(
+        "Default small",
+        "A small default toggle owns its pressed state.",
+        watch_html,
+        FoundationsToggleDefaultSmallCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_toggle_group_demo(
+  density_html : @html.Html,
+  formatting_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Toggle Group",
+    "Single- and multi-selection groups own selection and roving keyboard focus.",
+    [
+      showcase_demo_section(
+        "Single selection",
+        "Choose one preview layout from a compact outline group.",
+        showcase_demo_stage(
+          @html.div(style=[FoundationsCenteredRowStyle], density_html),
+          FoundationsToggleGroupSingleCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Multiple selection",
+        "Formatting actions can be combined independently.",
+        showcase_demo_stage(
+          @html.div(style=[FoundationsCenteredRowStyle], formatting_html),
+          FoundationsToggleGroupMultipleCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_label_demo() -> @html.Html {
+  showcase_component_demos(
+    "Label",
+    "Native labels preserve explicit control relationships and disabled styling.",
+    [
+      showcase_demo_section(
+        "Default",
+        "The label remains explicitly associated with its input.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,24rem);margin-inline:auto"],
+            @rui.field([
+              @rui.label(for_="workspace-name", "Workspace name"),
+              @rui.input(id="workspace-name", placeholder="rabbit-tea"),
+            ]),
+          ),
+          FoundationsLabelDefaultCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Disabled",
+        "Disabled styling applies to both label and associated input.",
+        showcase_demo_stage(
+          @html.div(
+            style=["width:min(100%,24rem);margin-inline:auto"],
+            @rui.field([
+              @rui.label(for_="managed-name", disabled=true, "Managed name"),
+              @rui.input(id="managed-name", disabled=true, value="Production"),
+            ]),
+          ),
+          FoundationsLabelDisabledCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_kbd_demo() -> @html.Html {
+  showcase_component_demos(
+    "Kbd",
+    "Keyboard input is rendered as single keys or compact shortcut groups.",
+    [
+      foundations_centered_section(
+        "Key",
+        "A single named key.",
+        @rui.kbd("Escape"),
+        FoundationsKbdKeyCode,
+      ),
+      foundations_centered_section(
+        "Shortcut",
+        "A compact multi-key shortcut.",
+        @rui.kbd_group([@rui.kbd("Ctrl"), @rui.kbd("K")]),
+        FoundationsKbdShortcutCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_spinner_demo() -> @html.Html {
+  showcase_component_demos(
+    "Spinner",
+    "A CSS-animated status indicator works inline or inside an action.",
+    [
+      foundations_centered_section(
+        "Inline",
+        "An inline status indicator with visible context.",
+        @html.div(style=[RowStyle], [
+          @rui.spinner(label="Saving release"),
+          @html.span("Saving release metadata"),
+        ]),
+        FoundationsSpinnerInlineCode,
+      ),
+      foundations_centered_section(
+        "In a button",
+        "A spinner inside a disabled pending action.",
+        @rui.button(disabled=true, [
+          @rui.spinner(label="Publishing"),
+          @html.span("Publishing"),
+        ]),
+        FoundationsSpinnerButtonCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_alert_demo() -> @html.Html {
+  showcase_component_demos(
+    "Alert",
+    "Semantic live regions with default and destructive treatments.",
+    [
+      showcase_demo_section(
+        "Default",
+        "An optional action shares the same alert grid.",
+        showcase_demo_stage(
+          @html.div(
+            style=[FoundationsNarrowStackStyle],
+            @rui.alert([
+              @rui.alert_title("Deployment is ready"),
+              @rui.alert_description("The preview passed all required checks."),
+              @rui.alert_action(
+                @rui.button(variant=@rui.Ghost, size=@rui.Xs, "View"),
+              ),
+            ]),
+          ),
+          FoundationsAlertDefaultCode,
+          variant=ShowcaseStagePlain,
+        ),
+      ),
+      showcase_demo_section(
+        "Destructive",
+        "A destructive live region calls out a failure.",
+        showcase_demo_stage(
+          @html.div(
+            style=[FoundationsNarrowStackStyle],
+            @rui.alert(variant=@rui.Destructive, [
+              @rui.alert_title("Two checks need attention"),
+              @rui.alert_description(
+                "Update the package lock before publishing.",
+              ),
+            ]),
+          ),
+          FoundationsAlertDestructiveCode,
+          variant=ShowcaseStagePlain,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_message_demo() -> @html.Html {
+  showcase_component_demos(
+    "Message",
+    "Conversation rows compose avatar, alignment, metadata, and Bubble surfaces.",
+    [
+      showcase_demo_section(
+        "Start aligned",
+        "Avatar, header, bubble, and footer align to the start.",
+        showcase_demo_stage(
+          @rui.message_group(
+            style=[
+              "display:flex;width:min(100%,42rem);min-width:0;margin-inline:auto;flex-direction:column",
+            ],
+            [
+              @rui.message([
+                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("YO"))),
+                @rui.message_content([
+                  @rui.message_header("You · 09:41"),
+                  @rui.bubble_group([
+                    @rui.bubble(
+                      @rui.bubble_content(
+                        "The native package is ready. Can you review the component gallery?",
+                      ),
+                    ),
+                  ]),
+                  @rui.message_footer("Delivered"),
+                ]),
+              ]),
+            ],
+          ),
+          FoundationsMessageStartCode,
+          variant=ShowcaseStageSurface,
+          tall=true,
+        ),
+      ),
+      showcase_demo_section(
+        "End aligned",
+        "Avatar, header, and bubble align to the end.",
+        showcase_demo_stage(
+          @rui.message_group(
+            style=[
+              "display:flex;width:min(100%,42rem);min-width:0;margin-inline:auto;flex-direction:column",
+            ],
+            [
+              @rui.message(align=@rui.AlignEnd, [
+                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("RA"))),
+                @rui.message_content([
+                  @rui.message_header("Rabbita · 09:42"),
+                  @rui.bubble_group([
+                    @rui.bubble(variant=@rui.BubbleSecondary, [
+                      @rui.bubble_content(
+                        "Reviewed. The inline styles and native semantics are both visible.",
+                      ),
+                    ]),
+                  ]),
+                ]),
+              ]),
+            ],
+          ),
+          FoundationsMessageEndCode,
+          variant=ShowcaseStageSurface,
+          tall=true,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_bubble_demo() -> @html.Html {
+  showcase_component_demos(
+    "Bubble",
+    "All seven Vega treatments share root-owned color, alignment, focus, hover, and press states.",
+    [
+      foundations_centered_section(
+        "Default",
+        "Current-user emphasis.",
+        @rui.bubble(align=@rui.AlignEnd, [
+          @rui.bubble_content("Default · current-user emphasis"),
+        ]),
+        FoundationsBubbleDefaultCode,
+      ),
+      foundations_centered_section(
+        "Secondary",
+        "Neutral conversation surface.",
+        @rui.bubble(variant=@rui.BubbleSecondary, [
+          @rui.bubble_content("Secondary · neutral conversation"),
+        ]),
+        FoundationsBubbleSecondaryCode,
+      ),
+      foundations_centered_section(
+        "Muted",
+        "Quiet supporting surface.",
+        @rui.bubble(variant=@rui.BubbleMuted, [
+          @rui.bubble_content("Muted · quiet supporting text"),
+        ]),
+        FoundationsBubbleMutedCode,
+      ),
+      foundations_centered_section(
+        "Tinted",
+        "Primary-derived surface.",
+        @rui.bubble(variant=@rui.BubbleTinted, [
+          @rui.bubble_content("Tinted · primary-derived surface"),
+        ]),
+        FoundationsBubbleTintedCode,
+      ),
+      foundations_centered_section(
+        "Outline link",
+        "Bordered navigable content.",
+        @rui.bubble(variant=@rui.BubbleOutline, [
+          @rui.bubble_content_link(href="#forms", "Open form controls"),
+        ]),
+        FoundationsBubbleOutlineCode,
+      ),
+      foundations_centered_section(
+        "Ghost",
+        "Unframed assistant content.",
+        @rui.bubble(variant=@rui.BubbleGhost, [
+          @rui.bubble_content("Ghost · unframed assistant content."),
+        ]),
+        FoundationsBubbleGhostCode,
+      ),
+      foundations_centered_section(
+        "Destructive",
+        "Failed action content.",
+        @rui.bubble(variant=@rui.BubbleDestructive, [
+          @rui.bubble_content("Destructive · an action failed."),
+        ]),
+        FoundationsBubbleDestructiveCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_chart_demo() -> @html.Html {
+  foundations_single_demo(
+    "Chart",
+    "Chart primitives wrap application-owned marks, legends, and tooltip content.",
+    "Container, tooltip, and legend",
+    "Theme variables flow through the plot and its supporting content.",
+    @html.div(style=[StackStyle], [
+      @html.div(
+        style=["display:flex;justify-content:flex-end"],
+        @rui.badge(variant=@rui.Outline, "+18.4%"),
+      ),
+      @rui.chart_style(
+        variables=[
+          ("stable", "oklch(0.56 0.18 258)"),
+          ("preview", "oklch(0.72 0.15 72)"),
+        ],
+        @html.div(
+          style=[
+            "display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr));gap:1rem;align-items:center",
+          ],
+          [
+            @rui.chart_container(
+              aria_label="Release downloads from Monday through Friday",
+              aspect="5 / 2",
+              style=[
+                "position:relative;display:block;min-height:12rem;border:1px solid var(--rui-border);border-radius:0.625rem;background:linear-gradient(to bottom,color-mix(in oklab,var(--rui-muted) 42%,transparent) 1px,transparent 1px);background-size:100% 25%",
+              ],
+              [
+                @html.div(style=[FoundationsChartPlotStyle], [
+                  foundations_chart_bar("Mon", "42%", "var(--color-stable)"),
+                  foundations_chart_bar("Tue", "58%", "var(--color-stable)"),
+                  foundations_chart_bar("Wed", "51%", "var(--color-preview)"),
+                  foundations_chart_bar("Thu", "76%", "var(--color-stable)"),
+                  foundations_chart_bar("Fri", "88%", "var(--color-stable)"),
+                ]),
+              ],
+            ),
+            @html.div(style=[StackStyle], [
+              @rui.chart_tooltip(
+                @rui.chart_tooltip_content([
+                  @rui.chart_tooltip_label("Friday"),
+                  @rui.chart_tooltip_item(
+                    label="Stable",
+                    value="8,842",
+                    color="var(--color-stable)",
+                  ),
+                  @rui.chart_tooltip_item(
+                    label="Preview",
+                    value="1,204",
+                    color="var(--color-preview)",
+                    indicator=@rui.ChartDashed,
+                  ),
+                ]),
+              ),
+              @rui.chart_legend_content(
+                style=["justify-content:flex-start;padding:0"],
+                [
+                  @rui.chart_legend_item(color="var(--color-stable)", "Stable"),
+                  @rui.chart_legend_item(
+                    color="var(--color-preview)",
+                    "Preview",
+                  ),
+                ],
+              ),
+            ]),
+          ],
+        ),
+      ),
+    ]),
+    FoundationsChartCode,
+    false,
+    true,
+  )
+}
+
+///|
+fn foundations_table_demo() -> @html.Html {
+  foundations_single_demo(
+    "Table",
+    "A native table with caption, header, body, and summary footer.",
+    "Complete table",
+    "A caption and footer preserve context around dense row data.",
+    @rui.table([
+      @rui.table_caption("Latest verified builds across supported targets"),
+      @rui.table_header(
+        @rui.table_row([
+          @rui.table_head("Package"),
+          @rui.table_head("Target"),
+          @rui.table_head("Status"),
+          @rui.table_head(style=[FoundationsTableNumberStyle], "Tests"),
+        ]),
+      ),
+      @rui.table_body([
+        @rui.table_row([
+          @rui.table_cell("rui"),
+          @rui.table_cell("JavaScript"),
+          @rui.table_cell(@rui.badge("Passing")),
+          @rui.table_cell(style=[FoundationsTableNumberStyle], "Full suite"),
+        ]),
+        @rui.table_row([
+          @rui.table_cell("rui"),
+          @rui.table_cell("Native"),
+          @rui.table_cell(@rui.badge(variant=@rui.Secondary, "Passing")),
+          @rui.table_cell(style=[FoundationsTableNumberStyle], "Full suite"),
+        ]),
+        @rui.table_row([
+          @rui.table_cell("showcase"),
+          @rui.table_cell("In-app browser"),
+          @rui.table_cell(@rui.badge(variant=@rui.Outline, "Replayed")),
+          @rui.table_cell(style=[FoundationsTableNumberStyle], "Key flows"),
+        ]),
+      ]),
+      @rui.table_footer(
+        @rui.table_row([
+          @rui.table_cell(colspan=3, "Automated targets"),
+          @rui.table_cell(style=[FoundationsTableNumberStyle], "JS + native"),
+        ]),
+      ),
+    ]),
+    FoundationsTableCode,
+    false,
+    true,
+  )
+}
+
+///|
+fn foundations_identity_gallery_view(
+  pin_html : @html.Html,
+  watch_html : @html.Html,
+  density_html : @html.Html,
+  formatting_html : @html.Html,
+) -> @html.Html {
+  @html.section(style=[FoundationsSectionStyle], [
+    foundations_button_demo(),
+    foundations_badge_demo(),
+    foundations_button_group_demo(),
+    foundations_toggle_demo(pin_html, watch_html),
+    foundations_toggle_group_demo(density_html, formatting_html),
+    foundations_label_demo(),
+    foundations_kbd_demo(),
+    foundations_spinner_demo(),
+    foundations_skeleton_demo(),
+    foundations_identity_variants(),
+  ])
+}
+
+///|
+fn foundations_identity_gallery() -> @rabbita.Val[@html.Html] {
+  let pin_view = @rui.toggle(
+    variant=@rui.Outline,
+    size=@rui.Lg,
+    aria_label="Pin release",
+    "Pin release",
+  )
+  let watch_view = @rui.toggle(
+    variant=@rui.Default,
+    size=@rui.Sm,
+    aria_label="Watch release",
+    "Watch",
+  )
+  let density_view = @rui.toggle_group(
+    default_values=["grid"],
+    variant=@rui.Outline,
+    size=@rui.Sm,
+    aria_label="Preview layout",
+    scope => {
+      @html.fragment([
+        @rui.toggle_group_item(scope~, value="list", aria_label="List", "List"),
+        @rui.toggle_group_item(scope~, value="grid", aria_label="Grid", "Grid"),
+      ])
+    },
+  )
+  let formatting_view = @rui.toggle_group(
+    default_values=["bold"],
+    multiple=true,
+    variant=@rui.Default,
+    size=@rui.Lg,
+    aria_label="Text formatting",
+    scope => {
+      @html.fragment([
+        @rui.toggle_group_item(
+          scope~,
+          value="bold",
+          aria_label="Bold",
+          showcase_bold_icon(),
+        ),
+        @rui.toggle_group_item(
+          scope~,
+          value="italic",
+          aria_label="Italic",
+          showcase_italic_icon(),
+        ),
+        @rui.toggle_group_item(
+          scope~,
+          value="underline",
+          aria_label="Underline",
+          showcase_underline_icon(),
+        ),
+      ])
+    },
+  )
+  pin_view.view4(watch_view, density_view, formatting_view, (
+    pin_html,
+    watch_html,
+    density_html,
+    formatting_html,
+  ) => {
+    foundations_identity_gallery_view(
+      pin_html, watch_html, density_html, formatting_html,
+    )
+  })
+}
+
+///|
+fn foundations_data_gallery() -> @rabbita.Val[@html.Html] {
+  fdv_data_table_view().view(data_table_html => {
+    @html.section(style=[FoundationsSectionStyle], [
+      foundations_alert_demo(),
+      foundations_message_demo(),
+      foundations_bubble_demo(),
+      foundations_chart_demo(),
+      foundations_table_demo(),
+      foundations_data_variants(data_table_html),
+    ])
+  })
+}

--- a/website/homepage/components/foundations_identity_variants.mbt
+++ b/website/homepage/components/foundations_identity_variants.mbt
@@ -1,0 +1,475 @@
+///|
+const IdentityVariantsStackStyle : String = "display:flex;min-width:0;flex-direction:column;gap:4rem;align-items:stretch"
+
+///|
+const IdentityVariantsGridStyle : String = "display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr));gap:1rem;align-items:start"
+
+///|
+const IdentityVariantStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.75rem"
+
+///|
+const IdentityVariantLabelStyle : String = "margin:0;color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.25rem;font-weight:500"
+
+///|
+const IdentitySurfaceStyle : String = "box-sizing:border-box;min-width:0;padding:0.25rem"
+
+///|
+const IdentityAspectSurfaceStyle : String = "display:flex;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) - 0.125rem);background:color-mix(in oklab,var(--rui-muted) 55%,var(--rui-background));color:var(--rui-muted-foreground);font-size:0.8125rem;font-weight:600"
+
+///|
+const IdentityAvatarImage : String = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 80'%3E%3Crect width='80' height='80' rx='16' fill='%2318171b'/%3E%3Ccircle cx='40' cy='30' r='14' fill='%23fafafa'/%3E%3Cpath d='M14 80c2-20 12-31 26-31s24 11 26 31' fill='%23fafafa'/%3E%3C/svg%3E"
+
+///|
+const IdentityAvatarDefaultCode : String =
+  #|@rui.avatar(@rui.avatar_fallback("AV"))
+  #|
+
+///|
+const IdentityAvatarSmallCode : String =
+  #|@rui.avatar(size=@rui.Sm, @rui.avatar_fallback("SM"))
+  #|
+
+///|
+const IdentityAvatarLargeCode : String =
+  #|@rui.avatar(size=@rui.Lg, @rui.avatar_fallback("LG"))
+  #|
+
+///|
+const IdentityAvatarImageCode : String =
+  #|@rui.avatar(size=@rui.Lg, [
+  #|  @rui.avatar_image(
+  #|    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 80'%3E%3Crect width='80' height='80' rx='16' fill='%2318171b'/%3E%3Ccircle cx='40' cy='30' r='14' fill='%23fafafa'/%3E%3Cpath d='M14 80c2-20 12-31 26-31s24 11 26 31' fill='%23fafafa'/%3E%3C/svg%3E",
+  #|    alt="Alex Rivera",
+  #|    width=80,
+  #|    height=80,
+  #|  ),
+  #|  @rui.avatar_fallback("AR"),
+  #|  @rui.avatar_badge(""),
+  #|])
+  #|
+
+///|
+const IdentityAvatarGroupCode : String =
+  #|@rui.avatar_group([
+  #|  @rui.avatar(@rui.avatar_fallback("YO")),
+  #|  @rui.avatar(@rui.avatar_fallback("RA")),
+  #|  @rui.avatar(@rui.avatar_fallback("MB")),
+  #|  @rui.avatar_group_count("+4"),
+  #|])
+  #|
+
+///|
+const IdentityCardDefaultCode : String =
+  #|@rui.card([
+  #|  @rui.card_header([
+  #|    @rui.card_title("Release notes"),
+  #|    @rui.card_description("Review the changes included in this release."),
+  #|    @rui.card_action(@rui.button(variant=@rui.Ghost, size=@rui.Sm, "Open")),
+  #|  ]),
+  #|  @rui.card_content(@html.p("The component package is ready for review.")),
+  #|  @rui.card_footer(@rui.button(size=@rui.Sm, "Review")),
+  #|])
+  #|
+
+///|
+const IdentityCardSmallCode : String =
+  #|@rui.card(size=@rui.Sm, [
+  #|  @rui.card_header([
+  #|    @rui.card_title("Preview build"),
+  #|    @rui.card_description("A compact card using the same composition."),
+  #|    @rui.card_action(@rui.button(variant=@rui.Ghost, size=@rui.Xs, "Open")),
+  #|  ]),
+  #|  @rui.card_content(@html.p("Checks passed and the preview is available.")),
+  #|  @rui.card_footer(@rui.button(size=@rui.Xs, "View")),
+  #|])
+  #|
+
+///|
+const IdentityAspectSquareCode : String =
+  #|@rui.aspect_ratio(
+  #|  ratio=1.0,
+  #|  style=["display:flex;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) - 0.125rem);background:color-mix(in oklab,var(--rui-muted) 55%,var(--rui-background));color:var(--rui-muted-foreground);font-size:0.8125rem;font-weight:600"],
+  #|  @html.span("1:1"),
+  #|)
+  #|
+
+///|
+const IdentityAspectStandardCode : String =
+  #|@rui.aspect_ratio(
+  #|  ratio=1.3333333333,
+  #|  style=["display:flex;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) - 0.125rem);background:color-mix(in oklab,var(--rui-muted) 55%,var(--rui-background));color:var(--rui-muted-foreground);font-size:0.8125rem;font-weight:600"],
+  #|  @html.span("4:3"),
+  #|)
+  #|
+
+///|
+const IdentityAspectWidescreenCode : String =
+  #|@rui.aspect_ratio(
+  #|  ratio=1.7777777778,
+  #|  style=["display:flex;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) - 0.125rem);background:color-mix(in oklab,var(--rui-muted) 55%,var(--rui-background));color:var(--rui-muted-foreground);font-size:0.8125rem;font-weight:600"],
+  #|  @html.span("16:9"),
+  #|)
+  #|
+
+///|
+const IdentitySeparatorHorizontalCode : String =
+  #|@html.div(style=["box-sizing:border-box;min-width:0;padding:0.25rem", "display:flex;flex-direction:column;gap:0.75rem"], [
+  #|  @html.span("Release"),
+  #|  @rui.separator(orientation=@rui.Horizontal),
+  #|  @html.span("Activity"),
+  #|])
+  #|
+
+///|
+const IdentitySeparatorVerticalCode : String =
+  #|@html.div(style=["box-sizing:border-box;min-width:0;padding:0.25rem", "display:flex;min-height:4rem;align-items:center;gap:1rem"], [
+  #|  @html.span("Release"),
+  #|  @rui.separator(orientation=@rui.Vertical, style=["height:2.5rem"]),
+  #|  @html.span("Activity"),
+  #|])
+  #|
+
+///|
+const IdentityDirectionCode : String =
+  #|fn direction_demo() -> @html.Html {
+  #|  let variant = fn(label, body) {
+  #|    @html.div(
+  #|      style=["display:flex;min-width:0;flex-direction:column;gap:0.75rem"],
+  #|      [
+  #|        @html.p(
+  #|          style=["margin:0;color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.25rem;font-weight:500"],
+  #|          label,
+  #|        ),
+  #|        body,
+  #|      ],
+  #|    )
+  #|  }
+  #|  @html.div(
+  #|    style=["display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr));gap:1rem;align-items:start"],
+  #|    [
+  #|      variant("Ltr", @rui.direction(
+  #|        direction=@rui.Ltr,
+  #|        style=["box-sizing:border-box;min-width:0;padding:0.25rem", "text-align:start"],
+  #|        [
+  #|          @html.div(style=["font-weight:600"], "Build complete"),
+  #|          @html.div(
+  #|            style=["margin-top:0.25rem;color:var(--rui-muted-foreground);font-size:0.8125rem"],
+  #|            "The release is ready to publish.",
+  #|          ),
+  #|        ],
+  #|      )),
+  #|      variant("Rtl", @rui.direction(
+  #|        direction=@rui.Rtl,
+  #|        style=["box-sizing:border-box;min-width:0;padding:0.25rem", "text-align:start"],
+  #|        [
+  #|          @html.div(style=["font-weight:600"], "اكتمل البناء"),
+  #|          @html.div(
+  #|            style=["margin-top:0.25rem;color:var(--rui-muted-foreground);font-size:0.8125rem"],
+  #|            "الإصدار جاهز للنشر.",
+  #|          ),
+  #|        ],
+  #|      )),
+  #|    ],
+  #|  )
+  #|}
+  #|
+
+///|
+fn identity_variant(label : String, body : @html.Html) -> @html.Html {
+  @html.div(style=[IdentityVariantStyle], [
+    @html.p(style=[IdentityVariantLabelStyle], label),
+    body,
+  ])
+}
+
+///|
+fn identity_component_demo(
+  title : String,
+  description : String,
+  variant_title : String,
+  variant_description : String,
+  body : @html.Html,
+  code : String,
+  tall? : Bool = false,
+  stage_variant? : ShowcaseStageVariant = ShowcaseStageSurface,
+) -> @html.Html {
+  showcase_component_demos(title, description, [
+    showcase_demo_section(
+      variant_title,
+      variant_description,
+      showcase_demo_stage(body, code, variant=stage_variant, tall~),
+    ),
+  ])
+}
+
+///|
+fn identity_demo_section(
+  title : String,
+  description : String,
+  body : @html.Html,
+  code : String,
+  tall? : Bool = false,
+  stage_variant? : ShowcaseStageVariant = ShowcaseStageSurface,
+) -> ShowcaseDemoEntry {
+  showcase_demo_section(
+    title,
+    description,
+    showcase_demo_stage(body, code, variant=stage_variant, tall~),
+  )
+}
+
+///|
+fn foundations_avatar_demo() -> @html.Html {
+  showcase_component_demos(
+    "Avatar",
+    "Fallbacks, images, badges, sizes, and grouped identities.",
+    [
+      identity_demo_section(
+        "Default",
+        "Default fallback avatar.",
+        @html.div(style=[IdentitySurfaceStyle], [
+          @rui.avatar(@rui.avatar_fallback("AV")),
+        ]),
+        IdentityAvatarDefaultCode,
+      ),
+      identity_demo_section(
+        "Small",
+        "Small fallback avatar.",
+        @html.div(style=[IdentitySurfaceStyle], [
+          @rui.avatar(size=@rui.Sm, @rui.avatar_fallback("SM")),
+        ]),
+        IdentityAvatarSmallCode,
+      ),
+      identity_demo_section(
+        "Large",
+        "Large fallback avatar.",
+        @html.div(style=[IdentitySurfaceStyle], [
+          @rui.avatar(size=@rui.Lg, @rui.avatar_fallback("LG")),
+        ]),
+        IdentityAvatarLargeCode,
+      ),
+      identity_demo_section(
+        "Image and badge",
+        "Image, fallback, and badge form one avatar.",
+        @html.div(style=[IdentitySurfaceStyle], [
+          @rui.avatar(size=@rui.Lg, [
+            @rui.avatar_image(
+              src=IdentityAvatarImage,
+              alt="Alex Rivera",
+              width=80,
+              height=80,
+            ),
+            @rui.avatar_fallback("AR"),
+            @rui.avatar_badge(""),
+          ]),
+        ]),
+        IdentityAvatarImageCode,
+      ),
+      identity_demo_section(
+        "Group and count",
+        "Overlapping avatars with an overflow count.",
+        @html.div(style=[IdentitySurfaceStyle], [
+          @rui.avatar_group([
+            @rui.avatar(@rui.avatar_fallback("YO")),
+            @rui.avatar(@rui.avatar_fallback("RA")),
+            @rui.avatar(@rui.avatar_fallback("MB")),
+            @rui.avatar_group_count("+4"),
+          ]),
+        ]),
+        IdentityAvatarGroupCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_card_demo() -> @html.Html {
+  showcase_component_demos(
+    "Card",
+    "Default and compact compositions with headers, actions, content, and footers.",
+    [
+      identity_demo_section(
+        "Default",
+        "Default card composition.",
+        @rui.card([
+          @rui.card_header([
+            @rui.card_title("Release notes"),
+            @rui.card_description(
+              "Review the changes included in this release.",
+            ),
+            @rui.card_action(
+              @rui.button(variant=@rui.Ghost, size=@rui.Sm, "Open"),
+            ),
+          ]),
+          @rui.card_content(
+            @html.p("The component package is ready for review."),
+          ),
+          @rui.card_footer(@rui.button(size=@rui.Sm, "Review")),
+        ]),
+        IdentityCardDefaultCode,
+        tall=true,
+      ),
+      identity_demo_section(
+        "Small",
+        "Compact card composition.",
+        @rui.card(size=@rui.Sm, [
+          @rui.card_header([
+            @rui.card_title("Preview build"),
+            @rui.card_description("A compact card using the same composition."),
+            @rui.card_action(
+              @rui.button(variant=@rui.Ghost, size=@rui.Xs, "Open"),
+            ),
+          ]),
+          @rui.card_content(
+            @html.p("Checks passed and the preview is available."),
+          ),
+          @rui.card_footer(@rui.button(size=@rui.Xs, "View")),
+        ]),
+        IdentityCardSmallCode,
+        tall=true,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_aspect_ratio_demo() -> @html.Html {
+  showcase_component_demos(
+    "Aspect Ratio",
+    "Common media proportions keep their geometry across responsive widths.",
+    [
+      identity_demo_section(
+        "Square (1:1)",
+        "Square media frame.",
+        @rui.aspect_ratio(
+          ratio=1.0,
+          style=[IdentityAspectSurfaceStyle],
+          @html.span("1:1"),
+        ),
+        IdentityAspectSquareCode,
+        stage_variant=ShowcaseStagePlain,
+      ),
+      identity_demo_section(
+        "Standard (4:3)",
+        "Traditional landscape frame.",
+        @rui.aspect_ratio(
+          ratio=1.3333333333,
+          style=[IdentityAspectSurfaceStyle],
+          @html.span("4:3"),
+        ),
+        IdentityAspectStandardCode,
+        stage_variant=ShowcaseStagePlain,
+      ),
+      identity_demo_section(
+        "Widescreen (16:9)",
+        "Widescreen media frame.",
+        @rui.aspect_ratio(
+          ratio=1.7777777778,
+          style=[IdentityAspectSurfaceStyle],
+          @html.span("16:9"),
+        ),
+        IdentityAspectWidescreenCode,
+        stage_variant=ShowcaseStagePlain,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_direction_demo() -> @html.Html {
+  identity_component_demo(
+    "Direction",
+    "Left-to-right and right-to-left content share the same component surface.",
+    "Writing directions",
+    "Logical alignment follows the local direction without changing the component API.",
+    @html.div(style=[IdentityVariantsGridStyle], [
+      identity_variant(
+        "Ltr",
+        @rui.direction(
+          direction=@rui.Ltr,
+          style=[IdentitySurfaceStyle, "text-align:start"],
+          [
+            @html.div(style=["font-weight:600"], "Build complete"),
+            @html.div(
+              style=[
+                "margin-top:0.25rem;color:var(--rui-muted-foreground);font-size:0.8125rem",
+              ],
+              "The release is ready to publish.",
+            ),
+          ],
+        ),
+      ),
+      identity_variant(
+        "Rtl",
+        @rui.direction(
+          direction=@rui.Rtl,
+          style=[IdentitySurfaceStyle, "text-align:start"],
+          [
+            @html.div(style=["font-weight:600"], "اكتمل البناء"),
+            @html.div(
+              style=[
+                "margin-top:0.25rem;color:var(--rui-muted-foreground);font-size:0.8125rem",
+              ],
+              "الإصدار جاهز للنشر.",
+            ),
+          ],
+        ),
+      ),
+    ]),
+    IdentityDirectionCode,
+    stage_variant=ShowcaseStagePlain,
+  )
+}
+
+///|
+fn foundations_separator_demo() -> @html.Html {
+  showcase_component_demos(
+    "Separator",
+    "Horizontal and vertical separators divide related content without adding a container.",
+    [
+      identity_demo_section(
+        "Horizontal",
+        "A horizontal separator divides stacked content.",
+        @html.div(
+          style=[
+            IdentitySurfaceStyle,
+            "display:flex;flex-direction:column;gap:0.75rem",
+          ],
+          [
+            @html.span("Release"),
+            @rui.separator(orientation=@rui.Horizontal),
+            @html.span("Activity"),
+          ],
+        ),
+        IdentitySeparatorHorizontalCode,
+      ),
+      identity_demo_section(
+        "Vertical",
+        "A vertical separator divides inline content.",
+        @html.div(
+          style=[
+            IdentitySurfaceStyle,
+            "display:flex;min-height:4rem;align-items:center;gap:1rem",
+          ],
+          [
+            @html.span("Release"),
+            @rui.separator(orientation=@rui.Vertical, style=["height:2.5rem"]),
+            @html.span("Activity"),
+          ],
+        ),
+        IdentitySeparatorVerticalCode,
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_identity_variants() -> @html.Html {
+  @html.div(style=[IdentityVariantsStackStyle], [
+    foundations_avatar_demo(),
+    foundations_card_demo(),
+    foundations_aspect_ratio_demo(),
+    foundations_direction_demo(),
+    foundations_separator_demo(),
+  ])
+}

--- a/website/homepage/components/foundations_skeleton_variants.mbt
+++ b/website/homepage/components/foundations_skeleton_variants.mbt
@@ -1,0 +1,276 @@
+///|
+const FoundationsSkeletonDefaultCode : String =
+  #|@html.div(
+  #|  style=[
+  #|    "display:flex;width:min(100%,19.625rem);margin-inline:auto;align-items:center;gap:1rem",
+  #|  ],
+  #|  [
+  #|    @rui.skeleton(style=["width:3rem;height:3rem;flex:none;border-radius:9999px"]),
+  #|    @html.div(
+  #|      style=["display:flex;min-width:0;flex:1;flex-direction:column;gap:0.5rem"],
+  #|      [
+  #|        @rui.skeleton(style=["width:100%;height:1rem"]),
+  #|        @rui.skeleton(style=["width:80%;height:1rem"]),
+  #|      ],
+  #|    ),
+  #|  ],
+  #|)
+  #|
+
+///|
+const FoundationsSkeletonAvatarCode : String =
+  #|@html.div(
+  #|  style=[
+  #|    "display:flex;width:min(100%,12.875rem);margin-inline:auto;align-items:center;gap:1rem",
+  #|  ],
+  #|  [
+  #|    @rui.skeleton(style=["width:2.5rem;height:2.5rem;flex:none;border-radius:9999px"]),
+  #|    @html.div(
+  #|      style=["display:flex;min-width:0;flex:1;flex-direction:column;gap:0.5rem"],
+  #|      [
+  #|        @rui.skeleton(style=["width:100%;height:1rem"]),
+  #|        @rui.skeleton(style=["width:66.667%;height:1rem"]),
+  #|      ],
+  #|    ),
+  #|  ],
+  #|)
+  #|
+
+///|
+const FoundationsSkeletonCardCode : String =
+  #|@rui.card(style=["width:min(100%,20rem);margin-inline:auto"], [
+  #|  @rui.card_header([
+  #|    @rui.skeleton(style=["width:66.667%;height:1rem"]),
+  #|    @rui.skeleton(style=["width:50%;height:1rem"]),
+  #|  ]),
+  #|  @rui.card_content(
+  #|    @rui.skeleton(style=["width:100%;aspect-ratio:16/9"]),
+  #|  ),
+  #|])
+  #|
+
+///|
+const FoundationsSkeletonTextCode : String =
+  #|@html.div(
+  #|  style=[
+  #|    "display:flex;width:min(100%,20rem);margin-inline:auto;flex-direction:column;gap:0.5rem",
+  #|  ],
+  #|  [
+  #|    @rui.skeleton(style=["width:100%;height:1rem"]),
+  #|    @rui.skeleton(style=["width:100%;height:1rem"]),
+  #|    @rui.skeleton(style=["width:75%;height:1rem"]),
+  #|  ],
+  #|)
+  #|
+
+///|
+const FoundationsSkeletonFormCode : String =
+  #|@html.div(
+  #|  style=[
+  #|    "display:flex;width:min(100%,20rem);margin-inline:auto;flex-direction:column;gap:1.75rem",
+  #|  ],
+  #|  [
+  #|    @html.div(style=["display:flex;flex-direction:column;gap:0.75rem"], [
+  #|      @rui.skeleton(style=["width:5rem;height:1rem"]),
+  #|      @rui.skeleton(style=["width:100%;height:2rem"]),
+  #|    ]),
+  #|    @html.div(style=["display:flex;flex-direction:column;gap:0.75rem"], [
+  #|      @rui.skeleton(style=["width:6rem;height:1rem"]),
+  #|      @rui.skeleton(style=["width:100%;height:2rem"]),
+  #|    ]),
+  #|    @rui.skeleton(style=["width:6rem;height:2rem"]),
+  #|  ],
+  #|)
+  #|
+
+///|
+const FoundationsSkeletonTableCode : String =
+  #|@html.div(
+  #|  style=[
+  #|    "display:flex;width:min(100%,24rem);margin-inline:auto;flex-direction:column;gap:0.5rem",
+  #|  ],
+  #|  [
+  #|    for _row in 0..<5 => @html.div(
+  #|      style=["display:flex;min-width:0;gap:1rem"],
+  #|      [
+  #|        @rui.skeleton(style=["height:1rem;min-width:0;flex:1"]),
+  #|        @rui.skeleton(style=["width:6rem;max-width:25%;height:1rem"]),
+  #|        @rui.skeleton(style=["width:5rem;max-width:25%;height:1rem"]),
+  #|      ],
+  #|    )
+  #|  ],
+  #|)
+  #|
+
+///|
+fn foundations_skeleton_default() -> @html.Html {
+  @html.div(
+    style=[
+      "display:flex;width:min(100%,19.625rem);margin-inline:auto;align-items:center;gap:1rem",
+    ],
+    [
+      @rui.skeleton(style=[
+        "width:3rem;height:3rem;flex:none;border-radius:9999px",
+      ]),
+      @html.div(
+        style=[
+          "display:flex;min-width:0;flex:1;flex-direction:column;gap:0.5rem",
+        ],
+        [
+          @rui.skeleton(style=["width:100%;height:1rem"]),
+          @rui.skeleton(style=["width:80%;height:1rem"]),
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_skeleton_avatar() -> @html.Html {
+  @html.div(
+    style=[
+      "display:flex;width:min(100%,12.875rem);margin-inline:auto;align-items:center;gap:1rem",
+    ],
+    [
+      @rui.skeleton(style=[
+        "width:2.5rem;height:2.5rem;flex:none;border-radius:9999px",
+      ]),
+      @html.div(
+        style=[
+          "display:flex;min-width:0;flex:1;flex-direction:column;gap:0.5rem",
+        ],
+        [
+          @rui.skeleton(style=["width:100%;height:1rem"]),
+          @rui.skeleton(style=["width:66.667%;height:1rem"]),
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+fn foundations_skeleton_card() -> @html.Html {
+  @rui.card(style=["width:min(100%,20rem);margin-inline:auto"], [
+    @rui.card_header([
+      @rui.skeleton(style=["width:66.667%;height:1rem"]),
+      @rui.skeleton(style=["width:50%;height:1rem"]),
+    ]),
+    @rui.card_content(@rui.skeleton(style=["width:100%;aspect-ratio:16/9"])),
+  ])
+}
+
+///|
+fn foundations_skeleton_text() -> @html.Html {
+  @html.div(
+    style=[
+      "display:flex;width:min(100%,20rem);margin-inline:auto;flex-direction:column;gap:0.5rem",
+    ],
+    [
+      @rui.skeleton(style=["width:100%;height:1rem"]),
+      @rui.skeleton(style=["width:100%;height:1rem"]),
+      @rui.skeleton(style=["width:75%;height:1rem"]),
+    ],
+  )
+}
+
+///|
+fn foundations_skeleton_form() -> @html.Html {
+  @html.div(
+    style=[
+      "display:flex;width:min(100%,20rem);margin-inline:auto;flex-direction:column;gap:1.75rem",
+    ],
+    [
+      @html.div(style=["display:flex;flex-direction:column;gap:0.75rem"], [
+        @rui.skeleton(style=["width:5rem;height:1rem"]),
+        @rui.skeleton(style=["width:100%;height:2rem"]),
+      ]),
+      @html.div(style=["display:flex;flex-direction:column;gap:0.75rem"], [
+        @rui.skeleton(style=["width:6rem;height:1rem"]),
+        @rui.skeleton(style=["width:100%;height:2rem"]),
+      ]),
+      @rui.skeleton(style=["width:6rem;height:2rem"]),
+    ],
+  )
+}
+
+///|
+fn foundations_skeleton_table() -> @html.Html {
+  @html.div(
+    style=[
+      "display:flex;width:min(100%,24rem);margin-inline:auto;flex-direction:column;gap:0.5rem",
+    ],
+    [
+      for _row in 0..<5 => {
+        @html.div(style=["display:flex;min-width:0;gap:1rem"], [
+          @rui.skeleton(style=["height:1rem;min-width:0;flex:1"]),
+          @rui.skeleton(style=["width:6rem;max-width:25%;height:1rem"]),
+          @rui.skeleton(style=["width:5rem;max-width:25%;height:1rem"]),
+        ])
+      }
+    ],
+  )
+}
+
+///|
+fn foundations_skeleton_demo() -> @html.Html {
+  showcase_component_demos(
+    "Skeleton",
+    "Pulse placeholders preserve the shape and rhythm of content that is still loading.",
+    [
+      showcase_demo_section(
+        "Default",
+        "A circular media placeholder with two supporting text lines.",
+        showcase_demo_stage(
+          foundations_skeleton_default(),
+          FoundationsSkeletonDefaultCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Avatar",
+        "A compact avatar and identity placeholder for account lists.",
+        showcase_demo_stage(
+          foundations_skeleton_avatar(),
+          FoundationsSkeletonAvatarCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Card",
+        "Header copy and a media block preserve the dimensions of a loading card.",
+        showcase_demo_stage(
+          foundations_skeleton_card(),
+          FoundationsSkeletonCardCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Text",
+        "Three lines preserve paragraph rhythm with a shorter final line.",
+        showcase_demo_stage(
+          foundations_skeleton_text(),
+          FoundationsSkeletonTextCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Form",
+        "Labels, fields, and an action retain the spacing of a loading form.",
+        showcase_demo_stage(
+          foundations_skeleton_form(),
+          FoundationsSkeletonFormCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+      showcase_demo_section(
+        "Table",
+        "Five rows preserve the relative widths of primary and secondary columns.",
+        showcase_demo_stage(
+          foundations_skeleton_table(),
+          FoundationsSkeletonTableCode,
+          variant=ShowcaseStageSurface,
+        ),
+      ),
+    ],
+  )
+}

--- a/website/homepage/components/interactions_code.mbt
+++ b/website/homepage/components/interactions_code.mbt
@@ -1,0 +1,3138 @@
+///|
+const IgBreadcrumbDefaultCode : String =
+  #|@rui.breadcrumb(
+  #|  @rui.breadcrumb_list([
+  #|    @rui.breadcrumb_item(@rui.breadcrumb_link(href="#interactions", "UI")),
+  #|    @rui.breadcrumb_separator(),
+  #|    @rui.breadcrumb_item(
+  #|      @rui.breadcrumb_link(href="#navigation", "Patterns"),
+  #|    ),
+  #|    @rui.breadcrumb_separator(),
+  #|    @rui.breadcrumb_item(@rui.breadcrumb_page("Navigation")),
+  #|  ]),
+  #|)
+
+///|
+const IgBreadcrumbCondensedCode : String =
+  #|@rui.breadcrumb(
+  #|  @rui.breadcrumb_list([
+  #|    @rui.breadcrumb_item(@rui.breadcrumb_link(href="#interactions", "Home")),
+  #|    @rui.breadcrumb_separator(),
+  #|    @rui.breadcrumb_item(@rui.breadcrumb_ellipsis()),
+  #|    @rui.breadcrumb_separator(),
+  #|    @rui.breadcrumb_item(@rui.breadcrumb_page("Current page")),
+  #|  ]),
+  #|)
+
+///|
+const IgPaginationDefaultCode : String =
+  #|@rui.pagination(
+  #|  @rui.pagination_content([
+  #|    @rui.pagination_item(@rui.pagination_previous(href="#page-1")),
+  #|    @rui.pagination_item(
+  #|      @rui.pagination_link(href="#page-1", is_active=true, "1"),
+  #|    ),
+  #|    @rui.pagination_item(@rui.pagination_link(href="#page-2", "2")),
+  #|    @rui.pagination_item(@rui.pagination_ellipsis()),
+  #|    @rui.pagination_item(@rui.pagination_next(href="#page-2")),
+  #|  ]),
+  #|)
+
+///|
+const IgPaginationCompactCode : String =
+  #|@rui.pagination(
+  #|  aria_label="Compact pagination",
+  #|  @rui.pagination_content([
+  #|    @rui.pagination_item(@rui.pagination_previous(href="#page-1")),
+  #|    @rui.pagination_item(
+  #|      @rui.pagination_link(
+  #|        href="#page-1",
+  #|        is_active=true,
+  #|        size=@rui.Sm,
+  #|        "1",
+  #|      ),
+  #|    ),
+  #|    @rui.pagination_item(
+  #|      @rui.pagination_link(href="#page-2", size=@rui.Sm, "2"),
+  #|    ),
+  #|    @rui.pagination_item(@rui.pagination_next(href="#page-2")),
+  #|  ]),
+  #|)
+
+///|
+const IgAccordionSingleCode : String =
+  #|@rui.accordion(
+  #|  id="showcase-accordion",
+  #|  type_=@rui.Single,
+  #|  collapsible=true,
+  #|  default_value="keyboard",
+  #|  items=[
+  #|    @rui.accordion_entry(
+  #|      value="keyboard",
+  #|      label="Keyboard interaction",
+  #|      content=@html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|        "Tab reaches each trigger; Enter and Space toggle its panel.",
+  #|      ),
+  #|    ),
+  #|    @rui.accordion_entry(
+  #|      value="state",
+  #|      label="Owned state",
+  #|      content=@html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|        "The black-box root owns its expanded value through Rabbita.",
+  #|      ),
+  #|    ),
+  #|    @rui.accordion_entry(
+  #|      value="markup",
+  #|      label="Native markup",
+  #|      content=@html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|        "Details and summary preserve useful behavior without JavaScript.",
+  #|      ),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgAccordionMultipleCode : String =
+  #|@rui.accordion(
+  #|  id="showcase-accordion-multiple",
+  #|  type_=@rui.Multiple,
+  #|  default_values=["motion", "focus"],
+  #|  items=[
+  #|    @rui.accordion_entry(
+  #|      value="motion",
+  #|      label="Motion",
+  #|      content=@html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|        "Each expanded panel animates independently.",
+  #|      ),
+  #|    ),
+  #|    @rui.accordion_entry(
+  #|      value="focus",
+  #|      label="Keyboard focus",
+  #|      content=@html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|        "Arrow keys move between enabled triggers.",
+  #|      ),
+  #|    ),
+  #|    @rui.accordion_entry(
+  #|      value="locked",
+  #|      label="Unavailable section",
+  #|      disabled=true,
+  #|      content=@html.p("This panel cannot be opened."),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgCollapsibleOrderCode : String =
+  #|@rui.collapsible(
+  #|  id="showcase-collapsible-order",
+  #|  default_open=true,
+  #|  style=["width:min(100%,28rem);margin-inline:auto;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-card);box-shadow:0 1px 2px rgb(0 0 0 / 0.04)"],
+  #|  trigger_style=["min-height:3.75rem;padding:0.75rem 1rem;border:0;border-radius:calc(var(--rui-radius) - 1px);background:var(--rui-accordion-bg,transparent);text-decoration:none"],
+  #|  content_body_style=["padding:0 1rem 1rem;color:var(--rui-foreground);font-size:0.875rem"],
+  #|  trigger=@html.span(
+  #|    style=["display:flex;min-width:0;align-items:center;justify-content:space-between;gap:0.75rem;text-align:start"],
+  #|    [
+  #|      @html.span(style=["display:grid;min-width:0;gap:0.125rem"], [
+  #|        @html.strong("Order #4189"),
+  #|        @html.span(
+  #|          style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|          "July 16 · 2 items",
+  #|        ),
+  #|      ]),
+  #|      @rui.badge(variant=@rui.Secondary, "Paid"),
+  #|    ],
+  #|  ),
+  #|  content=@html.div(style=["display:grid;gap:0.625rem"], [
+  #|    @html.div(style=["display:flex;justify-content:space-between;gap:1rem"], [
+  #|      @html.span("UI component license"),
+  #|      @html.strong("$49.00"),
+  #|    ]),
+  #|    @html.div(style=["display:flex;justify-content:space-between;gap:1rem"], [
+  #|      @html.span("Icon pack"),
+  #|      @html.strong("$16.00"),
+  #|    ]),
+  #|    @html.hr(style=["width:100%;height:1px;border:0;background:var(--rui-border);margin:0.125rem 0"]),
+  #|    @html.div(style=["display:flex;justify-content:space-between;gap:1rem"], [
+  #|      @html.strong("Total"),
+  #|      @html.strong("$65.00"),
+  #|    ]),
+  #|  ]),
+  #|)
+
+///|
+const IgCollapsibleBasicCode : String =
+  #|@rui.collapsible(
+  #|  id="showcase-collapsible-basic",
+  #|  style=["width:min(100%,26rem);margin-inline:auto"],
+  #|  trigger_style=["min-height:2.5rem;padding:0.5rem 0.625rem;border:1px solid var(--rui-accordion-border,transparent);border-radius:var(--rui-radius);background:var(--rui-accordion-bg,transparent);text-decoration:none"],
+  #|  content_body_style=["padding:0.25rem 0.625rem 0.75rem"],
+  #|  trigger="Can I use this in my project?",
+  #|  content=@html.p(
+  #|    style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|    "Yes. The component owns its state, ARIA relationship, and keyboard activation.",
+  #|  ),
+  #|)
+
+///|
+const IgCollapsibleSettingsCode : String = IgMenuStrokeIconCode +
+  (
+    #|
+    #|fn showcase_settings_icon() -> @html.Html {
+    #|  showcase_stroke_icon("M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z")
+    #|}
+    #|
+    #|@rui.collapsible(
+    #|  id="showcase-collapsible-settings",
+    #|  style=["width:min(100%,28rem);margin-inline:auto;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-card);box-shadow:0 1px 2px rgb(0 0 0 / 0.04)"],
+    #|  trigger_style=["min-height:3.75rem;padding:0.75rem 1rem;border:0;border-radius:calc(var(--rui-radius) - 1px);background:var(--rui-accordion-bg,transparent);text-decoration:none"],
+    #|  content_body_style=["padding:0 1rem 1rem;color:var(--rui-foreground);font-size:0.875rem"],
+    #|  trigger=@html.span(style=["display:flex;min-width:0;align-items:center;gap:0.75rem;text-align:start"], [
+    #|    showcase_settings_icon(),
+    #|    @html.span(style=["display:grid;min-width:0;gap:0.125rem"], [
+    #|      @html.strong("Advanced settings"),
+    #|      @html.span(
+    #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+    #|        "Configure the generated workspace",
+    #|      ),
+    #|    ]),
+    #|  ]),
+    #|  content=@html.div(style=["display:grid;gap:0.875rem"], [
+    #|    @html.div(style=["display:grid;gap:0.375rem"], [
+    #|      @rui.label(for_="collapsible-workspace-name", "Workspace name"),
+    #|      @rui.input(id="collapsible-workspace-name", value="Rabbit Tea"),
+    #|    ]),
+    #|    @html.div(style=["display:grid;gap:0.375rem"], [
+    #|      @rui.label(for_="collapsible-release-channel", "Release channel"),
+    #|      @rui.input(id="collapsible-release-channel", value="Stable"),
+    #|    ]),
+    #|  ]),
+    #|)
+  )
+
+///|
+const IgCollapsibleFileTreeCode : String = IgMenuStrokeIconCode +
+  (
+    #|
+    #|fn tree_file_icon() -> @html.Html {
+    #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+    #|}
+    #|
+    #|fn tree_folder_icon(open : Bool) -> @html.Html {
+    #|  if open {
+    #|    showcase_stroke_icon("M6 14l1.5-4h12.8a1.5 1.5 0 0 1 1.42 2l-2.1 6.2A2 2 0 0 1 17.72 20H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2")
+    #|  } else {
+    #|    showcase_stroke_icon("M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z")
+    #|  }
+    #|}
+    #|
+    #|fn tree_chevron_icon() -> @html.Html {
+    #|  showcase_stroke_icon("m9 18 6-6-6-6", box_size="0.875rem")
+    #|}
+    #|
+    #|fn tree_leaf(name : String) -> @html.Html {
+    #|  @html.div(
+    #|    style=["display:flex;min-height:2rem;min-width:0;align-items:center;gap:0.5rem;padding:0.25rem 0.375rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem"],
+    #|    [
+    #|      tree_file_icon(),
+    #|      @html.span(
+    #|        style=["min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"],
+    #|        name,
+    #|      ),
+    #|    ],
+    #|  )
+    #|}
+    #|
+    #|fn tree_folder(
+    #|  open_paths : Array[String],
+    #|  set_path_open : @rabbita.Emit[(String, Bool)],
+    #|  path : String,
+    #|  name : String,
+    #|  children : Array[@html.Html],
+    #|) -> @html.Html {
+    #|  let open = open_paths.contains(path)
+    #|  let trigger_id = "showcase-file-tree-" + path + "-trigger"
+    #|  let content_id = "showcase-file-tree-" + path + "-content"
+    #|  let on_open_change = set_path_open.map(next => (path, next))
+    #|  @rui.collapsible_root(
+    #|    open~,
+    #|    attrs=@html.Attrs::build().data_set("path", path),
+    #|    [
+    #|      @rui.collapsible_trigger(
+    #|        open~,
+    #|        controls=content_id,
+    #|        show_indicator=false,
+    #|        on_open_change~,
+    #|        id=trigger_id,
+    #|        style=["min-height:2rem;padding:0.25rem 0.375rem;border:1px solid var(--rui-accordion-border,transparent);border-radius:calc(var(--rui-radius) - 0.25rem);background:var(--rui-accordion-bg,transparent);font-weight:400;text-decoration:none"],
+    #|        @html.span(
+    #|          style=["display:flex;min-width:0;align-items:center;gap:0.5rem"],
+    #|          [
+    #|            @html.span(
+    #|              style=["display:inline-flex;flex:none;transition:transform 150ms ease;transform:\{if open { "rotate(90deg)" } else { "rotate(0deg)" }}"],
+    #|              tree_chevron_icon(),
+    #|            ),
+    #|            tree_folder_icon(open),
+    #|            @html.span(
+    #|              style=["min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"],
+    #|              name,
+    #|            ),
+    #|          ],
+    #|        ),
+    #|      ),
+    #|      @rui.collapsible_content(
+    #|        open~,
+    #|        labelledby=trigger_id,
+    #|        id=content_id,
+    #|        body_style=["padding:0;color:var(--rui-foreground);font-size:0.875rem"],
+    #|        @html.div(
+    #|          style=["display:flex;min-width:0;flex-direction:column;padding-inline-start:1.125rem"],
+    #|          children,
+    #|        ),
+    #|      ),
+    #|    ],
+    #|  )
+    #|}
+    #|
+    #|let view_tabs = @rui.tabs(
+    #|  id="showcase-file-tree-tabs",
+    #|  default_value="explorer",
+    #|  aria_label="File tree view",
+    #|  style=["gap:0"],
+    #|  list_style=["width:100%"],
+    #|  content_style=["display:none"],
+    #|  items=[
+    #|    @rui.tab_entry(
+    #|      value="explorer",
+    #|      label="Explorer",
+    #|      content=@html.nothing,
+    #|    ),
+    #|    @rui.tab_entry(
+    #|      value="outline",
+    #|      label="Outline",
+    #|      content=@html.nothing,
+    #|    ),
+    #|  ],
+    #|)
+    #|let (open_paths, set_open_paths) = @rabbita.create_variable([
+    #|  "components", "components/ui", "lib",
+    #|])
+    #|let set_path_open = set_open_paths.map(change => current => {
+    #|  let (path, open) = change
+    #|  if open {
+    #|    if current.contains(path) {
+    #|      current
+    #|    } else {
+    #|      let next = current.copy()
+    #|      next.push(path)
+    #|      next
+    #|    }
+    #|  } else {
+    #|    current.filter(item => item != path)
+    #|  }
+    #|})
+    #|open_paths.view2(view_tabs, (open_paths, tabs_html) => {
+    #|  let components_ui = tree_folder(
+    #|    open_paths,
+    #|    set_path_open,
+    #|    "components/ui",
+    #|    "ui",
+    #|    [
+    #|      tree_leaf("button.mbt"),
+    #|      tree_leaf("card.mbt"),
+    #|      tree_leaf("dialog.mbt"),
+    #|      tree_leaf("input.mbt"),
+    #|      tree_leaf("select.mbt"),
+    #|      tree_leaf("table.mbt"),
+    #|    ],
+    #|  )
+    #|  let components = tree_folder(
+    #|    open_paths,
+    #|    set_path_open,
+    #|    "components",
+    #|    "components",
+    #|    [
+    #|      components_ui,
+    #|      tree_leaf("login-form.mbt"),
+    #|      tree_leaf("register-form.mbt"),
+    #|    ],
+    #|  )
+    #|  let lib = tree_folder(open_paths, set_path_open, "lib", "lib", [
+    #|    tree_leaf("utils.mbt"),
+    #|    tree_leaf("cn.mbt"),
+    #|    tree_leaf("api.mbt"),
+    #|  ])
+    #|  let hooks = tree_folder(open_paths, set_path_open, "hooks", "hooks", [
+    #|    tree_leaf("use-media-query.mbt"),
+    #|    tree_leaf("use-debounce.mbt"),
+    #|    tree_leaf("use-local-storage.mbt"),
+    #|  ])
+    #|  let types = tree_folder(open_paths, set_path_open, "types", "types", [
+    #|    tree_leaf("index.d.mbt"),
+    #|    tree_leaf("api.d.mbt"),
+    #|  ])
+    #|  let public_images = tree_folder(
+    #|    open_paths,
+    #|    set_path_open,
+    #|    "public/images",
+    #|    "images",
+    #|    [tree_leaf("workspace.png")],
+    #|  )
+    #|  let public = tree_folder(open_paths, set_path_open, "public", "public", [
+    #|    tree_leaf("favicon.ico"),
+    #|    tree_leaf("logo.svg"),
+    #|    public_images,
+    #|  ])
+    #|  @rui.card(
+    #|    size=@rui.Sm,
+    #|    style=["width:min(100%,16rem);margin-inline:auto;gap:0.5rem"],
+    #|    [
+    #|      @rui.card_header(tabs_html),
+    #|      @rui.card_content(
+    #|        @html.div(
+    #|          style=["display:flex;min-width:0;flex-direction:column;gap:0.25rem"],
+    #|          [
+    #|            components,
+    #|            lib,
+    #|            hooks,
+    #|            types,
+    #|            public,
+    #|            tree_leaf("app.mbt"),
+    #|            tree_leaf("layout.mbt"),
+    #|            tree_leaf("globals.css"),
+    #|            tree_leaf("moon.pkg"),
+    #|            tree_leaf("moon.mod"),
+    #|            tree_leaf("README.md"),
+    #|            tree_leaf(".gitignore"),
+    #|          ],
+    #|        ),
+    #|      ),
+    #|    ],
+    #|  )
+    #|})
+  )
+
+///|
+const IgTabsDefaultCode : String =
+  #|@rui.tabs(
+  #|  id="showcase-tabs",
+  #|  default_value="preview",
+  #|  orientation=@rui.TabsHorizontal,
+  #|  aria_label="Component workflow",
+  #|  items=[
+  #|    @rui.tab_entry(
+  #|      value="preview",
+  #|      label="Preview",
+  #|      content=@html.div(style=["position:relative;min-width:0;padding-block:1rem"], [
+  #|        @html.strong("Ready to interact"),
+  #|        @html.p(
+  #|          style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0.375rem 0 0"],
+  #|          "The selected panel is linked to its trigger.",
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="source",
+  #|      label="Source",
+  #|      content=@html.div(style=["position:relative;min-width:0;padding-block:1rem"], [
+  #|        @html.strong("Copy when you need control"),
+  #|        @html.p(
+  #|          style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0.375rem 0 0"],
+  #|          "Otherwise consume the component as a black box.",
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="accessibility",
+  #|      label="A11y",
+  #|      content=@html.div(style=["position:relative;min-width:0;padding-block:1rem"], [
+  #|        @html.strong("Roving focus"),
+  #|        @html.p(
+  #|          style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0.375rem 0 0"],
+  #|          "Use Left and Right to move across tabs.",
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgTabsLineCode : String =
+  #|@rui.tabs(
+  #|  id="showcase-tabs-line",
+  #|  default_value="account",
+  #|  list_variant=@rui.TabsLine,
+  #|  aria_label="Account sections",
+  #|  items=[
+  #|    @rui.tab_entry(
+  #|      value="account",
+  #|      label="Account",
+  #|      content=@html.div(style=["position:relative;min-width:0;padding-block:1rem"], [
+  #|        @html.strong("Account profile"),
+  #|        @html.p(
+  #|          style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0.375rem 0 0"],
+  #|          "The active line follows the selected tab.",
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="security",
+  #|      label="Security",
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Security settings",
+  #|      ),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="notifications",
+  #|      label="Notifications",
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Notification preferences",
+  #|      ),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgTabsVerticalCode : String =
+  #|@rui.tabs(
+  #|  id="showcase-tabs-vertical",
+  #|  default_value="general",
+  #|  orientation=@rui.TabsVertical,
+  #|  aria_label="Vertical settings tabs",
+  #|  items=[
+  #|    @rui.tab_entry(
+  #|      value="general",
+  #|      label="General",
+  #|      content=@html.div(style=["position:relative;min-width:0;padding-block:1rem"], [
+  #|        @html.strong("General settings"),
+  #|        @html.p(
+  #|          style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0.375rem 0 0"],
+  #|          "Up and Down move focus in a vertical list.",
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="members",
+  #|      label="Members",
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Member access settings",
+  #|      ),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="billing",
+  #|      label="Billing",
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Billing settings",
+  #|      ),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgTabsDisabledCode : String =
+  #|@rui.tabs(
+  #|  id="showcase-tabs-disabled",
+  #|  default_value="home",
+  #|  aria_label="Disabled tab example",
+  #|  items=[
+  #|    @rui.tab_entry(
+  #|      value="home",
+  #|      label="Home",
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Home content",
+  #|      ),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="disabled",
+  #|      label="Disabled",
+  #|      disabled=true,
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Unavailable",
+  #|      ),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgTabsIconsCode : String =
+  #|fn showcase_stroke_icon(
+  #|  path : String,
+  #|  box_size? : String = "1rem",
+  #|) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=[
+  #|      "display:inline-flex;width:\{box_size};height:\{box_size};flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none",
+  #|    ],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d=path,
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_code_icon() -> @html.Html {
+  #|  showcase_stroke_icon("m16 18 6-6-6-6M8 6l-6 6 6 6")
+  #|}
+  #|
+  #|@rui.tabs(
+  #|  id="showcase-tabs-icons",
+  #|  default_value="preview",
+  #|  aria_label="View mode",
+  #|  items=[
+  #|    @rui.tab_entry(
+  #|      value="preview",
+  #|      label="Preview",
+  #|      icon=showcase_layout_icon(),
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Preview content",
+  #|      ),
+  #|    ),
+  #|    @rui.tab_entry(
+  #|      value="code",
+  #|      label="Code",
+  #|      icon=showcase_code_icon(),
+  #|      content=@html.div(
+  #|        style=["position:relative;min-width:0;padding-block:1rem"],
+  #|        "Code content",
+  #|      ),
+  #|    ),
+  #|  ],
+  #|)
+
+///|
+const IgCarouselHorizontalCode : String =
+  #|@rui.carousel(
+  #|  id="showcase-carousel",
+  #|  count=3,
+  #|  loop_=true,
+  #|  orientation=@rui.CarouselHorizontal,
+  #|  aria_label="Rabbita UI highlights",
+  #|  style=["width:min(calc(100% - 6rem),32rem);margin-inline:auto"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.carousel_items(scope~, items=[
+  #|        @html.div(
+  #|          style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600"],
+  #|          "Inline styles",
+  #|        ),
+  #|        @html.div(
+  #|          style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600"],
+  #|          "Incremental state",
+  #|        ),
+  #|        @html.div(
+  #|          style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600"],
+  #|          "Native semantics",
+  #|        ),
+  #|      ]),
+  #|      @rui.carousel_previous(scope~),
+  #|      @rui.carousel_next(scope~),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgCarouselVerticalCode : String =
+  #|@rui.carousel(
+  #|  id="showcase-carousel-vertical",
+  #|  count=3,
+  #|  default_index=1,
+  #|  orientation=@rui.CarouselVertical,
+  #|  aria_label="Vertical Rabbita UI highlights",
+  #|  style=["width:min(calc(100% - 6rem),32rem);margin:3rem auto"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.carousel_items(scope~, items=[
+  #|        @html.div(
+  #|          style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600", "height:var(--rui-carousel-height,12rem)"],
+  #|          "First slide",
+  #|        ),
+  #|        @html.div(
+  #|          style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600", "height:var(--rui-carousel-height,12rem)"],
+  #|          "Selected slide",
+  #|        ),
+  #|        @html.div(
+  #|          style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600", "height:var(--rui-carousel-height,12rem)"],
+  #|          "Last slide",
+  #|        ),
+  #|      ]),
+  #|      @rui.carousel_previous(scope~),
+  #|      @rui.carousel_next(scope~),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgNavigationMenuViewportCode : String =
+  #|@rui.navigation_menu(
+  #|  id="showcase-navigation-menu",
+  #|  aria_label="Showcase navigation",
+  #|  scope => {
+  #|    @html.div(style=["min-height:10rem"], [
+  #|      @rui.navigation_menu_list(scope, [
+  #|        @rui.navigation_menu_item(scope, value="platform", item => {
+  #|          @html.fragment([
+  #|            @rui.navigation_menu_trigger(item, "Platform"),
+  #|            @rui.navigation_menu_indicator(item),
+  #|            @rui.navigation_menu_content(
+  #|              item,
+  #|              style=["box-sizing:border-box;display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,8rem),1fr));gap:0.5rem;width:min(30rem,calc(100vw - 2rem));padding:0.25rem"],
+  #|              [
+  #|                @rui.navigation_menu_link(
+  #|                  href="#components",
+  #|                  active=true,
+  #|                  style=["display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"],
+  #|                  [
+  #|                    @html.strong("Components"),
+  #|                    @html.span(
+  #|                      style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|                      "Black-box defaults",
+  #|                    ),
+  #|                  ],
+  #|                ),
+  #|                @rui.navigation_menu_link(
+  #|                  href="#patterns",
+  #|                  style=["display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"],
+  #|                  [
+  #|                    @html.strong("Patterns"),
+  #|                    @html.span(
+  #|                      style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|                      "Compound composition",
+  #|                    ),
+  #|                  ],
+  #|                ),
+  #|              ],
+  #|            ),
+  #|          ])
+  #|        }),
+  #|        @rui.navigation_menu_item(scope, value="resources", item => {
+  #|          @html.fragment([
+  #|            @rui.navigation_menu_trigger(item, "Resources"),
+  #|            @rui.navigation_menu_indicator(item),
+  #|            @rui.navigation_menu_content(
+  #|              item,
+  #|              style=["box-sizing:border-box;display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,8rem),1fr));gap:0.5rem;width:min(30rem,calc(100vw - 2rem));padding:0.25rem"],
+  #|              [
+  #|                @rui.navigation_menu_link(
+  #|                  href="#api",
+  #|                  style=["display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"],
+  #|                  [
+  #|                    @html.strong("API reference"),
+  #|                    @html.span(
+  #|                      style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|                      "Typed MoonBit surface",
+  #|                    ),
+  #|                  ],
+  #|                ),
+  #|                @rui.navigation_menu_link(
+  #|                  href="#examples",
+  #|                  style=["display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"],
+  #|                  [
+  #|                    @html.strong("Examples"),
+  #|                    @html.span(
+  #|                      style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|                      "Working interactions",
+  #|                    ),
+  #|                  ],
+  #|                ),
+  #|              ],
+  #|            ),
+  #|          ])
+  #|        }),
+  #|      ]),
+  #|      @rui.navigation_menu_viewport(scope, @html.nothing),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgNavigationMenuInlineCode : String =
+  #|@rui.navigation_menu(
+  #|  id="showcase-navigation-menu-inline",
+  #|  viewport=false,
+  #|  aria_label="Inline navigation menu",
+  #|  scope => {
+  #|    @rui.navigation_menu_list(scope, [
+  #|      @rui.navigation_menu_item(scope, value="learn", item => {
+  #|        @html.fragment([
+  #|          @rui.navigation_menu_trigger(item, "Learn"),
+  #|          @rui.navigation_menu_content(
+  #|            item,
+  #|            style=["box-sizing:border-box;display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,8rem),1fr));gap:0.5rem;width:min(30rem,calc(100vw - 2rem));padding:0.25rem"],
+  #|            [
+  #|              @rui.navigation_menu_link(
+  #|                href="#guide",
+  #|                active=true,
+  #|                style=["display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"],
+  #|                [
+  #|                  @html.strong("Guide"),
+  #|                  @html.span(
+  #|                    style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|                    "Active destination",
+  #|                  ),
+  #|                ],
+  #|              ),
+  #|              @rui.navigation_menu_link(
+  #|                href="#examples",
+  #|                style=["display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"],
+  #|                [
+  #|                  @html.strong("Examples"),
+  #|                  @html.span(
+  #|                    style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"],
+  #|                    "Inline content",
+  #|                  ),
+  #|                ],
+  #|              ),
+  #|            ],
+  #|          ),
+  #|        ])
+  #|      }),
+  #|      @rui.navigation_menu_item(scope, value="disabled", item => {
+  #|        @rui.navigation_menu_trigger(item, disabled=true, "Unavailable")
+  #|      }),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarSharedCode : String =
+  #|fn stroke_icon(path : String) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d=path,
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn layout_icon() -> @html.Html {
+  #|  stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn panel_left_icon() -> @html.Html {
+  #|  stroke_icon("M3 3h18v18H3zM9 3v18")
+  #|}
+  #|
+  #|fn activity_icon() -> @html.Html {
+  #|  stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+  #|
+  #|fn folder_icon() -> @html.Html {
+  #|  stroke_icon(
+  #|    "M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z",
+  #|  )
+  #|}
+  #|
+  #|fn settings_icon() -> @html.Html {
+  #|  stroke_icon(
+  #|    "M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z",
+  #|  )
+  #|}
+  #|
+  #|fn user_icon() -> @html.Html {
+  #|  stroke_icon("M20 21a8 8 0 0 0-16 0M12 13a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z")
+  #|}
+  #|
+  #|fn sidebar_navigation(
+  #|  scope : @rui.SidebarScope,
+  #|  side : @rui.SidebarSide,
+  #|  menu_size : @rui.SidebarMenuButtonSize,
+  #|  mobile : Bool,
+  #|  interactive : Bool,
+  #|) -> @html.Html {
+  #|  let close_command = if mobile {
+  #|    @rui.sidebar_close_mobile(scope)
+  #|  } else {
+  #|    @rui.sidebar_collapse(scope)
+  #|  }
+  #|  @html.fragment([
+  #|    @rui.sidebar_header(
+  #|      @rui.sidebar_input(
+  #|        aria_label="Filter workspace navigation",
+  #|        placeholder="Filter…",
+  #|      ),
+  #|    ),
+  #|    @rui.sidebar_content(
+  #|      @rui.sidebar_group([
+  #|        @rui.sidebar_group_label(scope~, "Workspace"),
+  #|        if interactive {
+  #|          @rui.sidebar_group_action(
+  #|            aria_label=if mobile {
+  #|              "Close sidebar"
+  #|            } else {
+  #|              "Collapse sidebar"
+  #|            },
+  #|            on_click=close_command,
+  #|            if side == @rui.SidebarRight {
+  #|              stroke_icon("M3 3h18v18H3zM15 3v18")
+  #|            } else {
+  #|              panel_left_icon()
+  #|            },
+  #|          )
+  #|        } else {
+  #|          @html.nothing
+  #|        },
+  #|        @rui.sidebar_group_content(
+  #|          @rui.sidebar_menu([
+  #|            @rui.sidebar_menu_item([
+  #|              @rui.sidebar_menu_button(
+  #|                href="#overview",
+  #|                is_active=true,
+  #|                size=menu_size,
+  #|                [layout_icon(), @html.span("Overview")],
+  #|              ),
+  #|              if interactive {
+  #|                @rui.sidebar_menu_action(
+  #|                  show_on_hover=true,
+  #|                  aria_label=if mobile {
+  #|                    "Close sidebar"
+  #|                  } else {
+  #|                    "Collapse sidebar"
+  #|                  },
+  #|                  on_click=close_command,
+  #|                  panel_left_icon(),
+  #|                )
+  #|              } else {
+  #|                @html.nothing
+  #|              },
+  #|            ]),
+  #|            @rui.sidebar_menu_item([
+  #|              @rui.sidebar_menu_button(href="#activity", size=menu_size, [
+  #|                activity_icon(),
+  #|                @html.span("Activity"),
+  #|              ]),
+  #|              @rui.sidebar_menu_badge("6"),
+  #|            ]),
+  #|            @rui.sidebar_menu_item([
+  #|              @rui.sidebar_menu_button(href="#projects", size=menu_size, [
+  #|                folder_icon(),
+  #|                @html.span("Projects and longer workspace names"),
+  #|              ]),
+  #|              @rui.sidebar_menu_sub([
+  #|                @rui.sidebar_menu_sub_item(
+  #|                  @rui.sidebar_menu_sub_button(href="#reports", "Reports"),
+  #|                ),
+  #|                @rui.sidebar_menu_sub_item(
+  #|                  @rui.sidebar_menu_sub_button(href="#roadmap", "Roadmap"),
+  #|                ),
+  #|              ]),
+  #|            ]),
+  #|            @rui.sidebar_menu_item(
+  #|              @rui.sidebar_menu_button(
+  #|                href="#settings",
+  #|                size=menu_size,
+  #|                disabled=true,
+  #|                [settings_icon(), @html.span("Unavailable")],
+  #|              ),
+  #|            ),
+  #|          ]),
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|    @rui.sidebar_separator(),
+  #|    @rui.sidebar_footer(
+  #|      @rui.sidebar_menu(
+  #|        @rui.sidebar_menu_item(
+  #|          @rui.sidebar_menu_button(
+  #|            href="#account",
+  #|            size=menu_size,
+  #|            variant=if menu_size == @rui.SidebarMenuLg {
+  #|              @rui.SidebarMenuButtonOutline
+  #|            } else {
+  #|              @rui.SidebarMenuButtonDefault
+  #|            },
+  #|            if menu_size == @rui.SidebarMenuLg {
+  #|              [
+  #|                user_icon(),
+  #|                @html.span(
+  #|                  style=["display:grid;min-width:0;line-height:1.1"],
+  #|                  [
+  #|                    @html.strong("Yorkin"),
+  #|                    @html.span(
+  #|                      style=["color:var(--rui-muted-foreground);font-size:0.75rem;line-height:1.35"],
+  #|                      "yorkin@example.com",
+  #|                    ),
+  #|                  ],
+  #|                ),
+  #|              ]
+  #|            } else {
+  #|              [user_icon(), @html.span("Account")]
+  #|            },
+  #|          ),
+  #|        ),
+  #|      ),
+  #|    ),
+  #|  ])
+  #|}
+  #|
+  #|fn sidebar_loading_navigation() -> @html.Html {
+  #|  @html.fragment([
+  #|    @rui.sidebar_header(
+  #|      @rui.sidebar_menu(
+  #|        @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+  #|      ),
+  #|    ),
+  #|    @rui.sidebar_content(
+  #|      @rui.sidebar_group([
+  #|        @rui.sidebar_group_label("Workspace"),
+  #|        @rui.sidebar_group_content(
+  #|          @rui.sidebar_menu([
+  #|            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+  #|            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+  #|            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+  #|            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+  #|          ]),
+  #|        ),
+  #|      ]),
+  #|    ),
+  #|    @rui.sidebar_separator(),
+  #|    @rui.sidebar_footer(
+  #|      @rui.sidebar_menu(
+  #|        @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+  #|      ),
+  #|    ),
+  #|  ])
+  #|}
+  #|
+  #|fn sidebar_workspace_content(
+  #|  scope : @rui.SidebarScope,
+  #|  id : String,
+  #|  mobile : Bool,
+  #|  interactive : Bool,
+  #|  icon : @html.Html,
+  #|) -> @html.Html {
+  #|  @html.fragment([
+  #|    @html.div(
+  #|      style=["display:flex;flex-wrap:wrap;align-items:center;gap:0.75rem"],
+  #|      [
+  #|        if interactive {
+  #|          @rui.sidebar_trigger(
+  #|            scope,
+  #|            mobile~,
+  #|            controls=id,
+  #|            aria_label=if mobile {
+  #|              "Open mobile sidebar"
+  #|            } else {
+  #|              "Toggle sidebar"
+  #|            },
+  #|            icon,
+  #|          )
+  #|        } else {
+  #|          @html.nothing
+  #|        },
+  #|        @html.strong("Workspace overview"),
+  #|      ],
+  #|    ),
+  #|    @html.div(
+  #|      style=["display:flex;min-height:0;flex:1;align-items:center;justify-content:center;padding:1rem"],
+  #|      @html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;max-width:18rem;margin:0;text-align:center"],
+  #|        if mobile {
+  #|          "Open the mobile sheet, then close it with the overlay, Escape, or its navigation action."
+  #|        } else if interactive {
+  #|          "Use the trigger or sidebar rail; the provider owns every state change."
+  #|        } else {
+  #|          "This persistent sidebar remains visible and does not expose a collapse control."
+  #|        },
+  #|      ),
+  #|    ),
+  #|  ])
+  #|}
+
+///|
+const IgSidebarDefaultCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-default",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarOffcanvas,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuDefault, false, true,
+  #|          ),
+  #|          @rui.sidebar_rail(scope),
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-default",
+  #|          false,
+  #|          true,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarFixedCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-fixed",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarFixed,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuSm, false, false,
+  #|          ),
+  #|          @html.nothing,
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-fixed",
+  #|          false,
+  #|          false,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarIconCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=true,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-icon",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarIcon,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuDefault, false, true,
+  #|          ),
+  #|          @rui.sidebar_rail(scope),
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-icon",
+  #|          false,
+  #|          true,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarLoadingCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-loading",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarFixed,
+  #|        mobile=false,
+  #|        sidebar_loading_navigation(),
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-loading",
+  #|          false,
+  #|          false,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarFloatingCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-floating",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarFloating,
+  #|        collapsible=@rui.SidebarIcon,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuLg, false, true,
+  #|          ),
+  #|          @rui.sidebar_rail(scope),
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-floating",
+  #|          false,
+  #|          true,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarInsetCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-inset",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarInset,
+  #|        collapsible=@rui.SidebarOffcanvas,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuDefault, false, true,
+  #|          ),
+  #|          @rui.sidebar_rail(scope),
+  #|        ],
+  #|      ),
+  #|      @rui.sidebar_inset(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-inset",
+  #|          false,
+  #|          true,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarRightCode : String =
+  #|fn panel_right_icon() -> @html.Html {
+  #|  stroke_icon("M3 3h18v18H3zM15 3v18")
+  #|}
+  #|
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-right",
+  #|        side=@rui.SidebarRight,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarIcon,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarRight, @rui.SidebarMenuDefault, false, true,
+  #|          ),
+  #|          @rui.sidebar_rail(scope),
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-right",
+  #|          false,
+  #|          true,
+  #|          panel_right_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarResizeCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-resize",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarIcon,
+  #|        mobile=false,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuDefault, false, true,
+  #|          ),
+  #|          @rui.sidebar_rail(
+  #|            scope,
+  #|            min_width=192,
+  #|            max_width=352,
+  #|          ),
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-resize",
+  #|          false,
+  #|          true,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgSidebarMobileCode : String =
+  #|@rui.sidebar_provider(
+  #|  default_collapsed=false,
+  #|  style=["--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.sidebar(
+  #|        scope,
+  #|        id="showcase-sidebar-mobile",
+  #|        side=@rui.SidebarLeft,
+  #|        variant=@rui.SidebarDefault,
+  #|        collapsible=@rui.SidebarOffcanvas,
+  #|        mobile=true,
+  #|        [
+  #|          sidebar_navigation(
+  #|            scope, @rui.SidebarLeft, @rui.SidebarMenuDefault, true, true,
+  #|          ),
+  #|          @html.nothing,
+  #|        ],
+  #|      ),
+  #|      @html.div(
+  #|        style=["box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"],
+  #|        sidebar_workspace_content(
+  #|          scope,
+  #|          "showcase-sidebar-mobile",
+  #|          true,
+  #|          true,
+  #|          panel_left_icon(),
+  #|        ),
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+fn ig_sidebar_code(call : String) -> String {
+  IgSidebarSharedCode + "\n\n" + call
+}
+
+///|
+const IgAlertDialogDefaultCode : String =
+  #|@rui.alert_dialog(id="showcase-alert-dialog-default", scope => {
+  #|  @html.fragment([
+  #|    @rui.alert_dialog_trigger(scope, variant=@rui.Outline, "Archive project"),
+  #|    @rui.alert_dialog_portal([
+  #|      @rui.alert_dialog_content(scope, [
+  #|        @rui.alert_dialog_header([
+  #|          @rui.alert_dialog_title(scope, "Archive this project?"),
+  #|          @rui.alert_dialog_description(
+  #|            scope,
+  #|            "You can restore an archived project later from workspace settings.",
+  #|          ),
+  #|        ]),
+  #|        @rui.alert_dialog_footer([
+  #|          @rui.alert_dialog_cancel(scope, "Cancel"),
+  #|          @rui.alert_dialog_action(scope, "Archive"),
+  #|        ]),
+  #|      ]),
+  #|    ]),
+  #|  ])
+  #|})
+
+///|
+const IgAlertDialogDestructiveCode : String =
+  #|fn alert_triangle_icon() -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:2rem;height:2rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d="M21.73 18 13.73 4a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3ZM12 9v4M12 17h.01",
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|@rui.alert_dialog(
+  #|  id="showcase-alert-dialog",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.alert_dialog_trigger(
+  #|        scope,
+  #|        variant=@rui.Destructive,
+  #|        "Delete snapshot",
+  #|      ),
+  #|      @rui.alert_dialog_portal([
+  #|        @rui.alert_dialog_content(scope, [
+  #|          @rui.alert_dialog_header([
+  #|            @rui.alert_dialog_media(alert_triangle_icon()),
+  #|            @rui.alert_dialog_title(scope, "Delete this snapshot?"),
+  #|            @rui.alert_dialog_description(
+  #|              scope,
+  #|              "This removes the saved state permanently.",
+  #|            ),
+  #|          ]),
+  #|          @rui.alert_dialog_footer([
+  #|            @rui.alert_dialog_cancel(scope, "Cancel"),
+  #|            @rui.alert_dialog_action(scope, "Delete"),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDialogSharedCode : String =
+  #|fn dialog_variant(
+  #|  id : String,
+  #|  modal : Bool,
+  #|  trigger_variant : @rui.ButtonVariant,
+  #|  trigger_label : String,
+  #|) -> @rabbita.Val[@html.Html] {
+  #|  @rui.dialog(id~, modal~, scope => {
+  #|    @html.fragment([
+  #|      @rui.dialog_trigger(scope, variant=trigger_variant, trigger_label),
+  #|      @rui.dialog_portal([
+  #|        @rui.dialog_content(scope, show_close=true, [
+  #|          @rui.dialog_header([
+  #|            @rui.dialog_title(scope, trigger_label),
+  #|            @rui.dialog_description(
+  #|              scope,
+  #|              if modal {
+  #|                "Focus stays inside this modal surface until it closes."
+  #|              } else {
+  #|                "This non-modal surface leaves the surrounding page available."
+  #|              },
+  #|            ),
+  #|          ]),
+  #|          @html.div(style=["display:flex;flex-direction:column;gap:1rem"], [
+  #|            @rui.label(for_=id + "-name", "Display name"),
+  #|            @rui.input(id=id + "-name", value="Rabbita team"),
+  #|          ]),
+  #|          @rui.dialog_footer(@rui.dialog_close(scope, "Save changes")),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  })
+  #|}
+  #|
+
+///|
+const IgDialogModalCallCode : String =
+  #|dialog_variant(
+  #|  "showcase-dialog-modal",
+  #|  true,
+  #|  @rui.Outline,
+  #|  "Edit profile",
+  #|)
+
+///|
+const IgDialogNonModalCallCode : String =
+  #|dialog_variant(
+  #|  "showcase-dialog-nonmodal",
+  #|  false,
+  #|  @rui.Secondary,
+  #|  "Open non-modal",
+  #|)
+
+///|
+fn ig_dialog_code(call : String) -> String {
+  IgDialogSharedCode + "\n\n" + call
+}
+
+///|
+const IgDrawerSharedCode : String =
+  #|fn drawer_variant(
+  #|  id : String,
+  #|  direction : @rui.DrawerDirection,
+  #|  trigger_label : String,
+  #|) -> @rabbita.Val[@html.Html] {
+  #|  @rui.drawer(id~, scope => {
+  #|    @html.fragment([
+  #|      @rui.drawer_trigger(scope, variant=@rui.Outline, trigger_label),
+  #|      @rui.drawer_portal([
+  #|        @rui.drawer_content(
+  #|          scope,
+  #|          direction~,
+  #|          show_handle=true,
+  #|          show_close=true,
+  #|          [
+  #|            @rui.drawer_header([
+  #|              @rui.drawer_title(scope, trigger_label),
+  #|              @rui.drawer_description(
+  #|                scope,
+  #|                "The direction controls placement, motion, and handle orientation.",
+  #|              ),
+  #|            ]),
+  #|            @html.div(
+  #|              style=["position:relative;min-width:0;padding-block:1rem"],
+  #|              "All checks passed",
+  #|            ),
+  #|            @rui.drawer_footer(@rui.drawer_close(scope, "Close")),
+  #|          ],
+  #|        ),
+  #|      ]),
+  #|    ])
+  #|  })
+  #|}
+  #|
+
+///|
+const IgDrawerTopCallCode : String =
+  #|drawer_variant(
+  #|  "showcase-drawer-top",
+  #|  @rui.DrawerTop,
+  #|  "Open top drawer",
+  #|)
+
+///|
+const IgDrawerRightCallCode : String =
+  #|drawer_variant(
+  #|  "showcase-drawer-right",
+  #|  @rui.DrawerRight,
+  #|  "Open right drawer",
+  #|)
+
+///|
+const IgDrawerBottomCallCode : String =
+  #|drawer_variant(
+  #|  "showcase-drawer-bottom",
+  #|  @rui.DrawerBottom,
+  #|  "Open bottom drawer",
+  #|)
+
+///|
+const IgDrawerLeftCallCode : String =
+  #|drawer_variant(
+  #|  "showcase-drawer-left",
+  #|  @rui.DrawerLeft,
+  #|  "Open left drawer",
+  #|)
+
+///|
+fn ig_drawer_code(call : String) -> String {
+  IgDrawerSharedCode + "\n\n" + call
+}
+
+///|
+const IgMenuStrokeIconCode : String =
+  #|fn showcase_stroke_icon(
+  #|  path : String,
+  #|  box_size? : String = "1rem",
+  #|) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:\{box_size};height:\{box_size};flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d=path,
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+
+///|
+fn ig_menu_code(icon_helpers : String, component : String) -> String {
+  IgMenuStrokeIconCode + "\n\n" + icon_helpers + "\n\n" + component
+}
+
+///|
+const IgContextMenuActionsIconsCode : String =
+  #|fn showcase_copy_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2ZM4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2")
+  #|}
+  #|
+  #|fn showcase_settings_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z")
+  #|}
+  #|
+  #|fn showcase_file_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+  #|}
+  #|
+  #|fn showcase_archive_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M21 8v13H3V8M1 3h22v5H1zM10 12h4")
+  #|}
+
+///|
+const IgContextMenuActionsCode : String =
+  #|@rui.context_menu(
+  #|  id="showcase-context-menu-actions",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.context_menu_trigger(
+  #|        scope,
+  #|        style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px dashed var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);color:var(--rui-muted-foreground);font-size:0.8125rem;text-align:center;user-select:none"],
+  #|        "Right-click for canvas actions",
+  #|      ),
+  #|      @rui.context_menu_portal([
+  #|        @rui.context_menu_content(scope, aria_label="Canvas actions", [
+  #|          @rui.context_menu_group(aria_label="Canvas", [
+  #|            @rui.context_menu_label("Canvas"),
+  #|            @rui.context_menu_item(scope, [
+  #|              showcase_copy_icon(),
+  #|              @html.span("Duplicate"),
+  #|              @rui.context_menu_shortcut("⌘D"),
+  #|            ]),
+  #|            @rui.context_menu_item(scope, [
+  #|              showcase_settings_icon(),
+  #|              @html.span("Rename"),
+  #|            ]),
+  #|            @rui.context_menu_item(scope, [
+  #|              showcase_file_icon(),
+  #|              @html.span("Export"),
+  #|              @rui.context_menu_shortcut("⇧⌘E"),
+  #|            ]),
+  #|            @rui.context_menu_item(scope, disabled=true, [
+  #|              showcase_archive_icon(),
+  #|              @html.span("Paste"),
+  #|            ]),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgContextMenuSubmenuIconsCode : String =
+  #|fn showcase_settings_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z")
+  #|}
+  #|
+  #|fn showcase_archive_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M21 8v13H3V8M1 3h22v5H1zM10 12h4")
+  #|}
+  #|
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+  #|
+  #|fn showcase_close_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M18 6 6 18M6 6l12 12")
+  #|}
+
+///|
+const IgContextMenuSubmenuCode : String =
+  #|@rui.context_menu(
+  #|  id="showcase-context-menu-submenu",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.context_menu_trigger(
+  #|        scope,
+  #|        style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px dashed var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);color:var(--rui-muted-foreground);font-size:0.8125rem;text-align:center;user-select:none"],
+  #|        "Right-click for project options",
+  #|      ),
+  #|      @rui.context_menu_portal([
+  #|        @rui.context_menu_content(scope, aria_label="Project options", [
+  #|          @rui.context_menu_item(scope, [
+  #|            showcase_settings_icon(),
+  #|            @html.span("Project settings"),
+  #|          ]),
+  #|          @rui.context_menu_sub(scope, value="move", sub => {
+  #|            @html.fragment([
+  #|              @rui.context_menu_sub_trigger(sub, [
+  #|                showcase_archive_icon(),
+  #|                @html.span("Move to"),
+  #|              ]),
+  #|              @rui.context_menu_sub_content(sub, [
+  #|                @rui.context_menu_group(aria_label="Destination", [
+  #|                  @rui.context_menu_label("Destination"),
+  #|                  @rui.context_menu_item(scope, [
+  #|                    showcase_layout_icon(),
+  #|                    @html.span("Design system"),
+  #|                  ]),
+  #|                  @rui.context_menu_item(scope, [
+  #|                    showcase_activity_icon(),
+  #|                    @html.span("Experiments"),
+  #|                  ]),
+  #|                ]),
+  #|              ]),
+  #|            ])
+  #|          }),
+  #|          @rui.context_menu_separator(),
+  #|          @rui.context_menu_item(scope, destructive=true, [
+  #|            showcase_close_icon(),
+  #|            @html.span("Delete project"),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgContextMenuCheckboxIconsCode : String =
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_panel_left_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 3h18v18H3zM9 3v18")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+  #|
+
+///|
+const IgContextMenuCheckboxCode : String =
+  #|@rui.context_menu(
+  #|  id="showcase-context-menu-checkbox",
+  #|  default_checked_values=["grid", "activity"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.context_menu_trigger(
+  #|        scope,
+  #|        style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px dashed var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);color:var(--rui-muted-foreground);font-size:0.8125rem;text-align:center;user-select:none"],
+  #|        "Right-click for visibility controls",
+  #|      ),
+  #|      @rui.context_menu_portal([
+  #|        @rui.context_menu_content(scope, aria_label="Visibility controls", [
+  #|          @rui.context_menu_group(aria_label="Visibility", [
+  #|            @rui.context_menu_label("Visibility"),
+  #|            @rui.context_menu_checkbox_item(scope, value="grid", [
+  #|              showcase_layout_icon(),
+  #|              @html.span("Show grid"),
+  #|            ]),
+  #|            @rui.context_menu_checkbox_item(scope, value="sidebar", [
+  #|              showcase_panel_left_icon(),
+  #|              @html.span("Show sidebar"),
+  #|            ]),
+  #|            @rui.context_menu_checkbox_item(scope, value="activity", [
+  #|              showcase_activity_icon(),
+  #|              @html.span("Show activity"),
+  #|            ]),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgContextMenuRadioIconsCode : String =
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_file_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+
+///|
+const IgContextMenuRadioCode : String =
+  #|@rui.context_menu(
+  #|  id="showcase-context-menu-radio",
+  #|  default_radio_values=[("layout", "canvas")],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.context_menu_trigger(
+  #|        scope,
+  #|        style=["display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px dashed var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);color:var(--rui-muted-foreground);font-size:0.8125rem;text-align:center;user-select:none"],
+  #|        "Right-click for layout controls",
+  #|      ),
+  #|      @rui.context_menu_portal([
+  #|        @rui.context_menu_content(scope, aria_label="Layout controls", [
+  #|          @rui.context_menu_group(aria_label="Layout", [
+  #|            @rui.context_menu_label("Layout"),
+  #|            @rui.context_menu_radio_group(scope, value="layout", radio => {
+  #|              @html.fragment([
+  #|                @rui.context_menu_radio_item(radio, value="canvas", [
+  #|                  showcase_layout_icon(),
+  #|                  @html.span("Canvas"),
+  #|                ]),
+  #|                @rui.context_menu_radio_item(radio, value="editor", [
+  #|                  showcase_file_icon(),
+  #|                  @html.span("Editor"),
+  #|                ]),
+  #|                @rui.context_menu_radio_item(radio, value="focus", [
+  #|                  showcase_activity_icon(),
+  #|                  @html.span("Focus"),
+  #|                ]),
+  #|              ])
+  #|            }),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgCommandInlineCode : String =
+  #|@rui.command(
+  #|  id="showcase-command",
+  #|  style=["max-width:none;border:1px solid var(--rui-border);border-radius:var(--rui-radius);box-shadow:none"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.command_input(scope~, placeholder="Search actions…"),
+  #|      @rui.command_list(scope~, [
+  #|        @rui.command_empty(scope~, "No matching actions."),
+  #|        @rui.command_group(scope~, heading="Workspace", [
+  #|          @rui.command_item(
+  #|            scope~,
+  #|            value="Open dashboard",
+  #|            keywords=["home"],
+  #|            [@html.span("Open dashboard"), @rui.command_shortcut("⌘D")],
+  #|          ),
+  #|          @rui.command_item(scope~, value="Create project", keywords=["new"], [
+  #|            @html.span("Create project"),
+  #|            @rui.command_shortcut("⌘N"),
+  #|          ]),
+  #|          @rui.command_separator(),
+  #|          @rui.command_item(
+  #|            scope~,
+  #|            value="Settings",
+  #|            keywords=["preferences"],
+  #|            "Settings",
+  #|          ),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgCommandDialogCode : String =
+  #|@rui.command_dialog(
+  #|  id="showcase-command-dialog",
+  #|  aria_label="Command palette",
+  #|  trigger=scope => {
+  #|    @rui.command_dialog_trigger(scope~, variant=@rui.Outline, "Open palette")
+  #|  },
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.command_input(scope~, placeholder="Type a command…"),
+  #|      @rui.command_list(scope~, [
+  #|        @rui.command_empty(scope~, "No matching commands."),
+  #|        @rui.command_group(scope~, heading="Navigation", [
+  #|          @rui.command_item(scope~, value="Go to overview", "Go to overview"),
+  #|          @rui.command_item(scope~, value="Open settings", "Open settings"),
+  #|          @rui.command_item(
+  #|            scope~,
+  #|            value="Unavailable command",
+  #|            disabled=true,
+  #|            "Unavailable command",
+  #|          ),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDropdownMenuBasicCode : String =
+  #|@rui.dropdown_menu(
+  #|  id="showcase-dropdown-menu-basic",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Workspace menu"),
+  #|      @rui.dropdown_menu_portal([
+  #|        @rui.dropdown_menu_content(scope, side=@rui.Bottom, align=@rui.Start, [
+  #|          @rui.dropdown_menu_group(aria_label="Workspace", [
+  #|            @rui.dropdown_menu_label("Workspace"),
+  #|            @rui.dropdown_menu_item(scope, [
+  #|              @html.span("New tab"),
+  #|              @rui.dropdown_menu_shortcut("⌘T"),
+  #|            ]),
+  #|            @rui.dropdown_menu_item(scope, "Invite member"),
+  #|            @rui.dropdown_menu_item(scope, "Move workspace"),
+  #|            @rui.dropdown_menu_item(
+  #|              scope,
+  #|              disabled=true,
+  #|              "Duplicate workspace",
+  #|            ),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDropdownMenuIconsIconsCode : String =
+  #|fn showcase_user_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M20 21a8 8 0 0 0-16 0M12 13a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z")
+  #|}
+  #|
+  #|fn showcase_credit_card_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M2 10h20M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z")
+  #|}
+  #|
+  #|fn showcase_settings_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z")
+  #|}
+  #|
+  #|fn showcase_log_out_icon() -> @html.Html {
+  #|  showcase_stroke_icon("m16 17 5-5-5-5M21 12H9M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4")
+  #|}
+
+///|
+const IgDropdownMenuIconsCode : String =
+  #|@rui.dropdown_menu(
+  #|  id="showcase-dropdown-menu-icons",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Account"),
+  #|      @rui.dropdown_menu_portal([
+  #|        @rui.dropdown_menu_content(
+  #|          scope,
+  #|          side=@rui.Bottom,
+  #|          align=@rui.Start,
+  #|          style=["min-width:12rem"],
+  #|          [
+  #|            @rui.dropdown_menu_item(scope, [
+  #|              showcase_user_icon(),
+  #|              @html.span("Profile"),
+  #|            ]),
+  #|            @rui.dropdown_menu_item(scope, [
+  #|              showcase_credit_card_icon(),
+  #|              @html.span("Billing"),
+  #|            ]),
+  #|            @rui.dropdown_menu_item(scope, [
+  #|              showcase_settings_icon(),
+  #|              @html.span("Settings"),
+  #|            ]),
+  #|            @rui.dropdown_menu_separator(),
+  #|            @rui.dropdown_menu_item(scope, destructive=true, [
+  #|              showcase_log_out_icon(),
+  #|              @html.span("Log out"),
+  #|            ]),
+  #|          ],
+  #|        ),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDropdownMenuCheckboxIconsCode : String =
+  #|fn showcase_mail_icon() -> @html.Html {
+  #|  showcase_stroke_icon("m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z")
+  #|}
+  #|
+  #|fn showcase_message_square_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M21 15a4 4 0 0 1-4 4H7l-4 4V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4Z")
+  #|}
+  #|
+  #|fn showcase_bell_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M10.268 21a2 2 0 0 0 3.464 0M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326")
+  #|}
+  #|
+
+///|
+const IgDropdownMenuCheckboxCode : String =
+  #|@rui.dropdown_menu(
+  #|  id="showcase-dropdown-menu-checkbox",
+  #|  default_checked_values=["email", "push"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Notifications"),
+  #|      @rui.dropdown_menu_portal([
+  #|        @rui.dropdown_menu_content(scope, style=["min-width:14rem"], [
+  #|          @rui.dropdown_menu_group(aria_label="Notifications", [
+  #|            @rui.dropdown_menu_label("Notifications"),
+  #|            @rui.dropdown_menu_checkbox_item(scope, value="email", [
+  #|              showcase_mail_icon(),
+  #|              @html.span("Email"),
+  #|            ]),
+  #|            @rui.dropdown_menu_checkbox_item(scope, value="sms", [
+  #|              showcase_message_square_icon(),
+  #|              @html.span("SMS"),
+  #|            ]),
+  #|            @rui.dropdown_menu_checkbox_item(scope, value="push", [
+  #|              showcase_bell_icon(),
+  #|              @html.span("Push notifications"),
+  #|            ]),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDropdownMenuRadioIconsCode : String =
+  #|fn showcase_credit_card_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M2 10h20M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z")
+  #|}
+  #|
+  #|fn showcase_wallet_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M20 7V6a2 2 0 0 0-2-2H5a3 3 0 0 0 0 6h15v10H5a3 3 0 0 1-3-3V7M16 14h.01")
+  #|}
+  #|
+  #|fn showcase_building_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18M6 12H4a2 2 0 0 0-2 2v8h20v-8a2 2 0 0 0-2-2h-2M10 6h4M10 10h4M10 14h4M10 18h4")
+  #|}
+
+///|
+const IgDropdownMenuRadioCode : String =
+  #|@rui.dropdown_menu(
+  #|  id="showcase-dropdown-menu-radio",
+  #|  default_radio_values=[("payment", "card")],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Payment method"),
+  #|      @rui.dropdown_menu_portal([
+  #|        @rui.dropdown_menu_content(scope, style=["min-width:14rem"], [
+  #|          @rui.dropdown_menu_group(aria_label="Payment method", [
+  #|            @rui.dropdown_menu_label("Payment method"),
+  #|            @rui.dropdown_menu_radio_group(scope, value="payment", radio => {
+  #|              @html.fragment([
+  #|                @rui.dropdown_menu_radio_item(radio, value="card", [
+  #|                  showcase_credit_card_icon(),
+  #|                  @html.span("Credit card"),
+  #|                ]),
+  #|                @rui.dropdown_menu_radio_item(radio, value="wallet", [
+  #|                  showcase_wallet_icon(),
+  #|                  @html.span("PayPal"),
+  #|                ]),
+  #|                @rui.dropdown_menu_radio_item(radio, value="bank", [
+  #|                  showcase_building_icon(),
+  #|                  @html.span("Bank transfer"),
+  #|                ]),
+  #|              ])
+  #|            }),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDropdownMenuSubmenuCode : String =
+  #|@rui.dropdown_menu(
+  #|  id="showcase-dropdown-menu-submenu",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.dropdown_menu_trigger(
+  #|        scope,
+  #|        variant=@rui.Secondary,
+  #|        size=@rui.Sm,
+  #|        "Top-end menu",
+  #|      ),
+  #|      @rui.dropdown_menu_portal([
+  #|        @rui.dropdown_menu_content(
+  #|          scope,
+  #|          side=@rui.Top,
+  #|          align=@rui.End,
+  #|          style=["min-width:12rem"],
+  #|          [
+  #|            @rui.dropdown_menu_item(scope, [
+  #|              @html.span("Open workspace"),
+  #|              @rui.dropdown_menu_shortcut("⌘O"),
+  #|            ]),
+  #|            @rui.dropdown_menu_sub(scope, value="share", sub => {
+  #|              @html.fragment([
+  #|                @rui.dropdown_menu_sub_trigger(sub, "Share"),
+  #|                @rui.dropdown_menu_sub_content(sub, [
+  #|                  @rui.dropdown_menu_group(aria_label="Share workspace", [
+  #|                    @rui.dropdown_menu_label("Share workspace"),
+  #|                    @rui.dropdown_menu_item(scope, "Copy link"),
+  #|                    @rui.dropdown_menu_item(scope, "Invite people"),
+  #|                  ]),
+  #|                ]),
+  #|              ])
+  #|            }),
+  #|            @rui.dropdown_menu_item(scope, disabled=true, "Unavailable"),
+  #|          ],
+  #|        ),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgDropdownMenuMultiLevelIconsCode : String =
+  #|fn showcase_file_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+  #|}
+  #|
+  #|fn showcase_folder_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z")
+  #|}
+  #|
+  #|fn showcase_folder_open_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M6 14l1.5-4h12.8a1.5 1.5 0 0 1 1.42 2l-2.1 6.2A2 2 0 0 1 17.72 20H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2")
+  #|}
+  #|
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+  #|
+  #|fn showcase_archive_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M21 8v13H3V8M1 3h22v5H1zM10 12h4")
+  #|}
+
+///|
+const IgDropdownMenuMultiLevelCode : String =
+  #|@rui.dropdown_menu(
+  #|  id="showcase-dropdown-menu-multilevel",
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Organize file"),
+  #|      @rui.dropdown_menu_portal([
+  #|        @rui.dropdown_menu_content(scope, style=["min-width:13rem"], [
+  #|          @rui.dropdown_menu_item(scope, [
+  #|            showcase_file_icon(),
+  #|            @html.span("Rename"),
+  #|          ]),
+  #|          @rui.dropdown_menu_sub(scope, value="move", destination => {
+  #|            @html.fragment([
+  #|              @rui.dropdown_menu_sub_trigger(destination, [
+  #|                showcase_folder_icon(),
+  #|                @html.span("Move to"),
+  #|              ]),
+  #|              @rui.dropdown_menu_sub_content(
+  #|                destination,
+  #|                style=["min-width:12rem"],
+  #|                [
+  #|                  @rui.dropdown_menu_label("Destination"),
+  #|                  @rui.dropdown_menu_item(scope, [
+  #|                    showcase_folder_icon(),
+  #|                    @html.span("Inbox"),
+  #|                  ]),
+  #|                  @rui.dropdown_menu_sub(scope, value="projects", project => {
+  #|                    @html.fragment([
+  #|                      @rui.dropdown_menu_sub_trigger(project, [
+  #|                        showcase_folder_open_icon(),
+  #|                        @html.span("Projects"),
+  #|                      ]),
+  #|                      @rui.dropdown_menu_sub_content(
+  #|                        project,
+  #|                        style=["min-width:13rem"],
+  #|                        [
+  #|                          @rui.dropdown_menu_group(
+  #|                            aria_label="Project destination",
+  #|                            [
+  #|                              @rui.dropdown_menu_label("Project destination"),
+  #|                              @rui.dropdown_menu_item(scope, [
+  #|                                showcase_layout_icon(),
+  #|                                @html.span("Design system"),
+  #|                              ]),
+  #|                              @rui.dropdown_menu_item(scope, [
+  #|                                showcase_activity_icon(),
+  #|                                @html.span("Experiments"),
+  #|                              ]),
+  #|                            ],
+  #|                          ),
+  #|                        ],
+  #|                      ),
+  #|                    ])
+  #|                  }),
+  #|                ],
+  #|              ),
+  #|            ])
+  #|          }),
+  #|          @rui.dropdown_menu_separator(),
+  #|          @rui.dropdown_menu_item(scope, destructive=true, [
+  #|            showcase_archive_icon(),
+  #|            @html.span("Archive"),
+  #|          ]),
+  #|        ]),
+  #|      ]),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgMenubarCommandsIconsCode : String =
+  #|fn showcase_plus_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M12 5v14M5 12h14")
+  #|}
+  #|
+  #|fn showcase_file_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+  #|}
+  #|
+  #|fn showcase_archive_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M21 8v13H3V8M1 3h22v5H1zM10 12h4")
+  #|}
+  #|
+  #|fn showcase_circle_help_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.1 9a3 3 0 1 1 5.8 1c0 2-2.9 2-2.9 4M12 17h.01")
+  #|}
+
+///|
+const IgMenubarCommandsCode : String =
+  #|@rui.menubar(id="showcase-menubar-commands", scope => {
+  #|  @html.fragment([
+  #|    @rui.menubar_menu(scope, value="file", menu => {
+  #|      @html.fragment([
+  #|        @rui.menubar_trigger(menu, "File"),
+  #|        @rui.menubar_portal([
+  #|          @rui.menubar_content(menu, [
+  #|            @rui.menubar_group(aria_label="Project commands", [
+  #|              @rui.menubar_label("Project"),
+  #|              @rui.menubar_item(menu, [
+  #|                showcase_plus_icon(),
+  #|                @html.span("New project"),
+  #|                @rui.menubar_shortcut("⌘N"),
+  #|              ]),
+  #|              @rui.menubar_item(menu, [
+  #|                showcase_file_icon(),
+  #|                @html.span("Open…"),
+  #|                @rui.menubar_shortcut("⌘O"),
+  #|              ]),
+  #|              @rui.menubar_item(menu, disabled=true, [
+  #|                showcase_archive_icon(),
+  #|                @html.span("Import"),
+  #|              ]),
+  #|            ]),
+  #|          ]),
+  #|        ]),
+  #|      ])
+  #|    }),
+  #|    @rui.menubar_menu(scope, value="help", menu => {
+  #|      @html.fragment([
+  #|        @rui.menubar_trigger(menu, "Help"),
+  #|        @rui.menubar_portal([
+  #|          @rui.menubar_content(menu, [
+  #|            @rui.menubar_group(aria_label="Help", [
+  #|              @rui.menubar_label("Help"),
+  #|              @rui.menubar_item(menu, [
+  #|                showcase_circle_help_icon(),
+  #|                @html.span("Keyboard shortcuts"),
+  #|                @rui.menubar_shortcut("?"),
+  #|              ]),
+  #|            ]),
+  #|          ]),
+  #|        ]),
+  #|      ])
+  #|    }),
+  #|  ])
+  #|})
+
+///|
+const IgMenubarSubmenuIconsCode : String =
+  #|fn showcase_settings_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z")
+  #|}
+  #|
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_file_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+  #|
+  #|fn showcase_close_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M18 6 6 18M6 6l12 12")
+  #|}
+
+///|
+const IgMenubarSubmenuCode : String =
+  #|@rui.menubar(id="showcase-menubar-submenu", scope => {
+  #|  @html.fragment([
+  #|    @rui.menubar_menu(scope, value="project", menu => {
+  #|      @html.fragment([
+  #|        @rui.menubar_trigger(menu, "Project"),
+  #|        @rui.menubar_portal([
+  #|          @rui.menubar_content(menu, [
+  #|            @rui.menubar_item(menu, [
+  #|              showcase_settings_icon(),
+  #|              @html.span("Project settings"),
+  #|            ]),
+  #|            @rui.menubar_sub(menu, value="recent", sub => {
+  #|              @html.fragment([
+  #|                @rui.menubar_sub_trigger(sub, [
+  #|                  showcase_layout_icon(),
+  #|                  @html.span("Recent projects"),
+  #|                ]),
+  #|                @rui.menubar_sub_content(sub, [
+  #|                  @rui.menubar_group(aria_label="Recent projects", [
+  #|                    @rui.menubar_label("Recent projects"),
+  #|                    @rui.menubar_item(menu, [
+  #|                      showcase_file_icon(),
+  #|                      @html.span("Design system"),
+  #|                    ]),
+  #|                    @rui.menubar_item(menu, [
+  #|                      showcase_activity_icon(),
+  #|                      @html.span("Experiments"),
+  #|                    ]),
+  #|                  ]),
+  #|                ]),
+  #|              ])
+  #|            }),
+  #|            @rui.menubar_separator(),
+  #|            @rui.menubar_item(menu, destructive=true, [
+  #|              showcase_close_icon(),
+  #|              @html.span("Close project"),
+  #|            ]),
+  #|          ]),
+  #|        ]),
+  #|      ])
+  #|    }),
+  #|  ])
+  #|})
+
+///|
+const IgMenubarCheckboxIconsCode : String =
+  #|fn showcase_panel_left_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 3h18v18H3zM9 3v18")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+  #|
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+
+///|
+const IgMenubarCheckboxCode : String =
+  #|@rui.menubar(
+  #|  id="showcase-menubar-checkbox",
+  #|  default_checked_values=["sidebar", "activity"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.menubar_menu(scope, value="view", menu => {
+  #|        @html.fragment([
+  #|          @rui.menubar_trigger(menu, "View"),
+  #|          @rui.menubar_portal([
+  #|            @rui.menubar_content(menu, [
+  #|              @rui.menubar_group(aria_label="Panels", [
+  #|                @rui.menubar_label("Panels"),
+  #|                @rui.menubar_checkbox_item(menu, value="sidebar", [
+  #|                  showcase_panel_left_icon(),
+  #|                  @html.span("Sidebar"),
+  #|                ]),
+  #|                @rui.menubar_checkbox_item(menu, value="activity", [
+  #|                  showcase_activity_icon(),
+  #|                  @html.span("Activity bar"),
+  #|                ]),
+  #|                @rui.menubar_checkbox_item(menu, value="status", [
+  #|                  showcase_layout_icon(),
+  #|                  @html.span("Status bar"),
+  #|                ]),
+  #|              ]),
+  #|            ]),
+  #|          ]),
+  #|        ])
+  #|      }),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgMenubarRadioIconsCode : String =
+  #|fn showcase_file_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6")
+  #|}
+  #|
+  #|fn showcase_layout_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+  #|}
+  #|
+  #|fn showcase_activity_icon() -> @html.Html {
+  #|  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+  #|}
+
+///|
+const IgMenubarRadioCode : String =
+  #|@rui.menubar(
+  #|  id="showcase-menubar-radio",
+  #|  default_radio_values=[("workspace", "editor")],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.menubar_menu(scope, value="workspace", menu => {
+  #|        @html.fragment([
+  #|          @rui.menubar_trigger(menu, "Workspace"),
+  #|          @rui.menubar_portal([
+  #|            @rui.menubar_content(menu, [
+  #|              @rui.menubar_group(aria_label="Workspace mode", [
+  #|                @rui.menubar_label("Workspace mode"),
+  #|                @rui.menubar_radio_group(menu, value="workspace", radio => {
+  #|                  @html.fragment([
+  #|                    @rui.menubar_radio_item(radio, value="editor", [
+  #|                      showcase_file_icon(),
+  #|                      @html.span("Editor"),
+  #|                    ]),
+  #|                    @rui.menubar_radio_item(radio, value="canvas", [
+  #|                      showcase_layout_icon(),
+  #|                      @html.span("Canvas"),
+  #|                    ]),
+  #|                    @rui.menubar_radio_item(radio, value="focus", [
+  #|                      showcase_activity_icon(),
+  #|                      @html.span("Focus"),
+  #|                    ]),
+  #|                  ])
+  #|                }),
+  #|              ]),
+  #|            ]),
+  #|          ]),
+  #|        ])
+  #|      }),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgPopoverSharedCode : String =
+  #|fn popover_variant(
+  #|  id : String,
+  #|  side : @rui.PopupSide,
+  #|  align : @rui.PopupAlign,
+  #|  trigger_label : String,
+  #|) -> @rabbita.Val[@html.Html] {
+  #|  let title_id = id + "-title"
+  #|  let description_id = id + "-description"
+  #|  @rui.popover(
+  #|    id~,
+  #|    side~,
+  #|    align~,
+  #|    title_id~,
+  #|    description_id~,
+  #|    trigger_variant=@rui.Outline,
+  #|    trigger_label,
+  #|    @html.div(
+  #|      style=["display:flex;flex-direction:column;gap:0.75rem"],
+  #|      [
+  #|        @rui.popover_header([
+  #|          @rui.popover_title(id=title_id, trigger_label),
+  #|          @rui.popover_description(
+  #|            id=description_id,
+  #|            "Anchored content stays labelled at this placement.",
+  #|          ),
+  #|        ]),
+  #|        @rui.input(
+  #|          value="320 px",
+  #|          attrs=@html.Attrs::build().aria_label("Preferred width"),
+  #|        ),
+  #|        @rui.popover_close_button(target_id=id, size=@rui.Sm, "Apply"),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+
+///|
+const IgPopoverBottomStartCallCode : String =
+  #|popover_variant(
+  #|  "showcase-popover-bottom",
+  #|  @rui.Bottom,
+  #|  @rui.Start,
+  #|  "Bottom-start popover",
+  #|)
+
+///|
+const IgPopoverRightCenterCallCode : String =
+  #|popover_variant(
+  #|  "showcase-popover-right",
+  #|  @rui.Right,
+  #|  @rui.Center,
+  #|  "Right-center popover",
+  #|)
+
+///|
+fn ig_popover_code(call : String) -> String {
+  IgPopoverSharedCode + "\n\n" + call
+}
+
+///|
+const IgHoverCardSharedCode : String =
+  #|fn hover_card_variant(
+  #|  id : String,
+  #|  side : @rui.PopupSide,
+  #|  align : @rui.PopupAlign,
+  #|  trigger_label : String,
+  #|) -> @rabbita.Val[@html.Html] {
+  #|  @rui.hover_card(
+  #|    id~,
+  #|    href="#rabbita-profile",
+  #|    open_delay=120,
+  #|    close_delay=80,
+  #|    side~,
+  #|    align~,
+  #|    trigger_variant=@rui.Link,
+  #|    trigger_label,
+  #|    @html.div(style=["display:flex;flex-direction:column;gap:0.5rem"], [
+  #|      @html.strong("Rabbita UI"),
+  #|      @html.p(
+  #|        style=["color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35;margin:0"],
+  #|        "Native MoonBit components with incremental state.",
+  #|      ),
+  #|      @html.div(
+  #|        style=["display:flex;flex-wrap:wrap;align-items:center;gap:0.75rem"],
+  #|        [
+  #|          @rui.badge(variant=@rui.Secondary, "Vega"),
+  #|          @rui.badge(variant=@rui.Outline, "Inline"),
+  #|        ],
+  #|      ),
+  #|    ]),
+  #|  )
+  #|}
+  #|
+
+///|
+const IgHoverCardTopCenterCallCode : String =
+  #|hover_card_variant(
+  #|  "showcase-hover-card-top",
+  #|  @rui.Top,
+  #|  @rui.Center,
+  #|  "Top-center preview",
+  #|)
+
+///|
+const IgHoverCardLeftEndCallCode : String =
+  #|hover_card_variant(
+  #|  "showcase-hover-card-left",
+  #|  @rui.Left,
+  #|  @rui.End,
+  #|  "Left-end preview",
+  #|)
+
+///|
+fn ig_hover_card_code(call : String) -> String {
+  IgHoverCardSharedCode + "\n\n" + call
+}
+
+///|
+const IgTooltipSharedCode : String =
+  #|fn circle_help_icon() -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.1 9a3 3 0 1 1 5.8 1c0 2-2.9 2-2.9 4M12 17h.01",
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn tooltip_variant(
+  #|  id : String,
+  #|  side : @rui.PopupSide,
+  #|  align : @rui.PopupAlign,
+  #|  size : @rui.ButtonSize,
+  #|  label : String,
+  #|) -> @rabbita.Val[@html.Html] {
+  #|  @rui.tooltip(
+  #|    id~,
+  #|    delay=100,
+  #|    side~,
+  #|    align~,
+  #|    show_arrow=true,
+  #|    trigger_variant=@rui.Outline,
+  #|    trigger_size=size,
+  #|    trigger_attrs=@html.Attrs::build().aria_label(label),
+  #|    circle_help_icon(),
+  #|    label,
+  #|  )
+  #|}
+  #|
+
+///|
+const IgTooltipTopStartCallCode : String =
+  #|tooltip_variant(
+  #|  "showcase-tooltip-top",
+  #|  @rui.Top,
+  #|  @rui.Start,
+  #|  @rui.IconSm,
+  #|  "Top-start tooltip",
+  #|)
+
+///|
+const IgTooltipRightCenterCallCode : String =
+  #|tooltip_variant(
+  #|  "showcase-tooltip-right",
+  #|  @rui.Right,
+  #|  @rui.Center,
+  #|  @rui.Icon,
+  #|  "Right-center tooltip",
+  #|)
+
+///|
+const IgTooltipBottomEndCallCode : String =
+  #|tooltip_variant(
+  #|  "showcase-tooltip-bottom",
+  #|  @rui.Bottom,
+  #|  @rui.End,
+  #|  @rui.IconLg,
+  #|  "Bottom-end tooltip",
+  #|)
+
+///|
+const IgTooltipLeftCenterCallCode : String =
+  #|tooltip_variant(
+  #|  "showcase-tooltip-left",
+  #|  @rui.Left,
+  #|  @rui.Center,
+  #|  @rui.Icon,
+  #|  "Left-center tooltip",
+  #|)
+
+///|
+fn ig_tooltip_code(call : String) -> String {
+  IgTooltipSharedCode + "\n\n" + call
+}
+
+///|
+const IgSheetSharedCode : String =
+  #|fn sheet_variant(
+  #|  id : String,
+  #|  side : @rui.SheetSide,
+  #|  trigger_label : String,
+  #|) -> @rabbita.Val[@html.Html] {
+  #|  @rui.sheet(id~, scope => {
+  #|    @html.fragment([
+  #|      @rui.sheet_trigger(scope, variant=@rui.Outline, trigger_label),
+  #|      @rui.sheet_content(scope, side~, [
+  #|        @rui.sheet_header([
+  #|          @rui.sheet_title(scope, trigger_label),
+  #|          @rui.sheet_description(
+  #|            scope,
+  #|            "Placement changes while focus and dismissal behavior stay consistent.",
+  #|          ),
+  #|        ]),
+  #|        @html.div(style=["display:flex;flex-direction:column;gap:1rem"], [
+  #|          @rui.label(for_=id + "-email", "Notification email"),
+  #|          @rui.input(id=id + "-email", value="team@example.com"),
+  #|        ]),
+  #|        @rui.sheet_footer(@rui.sheet_close(scope, "Save settings")),
+  #|      ]),
+  #|    ])
+  #|  })
+  #|}
+  #|
+
+///|
+const IgSheetTopCallCode : String =
+  #|sheet_variant(
+  #|  "showcase-sheet-top",
+  #|  @rui.SheetTop,
+  #|  "Open top sheet",
+  #|)
+
+///|
+const IgSheetRightCallCode : String =
+  #|sheet_variant(
+  #|  "showcase-sheet-right",
+  #|  @rui.SheetRight,
+  #|  "Open right sheet",
+  #|)
+
+///|
+const IgSheetBottomCallCode : String =
+  #|sheet_variant(
+  #|  "showcase-sheet-bottom",
+  #|  @rui.SheetBottom,
+  #|  "Open bottom sheet",
+  #|)
+
+///|
+const IgSheetLeftCallCode : String =
+  #|sheet_variant(
+  #|  "showcase-sheet-left",
+  #|  @rui.SheetLeft,
+  #|  "Open left sheet",
+  #|)
+
+///|
+fn ig_sheet_code(call : String) -> String {
+  IgSheetSharedCode + "\n\n" + call
+}
+
+///|
+const IgSonnerDefaultCode : String =
+  #|@rui.sonner(max_toasts=3, position="bottom-right", scope => {
+  #|  @rui.button(
+  #|    size=@rui.Sm,
+  #|    on_click=scope.show(
+  #|      title="Saved",
+  #|      description="The draft remains in this workspace.",
+  #|      variant=@rui.ToastDefault,
+  #|    ),
+  #|    "Default toast",
+  #|  )
+  #|})
+
+///|
+const IgSonnerSuccessCode : String =
+  #|@rui.sonner(max_toasts=3, position="bottom-right", scope => {
+  #|  @rui.button(
+  #|    size=@rui.Sm,
+  #|    variant=@rui.Secondary,
+  #|    on_click=scope.show(
+  #|      title="Published",
+  #|      description="The latest UI preview is live.",
+  #|      variant=@rui.ToastSuccess,
+  #|    ),
+  #|    "Success toast",
+  #|  )
+  #|})
+
+///|
+const IgSonnerDestructiveCode : String =
+  #|@rui.sonner(max_toasts=3, position="bottom-right", scope => {
+  #|  @rui.button(
+  #|    size=@rui.Sm,
+  #|    variant=@rui.Destructive,
+  #|    on_click=scope.show(
+  #|      title="Could not sync",
+  #|      description="Check the connection and try again.",
+  #|      variant=@rui.ToastDestructive,
+  #|    ),
+  #|    "Error toast",
+  #|  )
+  #|})
+
+///|
+const IgSonnerQueueCode : String =
+  #|@rui.sonner(max_toasts=3, position="bottom-right", scope => {
+  #|  @html.div(
+  #|    style=["display:flex;min-width:0;flex-wrap:wrap;align-items:center;gap:0.5rem"],
+  #|    [
+  #|      @rui.button(
+  #|        size=@rui.Sm,
+  #|        on_click=scope.show(
+  #|          title="Queued",
+  #|          description="This notification joins the bounded queue.",
+  #|          variant=@rui.ToastDefault,
+  #|        ),
+  #|        "Add toast",
+  #|      ),
+  #|      @rui.button(
+  #|        size=@rui.Sm,
+  #|        variant=@rui.Ghost,
+  #|        on_click=scope.dismiss_all(),
+  #|        "Dismiss queue",
+  #|      ),
+  #|    ],
+  #|  )
+  #|})
+
+///|
+const IgToastDefaultCode : String =
+  #|@rui.toast(variant=@rui.ToastDefault, [
+  #|  @rui.toast_title("Draft saved"),
+  #|  @rui.toast_description("Your changes remain local."),
+  #|  @rui.toast_action("View"),
+  #|])
+
+///|
+const IgToastSuccessCode : String =
+  #|@rui.toast(variant=@rui.ToastSuccess, [
+  #|  @rui.toast_title("Published"),
+  #|  @rui.toast_description("The latest preview is live."),
+  #|])
+
+///|
+const IgToastDestructiveCode : String =
+  #|@rui.toast(variant=@rui.ToastDestructive, [
+  #|  @rui.toast_title("Could not sync"),
+  #|  @rui.toast_description("Check the connection and try again."),
+  #|])
+
+///|
+const IgMessageScrollerCode : String =
+  #|fn stroke_icon(path : String) -> @html.Html {
+  #|  let line_attrs = @svg.Attrs::build()
+  #|    .stroke_linecap("round")
+  #|    .stroke_linejoin("round")
+  #|  @html.span(
+  #|    style=["display:inline-flex;width:1rem;height:1rem;flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none"],
+  #|    attrs=@html.Attrs::build().aria_hidden("true"),
+  #|    @svg.svg(
+  #|      width=24,
+  #|      height=24,
+  #|      view_box="0 0 24 24",
+  #|      style=["display:block;width:100%;height:100%"],
+  #|      [
+  #|        @svg.path(
+  #|          d=path,
+  #|          fill="none",
+  #|          stroke="currentColor",
+  #|          stroke_width=2,
+  #|          attrs=line_attrs,
+  #|        ),
+  #|      ],
+  #|    ),
+  #|  )
+  #|}
+  #|
+  #|fn arrow_up_icon() -> @html.Html {
+  #|  stroke_icon("m18 15-6-6-6 6")
+  #|}
+  #|
+  #|fn arrow_down_icon() -> @html.Html {
+  #|  stroke_icon("m6 9 6 6 6-6")
+  #|}
+  #|
+  #|@rui.message_scroller(
+  #|  id="showcase-message-scroller",
+  #|  default_at_end=true,
+  #|  scope => {
+  #|    @html.div(style=["position:relative"], [
+  #|      @rui.message_scroller_viewport(
+  #|        scope~,
+  #|        style=["height:13rem"],
+  #|        @rui.message_scroller_content(
+  #|          style=["display:flex;flex-direction:column;gap:0.625rem;padding:0.75rem"],
+  #|          [
+  #|            @rui.message_scroller_item(
+  #|              @rui.message([
+  #|                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("RA"))),
+  #|                @rui.message_content([
+  #|                  @rui.message_header("Rabbita · 09:41"),
+  #|                  @rui.bubble_group(
+  #|                    @rui.bubble(
+  #|                      variant=@rui.BubbleSecondary,
+  #|                      @rui.bubble_content(
+  #|                        "The component catalogue is ready for review.",
+  #|                      ),
+  #|                    ),
+  #|                  ),
+  #|                ]),
+  #|              ]),
+  #|            ),
+  #|            @rui.message_scroller_item(
+  #|              @rui.message(align=@rui.AlignEnd, [
+  #|                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("YO"))),
+  #|                @rui.message_content([
+  #|                  @rui.message_header("You · 09:42"),
+  #|                  @rui.bubble_group(
+  #|                    @rui.bubble(
+  #|                      align=@rui.AlignEnd,
+  #|                      @rui.bubble_content(
+  #|                        "Great — keep state local and the API black-box.",
+  #|                      ),
+  #|                    ),
+  #|                  ),
+  #|                  @rui.message_footer("Delivered"),
+  #|                ]),
+  #|              ]),
+  #|            ),
+  #|            @rui.message_scroller_item(
+  #|              @rui.message([
+  #|                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("RA"))),
+  #|                @rui.message_content(
+  #|                  @rui.bubble_group(
+  #|                    @rui.bubble(
+  #|                      variant=@rui.BubbleMuted,
+  #|                      @rui.bubble_content(
+  #|                        "This scroller tracks both edges and exposes jump controls.",
+  #|                      ),
+  #|                    ),
+  #|                  ),
+  #|                ),
+  #|              ]),
+  #|            ),
+  #|            @rui.message_scroller_item(
+  #|              scroll_anchor=true,
+  #|              @rui.message(align=@rui.AlignEnd, [
+  #|                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("YO"))),
+  #|                @rui.message_content(
+  #|                  @rui.bubble_group(
+  #|                    @rui.bubble(
+  #|                      align=@rui.AlignEnd,
+  #|                      @rui.bubble_content("Ship the showcase."),
+  #|                    ),
+  #|                  ),
+  #|                ),
+  #|              ]),
+  #|            ),
+  #|          ],
+  #|        ),
+  #|      ),
+  #|      @html.div(
+  #|        style=["position:absolute;right:0.625rem;bottom:0.625rem;display:flex;gap:0.375rem"],
+  #|        [
+  #|          @rui.message_scroller_button(
+  #|            scope~,
+  #|            direction=@rui.ScrollStart,
+  #|            label="Jump to first message",
+  #|            size=@rui.IconSm,
+  #|            arrow_up_icon(),
+  #|          ),
+  #|          @rui.message_scroller_button(
+  #|            scope~,
+  #|            direction=@rui.ScrollEnd,
+  #|            label="Jump to latest message",
+  #|            size=@rui.IconSm,
+  #|            arrow_down_icon(),
+  #|          ),
+  #|        ],
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgResizableHorizontalCode : String =
+  #|@rui.resizable_group(
+  #|  id="showcase-resizable",
+  #|  default_sizes=[26, 44, 30],
+  #|  min_sizes=[16, 24, 18],
+  #|  max_sizes=[52, 68, 54],
+  #|  orientation=@rui.Horizontal,
+  #|  style=["height:14rem;overflow:hidden;border:1px solid var(--rui-border);border-radius:var(--rui-radius)"],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.resizable_group_panel(
+  #|        scope~,
+  #|        index=0,
+  #|        style=["display:flex;align-items:center;justify-content:center;padding:1.5rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center"],
+  #|        "Files",
+  #|      ),
+  #|      @rui.resizable_group_handle(
+  #|        scope~,
+  #|        between=0,
+  #|        with_handle=true,
+  #|        aria_label="Resize files and editor",
+  #|      ),
+  #|      @rui.resizable_group_panel(
+  #|        scope~,
+  #|        index=1,
+  #|        style=["display:flex;align-items:center;justify-content:center;padding:1.5rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center"],
+  #|        "Editor",
+  #|      ),
+  #|      @rui.resizable_group_handle(
+  #|        scope~,
+  #|        between=1,
+  #|        with_handle=true,
+  #|        aria_label="Resize editor and preview",
+  #|      ),
+  #|      @rui.resizable_group_panel(
+  #|        scope~,
+  #|        index=2,
+  #|        style=["display:flex;align-items:center;justify-content:center;padding:1.5rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center"],
+  #|        "Preview",
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgResizableVerticalCode : String =
+  #|@rui.resizable_panel_group(
+  #|  id="showcase-resizable-panel-group",
+  #|  default_size=42,
+  #|  min=24,
+  #|  max=72,
+  #|  orientation=@rui.Vertical,
+  #|  aria_label="Resize preview and console",
+  #|  style=[
+  #|    "height:14rem;overflow:hidden;border:1px solid var(--rui-border);border-radius:var(--rui-radius)",
+  #|    "width:min(100%,32rem);height:14rem;margin-inline:auto",
+  #|  ],
+  #|  scope => {
+  #|    @html.fragment([
+  #|      @rui.resizable_panel(
+  #|        scope~,
+  #|        side=@rui.FirstPanel,
+  #|        style=["display:flex;align-items:center;justify-content:center;padding:1.5rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center"],
+  #|        "Preview",
+  #|      ),
+  #|      @rui.resizable_handle(
+  #|        scope~,
+  #|        with_handle=true,
+  #|        aria_label="Resize preview and console",
+  #|      ),
+  #|      @rui.resizable_panel(
+  #|        scope~,
+  #|        side=@rui.SecondPanel,
+  #|        style=["display:flex;align-items:center;justify-content:center;padding:1.5rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center"],
+  #|        "Console",
+  #|      ),
+  #|    ])
+  #|  },
+  #|)
+
+///|
+const IgScrollAreaVerticalCode : String =
+  #|@rui.scroll_area_with_scrollbar(
+  #|  id="showcase-scroll-area",
+  #|  orientation=@rui.Vertical,
+  #|  style=["height:13rem;border:1px solid var(--rui-border);border-radius:var(--rui-radius)"],
+  #|  @html.div(
+  #|    style=["display:flex;flex-direction:column;gap:0.625rem;padding:0.875rem 1.25rem 0.875rem 0.875rem"],
+  #|    [
+  #|      @html.strong("Release checklist"),
+  #|      @rui.separator(),
+  #|      @html.span("Check semantic roles"),
+  #|      @html.span("Check keyboard order"),
+  #|      @html.span("Check light and dark themes"),
+  #|      @html.span("Check long labels"),
+  #|      @html.span("Check narrow containers"),
+  #|      @html.span("Check reduced motion"),
+  #|      @html.span("Check empty and error states"),
+  #|      @html.span("Check server rendering"),
+  #|      @html.span("Check native fallback"),
+  #|      @html.span("Ready to publish"),
+  #|    ],
+  #|  ),
+  #|)
+
+///|
+const IgScrollAreaHorizontalCode : String =
+  #|@rui.scroll_area_with_scrollbar(
+  #|  id="showcase-scroll-area-horizontal",
+  #|  orientation=@rui.Horizontal,
+  #|  style=["width:100%;max-width:100%;height:5.5rem;border:1px solid var(--rui-border);border-radius:var(--rui-radius)"],
+  #|  @html.div(
+  #|    style=["display:flex;width:max-content;min-width:44rem;gap:0.625rem;padding:0.875rem 1.25rem 1.25rem 0.875rem"],
+  #|    [
+  #|      @rui.badge(variant=@rui.Secondary, "Keyboard"),
+  #|      @rui.badge(variant=@rui.Secondary, "Pointer"),
+  #|      @rui.badge(variant=@rui.Secondary, "Touch"),
+  #|      @rui.badge(variant=@rui.Secondary, "RTL"),
+  #|      @rui.badge(variant=@rui.Secondary, "Measured thumb"),
+  #|      @rui.badge(variant=@rui.Secondary, "Native fallback"),
+  #|    ],
+  #|  ),
+  #|)

--- a/website/homepage/components/interactions_collapsible.mbt
+++ b/website/homepage/components/interactions_collapsible.mbt
@@ -1,0 +1,366 @@
+///|
+const IgCollapsibleWidthStyle : String = "width:min(100%,26rem);margin-inline:auto"
+
+///|
+const IgCollapsibleTriggerStyle : String = "min-height:2.5rem;padding:0.5rem 0.625rem;border:1px solid var(--rui-accordion-border,transparent);border-radius:var(--rui-radius);background:var(--rui-accordion-bg,transparent);text-decoration:none"
+
+///|
+const IgCollapsibleCardStyle : String = "width:min(100%,28rem);margin-inline:auto;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-card);box-shadow:0 1px 2px rgb(0 0 0 / 0.04)"
+
+///|
+const IgCollapsibleCardTriggerStyle : String = "min-height:3.75rem;padding:0.75rem 1rem;border:0;border-radius:calc(var(--rui-radius) - 1px);background:var(--rui-accordion-bg,transparent);text-decoration:none"
+
+///|
+const IgCollapsibleCardBodyStyle : String = "padding:0 1rem 1rem;color:var(--rui-foreground);font-size:0.875rem"
+
+///|
+const IgCollapsibleTreeCardStyle : String = "width:min(100%,16rem);margin-inline:auto;gap:0.5rem"
+
+///|
+const IgCollapsibleTreeListStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.25rem"
+
+///|
+const IgCollapsibleTreeTriggerStyle : String = "min-height:2rem;padding:0.25rem 0.375rem;border:1px solid var(--rui-accordion-border,transparent);border-radius:calc(var(--rui-radius) - 0.25rem);background:var(--rui-accordion-bg,transparent);font-weight:400;text-decoration:none"
+
+///|
+const IgCollapsibleTreeChildrenStyle : String = "display:flex;min-width:0;flex-direction:column;padding-inline-start:1.125rem"
+
+///|
+const IgCollapsibleTreeLeafStyle : String = "display:flex;min-height:2rem;min-width:0;align-items:center;gap:0.5rem;padding:0.25rem 0.375rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem"
+
+///|
+fn ig_collapsible_order_view() -> @rabbita.Val[@html.Html] {
+  @rui.collapsible(
+    id="showcase-collapsible-order",
+    default_open=true,
+    style=[IgCollapsibleCardStyle],
+    trigger_style=[IgCollapsibleCardTriggerStyle],
+    content_body_style=[IgCollapsibleCardBodyStyle],
+    trigger=@html.span(
+      style=[
+        "display:flex;min-width:0;align-items:center;justify-content:space-between;gap:0.75rem;text-align:start",
+      ],
+      [
+        @html.span(style=["display:grid;min-width:0;gap:0.125rem"], [
+          @html.strong("Order #4189"),
+          @html.span(style=[MutedStyle], "July 16 · 2 items"),
+        ]),
+        @rui.badge(variant=@rui.Secondary, "Paid"),
+      ],
+    ),
+    content=@html.div(style=["display:grid;gap:0.625rem"], [
+      @html.div(style=["display:flex;justify-content:space-between;gap:1rem"], [
+        @html.span("UI component license"),
+        @html.strong("$49.00"),
+      ]),
+      @html.div(style=["display:flex;justify-content:space-between;gap:1rem"], [
+        @html.span("Icon pack"),
+        @html.strong("$16.00"),
+      ]),
+      @html.hr(style=[
+        "width:100%;height:1px;border:0;background:var(--rui-border);margin:0.125rem 0",
+      ]),
+      @html.div(style=["display:flex;justify-content:space-between;gap:1rem"], [
+        @html.strong("Total"),
+        @html.strong("$65.00"),
+      ]),
+    ]),
+  )
+}
+
+///|
+fn ig_collapsible_basic_view() -> @rabbita.Val[@html.Html] {
+  @rui.collapsible(
+    id="showcase-collapsible-basic",
+    style=[IgCollapsibleWidthStyle],
+    trigger_style=[IgCollapsibleTriggerStyle],
+    content_body_style=["padding:0.25rem 0.625rem 0.75rem"],
+    trigger="Can I use this in my project?",
+    content=@html.p(
+      style=[MutedStyle, "margin:0"],
+      "Yes. The component owns its state, ARIA relationship, and keyboard activation.",
+    ),
+  )
+}
+
+///|
+fn ig_collapsible_settings_view() -> @rabbita.Val[@html.Html] {
+  @rui.collapsible(
+    id="showcase-collapsible-settings",
+    style=[IgCollapsibleCardStyle],
+    trigger_style=[IgCollapsibleCardTriggerStyle],
+    content_body_style=[IgCollapsibleCardBodyStyle],
+    trigger=@html.span(
+      style=[
+        "display:flex;min-width:0;align-items:center;gap:0.75rem;text-align:start",
+      ],
+      [
+        showcase_settings_icon(),
+        @html.span(style=["display:grid;min-width:0;gap:0.125rem"], [
+          @html.strong("Advanced settings"),
+          @html.span(style=[MutedStyle], "Configure the generated workspace"),
+        ]),
+      ],
+    ),
+    content=@html.div(style=["display:grid;gap:0.875rem"], [
+      @html.div(style=["display:grid;gap:0.375rem"], [
+        @rui.label(for_="collapsible-workspace-name", "Workspace name"),
+        @rui.input(id="collapsible-workspace-name", value="Rabbit Tea"),
+      ]),
+      @html.div(style=["display:grid;gap:0.375rem"], [
+        @rui.label(for_="collapsible-release-channel", "Release channel"),
+        @rui.input(id="collapsible-release-channel", value="Stable"),
+      ]),
+    ]),
+  )
+}
+
+///|
+fn ig_collapsible_tree_leaf(name : String) -> @html.Html {
+  @html.div(style=[IgCollapsibleTreeLeafStyle], [
+    showcase_file_icon(),
+    @html.span(
+      style=[
+        "min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap",
+      ],
+      name,
+    ),
+  ])
+}
+
+///|
+fn ig_collapsible_tree_folder(
+  open_paths : Array[String],
+  set_path_open : @rabbita.Emit[(String, Bool)],
+  path : String,
+  name : String,
+  children : Array[@html.Html],
+) -> @html.Html {
+  let open = open_paths.contains(path)
+  let trigger_id = "showcase-file-tree-" + path + "-trigger"
+  let content_id = "showcase-file-tree-" + path + "-content"
+  let on_open_change = set_path_open.map(next => (path, next))
+  @rui.collapsible_root(
+    open~,
+    attrs=@html.Attrs::build().data_set("path", path),
+    [
+      @rui.collapsible_trigger(
+        open~,
+        controls=content_id,
+        show_indicator=false,
+        on_open_change~,
+        id=trigger_id,
+        style=[IgCollapsibleTreeTriggerStyle],
+        @html.span(
+          style=["display:flex;min-width:0;align-items:center;gap:0.5rem"],
+          [
+            @html.span(
+              style=[
+                "display:inline-flex;flex:none;transition:transform 150ms ease;transform:\{if open { "rotate(90deg)" } else { "rotate(0deg)" }}",
+              ],
+              showcase_chevron_right_icon(),
+            ),
+            if open {
+              showcase_folder_open_icon()
+            } else {
+              showcase_folder_icon()
+            },
+            @html.span(
+              style=[
+                "min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap",
+              ],
+              name,
+            ),
+          ],
+        ),
+      ),
+      @rui.collapsible_content(
+        open~,
+        labelledby=trigger_id,
+        id=content_id,
+        body_style=["padding:0;color:var(--rui-foreground);font-size:0.875rem"],
+        @html.div(style=[IgCollapsibleTreeChildrenStyle], children),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_collapsible_next_open_paths(
+  current : Array[String],
+  path : String,
+  open : Bool,
+) -> Array[String] {
+  if open {
+    if current.contains(path) {
+      current
+    } else {
+      let next = current.copy()
+      next.push(path)
+      next
+    }
+  } else {
+    current.filter(item => item != path)
+  }
+}
+
+///|
+fn ig_collapsible_file_tree_view() -> @rabbita.Val[@html.Html] {
+  let view_tabs = @rui.tabs(
+    id="showcase-file-tree-tabs",
+    default_value="explorer",
+    aria_label="File tree view",
+    style=["gap:0"],
+    list_style=["width:100%"],
+    content_style=["display:none"],
+    items=[
+      @rui.tab_entry(value="explorer", label="Explorer", content=@html.nothing),
+      @rui.tab_entry(value="outline", label="Outline", content=@html.nothing),
+    ],
+  )
+  let (open_paths, set_open_paths) = @rabbita.create_variable([
+    "components", "components/ui", "lib",
+  ])
+  let set_path_open = set_open_paths.map(change => {
+    current => {
+      let (path, open) = change
+      ig_collapsible_next_open_paths(current, path, open)
+    }
+  })
+  open_paths.view2(view_tabs, (open_paths, tabs_html) => {
+    let components_ui = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "components/ui",
+      "ui",
+      [
+        ig_collapsible_tree_leaf("button.mbt"),
+        ig_collapsible_tree_leaf("card.mbt"),
+        ig_collapsible_tree_leaf("dialog.mbt"),
+        ig_collapsible_tree_leaf("input.mbt"),
+        ig_collapsible_tree_leaf("select.mbt"),
+        ig_collapsible_tree_leaf("table.mbt"),
+      ],
+    )
+    let components = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "components",
+      "components",
+      [
+        components_ui,
+        ig_collapsible_tree_leaf("login-form.mbt"),
+        ig_collapsible_tree_leaf("register-form.mbt"),
+      ],
+    )
+    let lib = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "lib",
+      "lib",
+      [
+        ig_collapsible_tree_leaf("utils.mbt"),
+        ig_collapsible_tree_leaf("cn.mbt"),
+        ig_collapsible_tree_leaf("api.mbt"),
+      ],
+    )
+    let hooks = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "hooks",
+      "hooks",
+      [
+        ig_collapsible_tree_leaf("use-media-query.mbt"),
+        ig_collapsible_tree_leaf("use-debounce.mbt"),
+        ig_collapsible_tree_leaf("use-local-storage.mbt"),
+      ],
+    )
+    let types = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "types",
+      "types",
+      [
+        ig_collapsible_tree_leaf("index.d.mbt"),
+        ig_collapsible_tree_leaf("api.d.mbt"),
+      ],
+    )
+    let public_images = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "public/images",
+      "images",
+      [ig_collapsible_tree_leaf("workspace.png")],
+    )
+    let public = ig_collapsible_tree_folder(
+      open_paths,
+      set_path_open,
+      "public",
+      "public",
+      [
+        ig_collapsible_tree_leaf("favicon.ico"),
+        ig_collapsible_tree_leaf("logo.svg"),
+        public_images,
+      ],
+    )
+    @rui.card(size=@rui.Sm, style=[IgCollapsibleTreeCardStyle], [
+      @rui.card_header(tabs_html),
+      @rui.card_content(
+        @html.div(style=[IgCollapsibleTreeListStyle], [
+          components,
+          lib,
+          hooks,
+          types,
+          public,
+          ig_collapsible_tree_leaf("app.mbt"),
+          ig_collapsible_tree_leaf("layout.mbt"),
+          ig_collapsible_tree_leaf("globals.css"),
+          ig_collapsible_tree_leaf("moon.pkg"),
+          ig_collapsible_tree_leaf("moon.mod"),
+          ig_collapsible_tree_leaf("README.md"),
+          ig_collapsible_tree_leaf(".gitignore"),
+        ]),
+      ),
+    ])
+  })
+}
+
+///|
+fn ig_collapsible_component(
+  order_html : @html.Html,
+  basic_html : @html.Html,
+  settings_html : @html.Html,
+  file_tree_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Collapsible",
+    "Disclosure patterns from compact details to independently controlled tree branches.",
+    [
+      showcase_demo_section(
+        "Order details",
+        "A summary card reveals line items without leaving the current context.",
+        showcase_demo_stage(order_html, IgCollapsibleOrderCode),
+      ),
+      showcase_demo_section(
+        "Basic",
+        "The black-box component owns open state and trigger-to-panel relationships.",
+        showcase_demo_stage(basic_html, IgCollapsibleBasicCode),
+      ),
+      showcase_demo_section(
+        "Settings panel",
+        "Rich trigger and panel content compose through the same public API.",
+        showcase_demo_stage(settings_html, IgCollapsibleSettingsCode),
+      ),
+      showcase_demo_section(
+        "File tree",
+        "Every folder is keyed by its full path, so nested open state survives parent toggles.",
+        showcase_demo_stage(
+          file_tree_html,
+          IgCollapsibleFileTreeCode,
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:34rem",
+        ),
+      ),
+    ],
+  )
+}

--- a/website/homepage/components/interactions_gallery.mbt
+++ b/website/homepage/components/interactions_gallery.mbt
@@ -1,0 +1,3154 @@
+///|
+const IgComponentListStyle : String = "display:flex;width:100%;min-width:0;flex-direction:column;gap:4rem"
+
+///|
+const IgDemoSurfaceStyle : String = "position:relative;min-width:0;padding-block:1rem"
+
+///|
+const IgControlWrapStyle : String = "display:flex;min-width:0;flex-wrap:wrap;align-items:center;gap:0.5rem"
+
+///|
+const IgSlideStyle : String = "display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px solid var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);font-size:1rem;font-weight:600"
+
+///|
+const IgCarouselStyle : String = "width:min(calc(100% - 6rem),32rem);margin-inline:auto"
+
+///|
+const IgVerticalCarouselStyle : String = "width:min(calc(100% - 6rem),32rem);margin:3rem auto"
+
+///|
+const IgVerticalSlideStyle : String = "height:var(--rui-carousel-height,12rem)"
+
+///|
+const IgNavigationContentStyle : String = "box-sizing:border-box;display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,8rem),1fr));gap:0.5rem;width:min(30rem,calc(100vw - 2rem));padding:0.25rem"
+
+///|
+const IgNavigationLinkStyle : String = "display:flex;min-height:4.5rem;flex-direction:column;justify-content:center;gap:0.25rem"
+
+///|
+const IgSidebarVariantFrameStyle : String = "--rui-sidebar-width:15rem;height:24rem;min-height:24rem;overflow:hidden"
+
+///|
+const IgSidebarWorkspaceStyle : String = "box-sizing:border-box;display:flex;min-width:0;flex:1;flex-direction:column;padding:0.75rem"
+
+///|
+const IgSidebarWorkspaceBodyStyle : String = "display:flex;min-height:0;flex:1;align-items:center;justify-content:center;padding:1rem"
+
+///|
+const IgContextTargetStyle : String = "display:flex;min-height:8rem;align-items:center;justify-content:center;border:1px dashed var(--rui-border);border-radius:var(--rui-radius);background:var(--rui-muted);color:var(--rui-muted-foreground);font-size:0.8125rem;text-align:center;user-select:none"
+
+///|
+const IgCommandStyle : String = "max-width:none;border:1px solid var(--rui-border);border-radius:var(--rui-radius);box-shadow:none"
+
+///|
+const IgMessageViewportStyle : String = "height:13rem"
+
+///|
+const IgMessageListStyle : String = "display:flex;flex-direction:column;gap:0.625rem;padding:0.75rem"
+
+///|
+const IgResizeStyle : String = "height:14rem;overflow:hidden;border:1px solid var(--rui-border);border-radius:var(--rui-radius)"
+
+///|
+const IgResizePanelStyle : String = "display:flex;align-items:center;justify-content:center;padding:1.5rem;color:var(--rui-foreground);font-size:0.875rem;line-height:1.25rem;font-weight:500;text-align:center"
+
+///|
+const IgResizableVerticalStyle : String = "width:min(100%,32rem);height:14rem;margin-inline:auto"
+
+///|
+const IgScrollAreaStyle : String = "height:13rem;border:1px solid var(--rui-border);border-radius:var(--rui-radius)"
+
+///|
+const IgScrollContentStyle : String = "display:flex;flex-direction:column;gap:0.625rem;padding:0.875rem 1.25rem 0.875rem 0.875rem"
+
+///|
+const IgHorizontalScrollAreaStyle : String = "width:100%;max-width:100%;height:5.5rem;border:1px solid var(--rui-border);border-radius:var(--rui-radius)"
+
+///|
+const IgHorizontalScrollContentStyle : String = "display:flex;width:max-content;min-width:44rem;gap:0.625rem;padding:0.875rem 1.25rem 1.25rem 0.875rem"
+
+///|
+fn ig_demo_card(
+  title : String,
+  description : String,
+  body : @html.Html,
+  variant_title : String,
+  variant_description : String,
+  code : String,
+  wide? : Bool = false,
+) -> @html.Html {
+  showcase_component_demos(title, description, [
+    showcase_demo_section(
+      variant_title,
+      variant_description,
+      showcase_demo_stage(body, code, tall=wide),
+    ),
+  ])
+}
+
+///|
+fn ig_breadcrumb_demo() -> @html.Html {
+  showcase_component_demos(
+    "Breadcrumb",
+    "Full and condensed trails cover links, separators, ellipsis, and current page state.",
+    [
+      showcase_demo_section(
+        "Default",
+        "Linked ancestors preserve the current-page relationship.",
+        showcase_demo_stage(
+          @rui.breadcrumb(
+            @rui.breadcrumb_list([
+              @rui.breadcrumb_item(
+                @rui.breadcrumb_link(href="#interactions", "UI"),
+              ),
+              @rui.breadcrumb_separator(),
+              @rui.breadcrumb_item(
+                @rui.breadcrumb_link(href="#navigation", "Patterns"),
+              ),
+              @rui.breadcrumb_separator(),
+              @rui.breadcrumb_item(@rui.breadcrumb_page("Navigation")),
+            ]),
+          ),
+          IgBreadcrumbDefaultCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Condensed",
+        "An ellipsis collapses intermediate ancestors without changing semantics.",
+        showcase_demo_stage(
+          @rui.breadcrumb(
+            @rui.breadcrumb_list([
+              @rui.breadcrumb_item(
+                @rui.breadcrumb_link(href="#interactions", "Home"),
+              ),
+              @rui.breadcrumb_separator(),
+              @rui.breadcrumb_item(@rui.breadcrumb_ellipsis()),
+              @rui.breadcrumb_separator(),
+              @rui.breadcrumb_item(@rui.breadcrumb_page("Current page")),
+            ]),
+          ),
+          IgBreadcrumbCondensedCode,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_pagination_demo() -> @html.Html {
+  showcase_component_demos(
+    "Pagination",
+    "Default and compact compositions preserve native link semantics.",
+    [
+      showcase_demo_section(
+        "Default",
+        "Pages, ellipsis, previous, and next controls retain native link behavior.",
+        showcase_demo_stage(
+          @rui.pagination(
+            @rui.pagination_content([
+              @rui.pagination_item(@rui.pagination_previous(href="#page-1")),
+              @rui.pagination_item(
+                @rui.pagination_link(href="#page-1", is_active=true, "1"),
+              ),
+              @rui.pagination_item(@rui.pagination_link(href="#page-2", "2")),
+              @rui.pagination_item(@rui.pagination_ellipsis()),
+              @rui.pagination_item(@rui.pagination_next(href="#page-2")),
+            ]),
+          ),
+          IgPaginationDefaultCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Compact",
+        "Smaller numbered links keep the same previous and next navigation.",
+        showcase_demo_stage(
+          @rui.pagination(
+            aria_label="Compact pagination",
+            @rui.pagination_content([
+              @rui.pagination_item(@rui.pagination_previous(href="#page-1")),
+              @rui.pagination_item(
+                @rui.pagination_link(
+                  href="#page-1",
+                  is_active=true,
+                  size=@rui.Sm,
+                  "1",
+                ),
+              ),
+              @rui.pagination_item(
+                @rui.pagination_link(href="#page-2", size=@rui.Sm, "2"),
+              ),
+              @rui.pagination_item(@rui.pagination_next(href="#page-2")),
+            ]),
+          ),
+          IgPaginationCompactCode,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_carousel_component(
+  horizontal_html : @html.Html,
+  vertical_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Carousel",
+    "Horizontal and vertical tracks with bounded and looping navigation.",
+    [
+      showcase_demo_section(
+        "Horizontal",
+        "A looping horizontal track keeps previous and next controls outside the viewport.",
+        showcase_demo_stage(
+          horizontal_html,
+          IgCarouselHorizontalCode,
+          tall=true,
+        ),
+      ),
+      showcase_demo_section(
+        "Vertical",
+        "A bounded vertical track starts on the selected middle slide.",
+        showcase_demo_stage(vertical_html, IgCarouselVerticalCode, tall=true),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_accordion_component(
+  single_html : @html.Html,
+  multiple_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Accordion",
+    "Single and multiple disclosure models.",
+    [
+      showcase_demo_section(
+        "Single",
+        "Single mode can collapse its active panel.",
+        showcase_demo_stage(single_html, IgAccordionSingleCode, tall=true),
+      ),
+      showcase_demo_section(
+        "Multiple",
+        "Multiple mode keeps independent panels open.",
+        showcase_demo_stage(multiple_html, IgAccordionMultipleCode, tall=true),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_tabs_component(
+  default_html : @html.Html,
+  line_html : @html.Html,
+  vertical_html : @html.Html,
+  disabled_html : @html.Html,
+  icons_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Tabs",
+    "List treatment and orientation change without moving selection state into the showcase.",
+    [
+      showcase_demo_section(
+        "Default",
+        "Horizontal tabs use Left and Right for roving focus.",
+        showcase_demo_stage(default_html, IgTabsDefaultCode),
+      ),
+      showcase_demo_section(
+        "Line",
+        "A line treatment keeps the same horizontal interaction model.",
+        showcase_demo_stage(line_html, IgTabsLineCode),
+      ),
+      showcase_demo_section(
+        "Vertical",
+        "Vertical tabs use Up and Down for roving focus.",
+        showcase_demo_stage(vertical_html, IgTabsVerticalCode),
+      ),
+      showcase_demo_section(
+        "Disabled",
+        "Disabled triggers stay visible while leaving the roving tab order.",
+        showcase_demo_stage(disabled_html, IgTabsDisabledCode),
+      ),
+      showcase_demo_section(
+        "Icons",
+        "SVG icons and text share the same trigger alignment and selection behavior.",
+        showcase_demo_stage(icons_html, IgTabsIconsCode),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_navigation_menu_component(
+  viewport_html : @html.Html,
+  inline_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Navigation Menu",
+    "Shared viewport and inline content use the same anchored interaction model.",
+    [
+      showcase_demo_section(
+        "Viewport",
+        "A shared viewport hosts content from the active navigation item.",
+        showcase_demo_stage(
+          viewport_html,
+          IgNavigationMenuViewportCode,
+          tall=true,
+        ),
+      ),
+      showcase_demo_section(
+        "Inline",
+        "Local panels remain anchored to their own navigation items.",
+        showcase_demo_stage(inline_html, IgNavigationMenuInlineCode, tall=true),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_sidebar_panel_icon(side : @rui.SidebarSide) -> @html.Html {
+  if side == @rui.SidebarRight {
+    showcase_stroke_icon("M3 3h18v18H3zM15 3v18")
+  } else {
+    showcase_panel_left_icon()
+  }
+}
+
+///|
+fn ig_sidebar_navigation(
+  scope : @rui.SidebarScope,
+  side : @rui.SidebarSide,
+  menu_size : @rui.SidebarMenuButtonSize,
+  mobile : Bool,
+  interactive : Bool,
+) -> @html.Html {
+  let close_command = if mobile {
+    @rui.sidebar_close_mobile(scope)
+  } else {
+    @rui.sidebar_collapse(scope)
+  }
+  @html.fragment([
+    @rui.sidebar_header(
+      @rui.sidebar_input(
+        aria_label="Filter workspace navigation",
+        placeholder="Filter…",
+      ),
+    ),
+    @rui.sidebar_content(
+      @rui.sidebar_group([
+        @rui.sidebar_group_label(scope~, "Workspace"),
+        if interactive {
+          @rui.sidebar_group_action(
+            aria_label=if mobile { "Close sidebar" } else { "Collapse sidebar" },
+            on_click=close_command,
+            ig_sidebar_panel_icon(side),
+          )
+        } else {
+          @html.nothing
+        },
+        @rui.sidebar_group_content(
+          @rui.sidebar_menu([
+            @rui.sidebar_menu_item([
+              @rui.sidebar_menu_button(
+                href="#overview",
+                is_active=true,
+                size=menu_size,
+                [showcase_layout_icon(), @html.span("Overview")],
+              ),
+              if interactive {
+                @rui.sidebar_menu_action(
+                  show_on_hover=true,
+                  aria_label=if mobile {
+                    "Close sidebar"
+                  } else {
+                    "Collapse sidebar"
+                  },
+                  on_click=close_command,
+                  showcase_panel_left_icon(),
+                )
+              } else {
+                @html.nothing
+              },
+            ]),
+            @rui.sidebar_menu_item([
+              @rui.sidebar_menu_button(href="#activity", size=menu_size, [
+                showcase_activity_icon(),
+                @html.span("Activity"),
+              ]),
+              @rui.sidebar_menu_badge("6"),
+            ]),
+            @rui.sidebar_menu_item([
+              @rui.sidebar_menu_button(href="#projects", size=menu_size, [
+                showcase_folder_icon(),
+                @html.span("Projects and longer workspace names"),
+              ]),
+              @rui.sidebar_menu_sub([
+                @rui.sidebar_menu_sub_item(
+                  @rui.sidebar_menu_sub_button(href="#reports", "Reports"),
+                ),
+                @rui.sidebar_menu_sub_item(
+                  @rui.sidebar_menu_sub_button(href="#roadmap", "Roadmap"),
+                ),
+              ]),
+            ]),
+            @rui.sidebar_menu_item(
+              @rui.sidebar_menu_button(
+                href="#settings",
+                size=menu_size,
+                disabled=true,
+                [showcase_settings_icon(), @html.span("Unavailable")],
+              ),
+            ),
+          ]),
+        ),
+      ]),
+    ),
+    @rui.sidebar_separator(),
+    @rui.sidebar_footer(
+      @rui.sidebar_menu(
+        @rui.sidebar_menu_item(
+          @rui.sidebar_menu_button(
+            href="#account",
+            size=menu_size,
+            variant=if menu_size == @rui.SidebarMenuLg {
+              @rui.SidebarMenuButtonOutline
+            } else {
+              @rui.SidebarMenuButtonDefault
+            },
+            if menu_size == @rui.SidebarMenuLg {
+              [
+                showcase_user_icon(),
+                @html.span(style=["display:grid;min-width:0;line-height:1.1"], [
+                  @html.strong("Yorkin"),
+                  @html.span(
+                    style=[
+                      "color:var(--rui-muted-foreground);font-size:0.75rem;line-height:1.35",
+                    ],
+                    "yorkin@example.com",
+                  ),
+                ]),
+              ]
+            } else {
+              [showcase_user_icon(), @html.span("Account")]
+            },
+          ),
+        ),
+      ),
+    ),
+  ])
+}
+
+///|
+fn ig_sidebar_loading_navigation() -> @html.Html {
+  @html.fragment([
+    @rui.sidebar_header(
+      @rui.sidebar_menu(
+        @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+      ),
+    ),
+    @rui.sidebar_content(
+      @rui.sidebar_group([
+        @rui.sidebar_group_label("Workspace"),
+        @rui.sidebar_group_content(
+          @rui.sidebar_menu([
+            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+            @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+          ]),
+        ),
+      ]),
+    ),
+    @rui.sidebar_separator(),
+    @rui.sidebar_footer(
+      @rui.sidebar_menu(
+        @rui.sidebar_menu_item(@rui.sidebar_menu_skeleton(show_icon=true)),
+      ),
+    ),
+  ])
+}
+
+///|
+fn ig_sidebar_workspace_content(
+  scope : @rui.SidebarScope,
+  id : String,
+  side : @rui.SidebarSide,
+  mobile : Bool,
+  interactive : Bool,
+) -> @html.Html {
+  @html.fragment([
+    @html.div(style=[RowStyle], [
+      if interactive {
+        @rui.sidebar_trigger(
+          scope,
+          mobile~,
+          controls=id,
+          aria_label=if mobile {
+            "Open mobile sidebar"
+          } else {
+            "Toggle sidebar"
+          },
+          ig_sidebar_panel_icon(side),
+        )
+      } else {
+        @html.nothing
+      },
+      @html.strong("Workspace overview"),
+    ]),
+    @html.div(
+      style=[IgSidebarWorkspaceBodyStyle],
+      @html.p(
+        style=[MutedStyle, "max-width:18rem;margin:0;text-align:center"],
+        if mobile {
+          "Open the mobile sheet, then close it with the overlay, Escape, or its navigation action."
+        } else if interactive {
+          "Use the trigger or sidebar rail; the provider owns every state change."
+        } else {
+          "This persistent sidebar remains visible and does not expose a collapse control."
+        },
+      ),
+    ),
+  ])
+}
+
+///|
+fn ig_sidebar_variant(
+  id : String,
+  side : @rui.SidebarSide,
+  variant : @rui.SidebarVariant,
+  collapsible : @rui.SidebarCollapsible,
+  default_collapsed : Bool,
+  menu_size : @rui.SidebarMenuButtonSize,
+  use_inset : Bool,
+  mobile : Bool,
+  resizable : Bool,
+) -> @rabbita.Val[@html.Html] {
+  @rui.sidebar_provider(
+    default_collapsed~,
+    style=[IgSidebarVariantFrameStyle],
+    scope => {
+      let interactive = collapsible != @rui.SidebarFixed
+      let rail = if mobile || !interactive {
+        @html.nothing
+      } else if resizable {
+        @rui.sidebar_rail(scope, min_width=192, max_width=352)
+      } else {
+        @rui.sidebar_rail(scope)
+      }
+      let workspace_content = ig_sidebar_workspace_content(
+        scope, id, side, mobile, interactive,
+      )
+      let workspace = if use_inset {
+        @rui.sidebar_inset(style=[IgSidebarWorkspaceStyle], workspace_content)
+      } else {
+        @html.div(style=[IgSidebarWorkspaceStyle], workspace_content)
+      }
+      @html.fragment([
+        @rui.sidebar(scope, id~, side~, variant~, collapsible~, mobile~, [
+          ig_sidebar_navigation(scope, side, menu_size, mobile, interactive),
+          rail,
+        ]),
+        workspace,
+      ])
+    },
+  )
+}
+
+///|
+fn ig_sidebar_loading_variant() -> @rabbita.Val[@html.Html] {
+  @rui.sidebar_provider(
+    default_collapsed=false,
+    style=[IgSidebarVariantFrameStyle],
+    scope => {
+      let id = "showcase-sidebar-loading"
+      @html.fragment([
+        @rui.sidebar(
+          scope,
+          id~,
+          side=@rui.SidebarLeft,
+          variant=@rui.SidebarDefault,
+          collapsible=@rui.SidebarFixed,
+          mobile=false,
+          ig_sidebar_loading_navigation(),
+        ),
+        @html.div(
+          style=[IgSidebarWorkspaceStyle],
+          ig_sidebar_workspace_content(
+            scope,
+            id,
+            @rui.SidebarLeft,
+            false,
+            false,
+          ),
+        ),
+      ])
+    },
+  )
+}
+
+///|
+fn ig_sidebar_component(
+  default : @html.Html,
+  fixed : @html.Html,
+  icon : @html.Html,
+  loading : @html.Html,
+  floating : @html.Html,
+  inset : @html.Html,
+  right : @html.Html,
+  resize : @html.Html,
+  mobile : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Sidebar",
+    "Desktop and mobile compositions cover collapse modes, surface variants, side placement, and rail resizing.",
+    [
+      showcase_demo_section(
+        "Default",
+        "The default surface starts expanded and moves fully off-canvas from its trigger or rail.",
+        showcase_demo_stage(
+          default,
+          ig_sidebar_code(IgSidebarDefaultCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Fixed",
+        "A persistent surface omits collapse controls because its visible state never changes.",
+        showcase_demo_stage(
+          fixed,
+          ig_sidebar_code(IgSidebarFixedCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Icon collapse",
+        "Collapsed navigation keeps its icons available without leaving a second active destination.",
+        showcase_demo_stage(
+          icon,
+          ig_sidebar_code(IgSidebarIconCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Loading",
+        "A complete persistent composition uses the public menu skeleton while navigation data is loading.",
+        showcase_demo_stage(
+          loading,
+          ig_sidebar_code(IgSidebarLoadingCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Floating",
+        "Floating adds its own radius, border, and shadow while the stage supplies the only outer frame.",
+        showcase_demo_stage(
+          floating,
+          ig_sidebar_code(IgSidebarFloatingCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Inset",
+        "Only this composition uses sidebar_inset for the adjacent content surface.",
+        showcase_demo_stage(
+          inset,
+          ig_sidebar_code(IgSidebarInsetCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Right side",
+        "Right placement mirrors the shell, rail edge, and trigger icon without changing menu semantics.",
+        showcase_demo_stage(
+          right,
+          ig_sidebar_code(IgSidebarRightCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Resize",
+        "Drag the rail between its minimum and maximum width; a click still toggles collapse.",
+        showcase_demo_stage(
+          resize,
+          ig_sidebar_code(IgSidebarResizeCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+      showcase_demo_section(
+        "Mobile",
+        "The explicit mobile form opens as a modal sheet and keeps desktop state independent.",
+        showcase_demo_stage(
+          mobile,
+          ig_sidebar_code(IgSidebarMobileCode),
+          tall=true,
+          stage_style="--rui-showcase-stage-min-height:24rem;padding:0",
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_navigation_page(selected : String) -> @rabbita.Val[@html.Html] {
+  let accordion_view = @rui.accordion(
+    id="showcase-accordion",
+    type_=@rui.Single,
+    collapsible=true,
+    default_value="keyboard",
+    items=[
+      @rui.accordion_entry(
+        value="keyboard",
+        label="Keyboard interaction",
+        content=@html.p(
+          style=[MutedStyle, "margin:0"],
+          "Tab reaches each trigger; Enter and Space toggle its panel.",
+        ),
+      ),
+      @rui.accordion_entry(
+        value="state",
+        label="Owned state",
+        content=@html.p(
+          style=[MutedStyle, "margin:0"],
+          "The black-box root owns its expanded value through Rabbita.",
+        ),
+      ),
+      @rui.accordion_entry(
+        value="markup",
+        label="Native markup",
+        content=@html.p(
+          style=[MutedStyle, "margin:0"],
+          "Details and summary preserve useful behavior without JavaScript.",
+        ),
+      ),
+    ],
+  )
+  let accordion_multiple_view = @rui.accordion(
+    id="showcase-accordion-multiple",
+    type_=@rui.Multiple,
+    default_values=["motion", "focus"],
+    items=[
+      @rui.accordion_entry(
+        value="motion",
+        label="Motion",
+        content=@html.p(
+          style=[MutedStyle, "margin:0"],
+          "Each expanded panel animates independently.",
+        ),
+      ),
+      @rui.accordion_entry(
+        value="focus",
+        label="Keyboard focus",
+        content=@html.p(
+          style=[MutedStyle, "margin:0"],
+          "Arrow keys move between enabled triggers.",
+        ),
+      ),
+      @rui.accordion_entry(
+        value="locked",
+        label="Unavailable section",
+        disabled=true,
+        content=@html.p("This panel cannot be opened."),
+      ),
+    ],
+  )
+  let carousel_view = @rui.carousel(
+    id="showcase-carousel",
+    count=3,
+    loop_=true,
+    orientation=@rui.CarouselHorizontal,
+    aria_label="Rabbita UI highlights",
+    style=[IgCarouselStyle],
+    scope => {
+      @html.fragment([
+        @rui.carousel_items(scope~, items=[
+          @html.div(style=[IgSlideStyle], "Inline styles"),
+          @html.div(style=[IgSlideStyle], "Incremental state"),
+          @html.div(style=[IgSlideStyle], "Native semantics"),
+        ]),
+        @rui.carousel_previous(scope~),
+        @rui.carousel_next(scope~),
+      ])
+    },
+  )
+  let carousel_vertical_view = @rui.carousel(
+    id="showcase-carousel-vertical",
+    count=3,
+    default_index=1,
+    orientation=@rui.CarouselVertical,
+    aria_label="Vertical Rabbita UI highlights",
+    style=[IgVerticalCarouselStyle],
+    scope => {
+      @html.fragment([
+        @rui.carousel_items(scope~, items=[
+          @html.div(style=[IgSlideStyle, IgVerticalSlideStyle], "First slide"),
+          @html.div(
+            style=[IgSlideStyle, IgVerticalSlideStyle],
+            "Selected slide",
+          ),
+          @html.div(style=[IgSlideStyle, IgVerticalSlideStyle], "Last slide"),
+        ]),
+        @rui.carousel_previous(scope~),
+        @rui.carousel_next(scope~),
+      ])
+    },
+  )
+  let collapsible_order_view = ig_collapsible_order_view()
+  let collapsible_basic_view = ig_collapsible_basic_view()
+  let collapsible_settings_view = ig_collapsible_settings_view()
+  let collapsible_file_tree_view = ig_collapsible_file_tree_view()
+  let navigation_view = @rui.navigation_menu(
+    id="showcase-navigation-menu",
+    aria_label="Showcase navigation",
+    scope => {
+      @html.div(style=["min-height:10rem"], [
+        @rui.navigation_menu_list(scope, [
+          @rui.navigation_menu_item(scope, value="platform", item => {
+            @html.fragment([
+              @rui.navigation_menu_trigger(item, "Platform"),
+              @rui.navigation_menu_indicator(item),
+              @rui.navigation_menu_content(
+                item,
+                style=[IgNavigationContentStyle],
+                [
+                  @rui.navigation_menu_link(
+                    href="#components",
+                    active=true,
+                    style=[IgNavigationLinkStyle],
+                    [
+                      @html.strong("Components"),
+                      @html.span(style=[MutedStyle], "Black-box defaults"),
+                    ],
+                  ),
+                  @rui.navigation_menu_link(
+                    href="#patterns",
+                    style=[IgNavigationLinkStyle],
+                    [
+                      @html.strong("Patterns"),
+                      @html.span(style=[MutedStyle], "Compound composition"),
+                    ],
+                  ),
+                ],
+              ),
+            ])
+          }),
+          @rui.navigation_menu_item(scope, value="resources", item => {
+            @html.fragment([
+              @rui.navigation_menu_trigger(item, "Resources"),
+              @rui.navigation_menu_indicator(item),
+              @rui.navigation_menu_content(
+                item,
+                style=[IgNavigationContentStyle],
+                [
+                  @rui.navigation_menu_link(
+                    href="#api",
+                    style=[IgNavigationLinkStyle],
+                    [
+                      @html.strong("API reference"),
+                      @html.span(style=[MutedStyle], "Typed MoonBit surface"),
+                    ],
+                  ),
+                  @rui.navigation_menu_link(
+                    href="#examples",
+                    style=[IgNavigationLinkStyle],
+                    [
+                      @html.strong("Examples"),
+                      @html.span(style=[MutedStyle], "Working interactions"),
+                    ],
+                  ),
+                ],
+              ),
+            ])
+          }),
+        ]),
+        @rui.navigation_menu_viewport(scope, @html.nothing),
+      ])
+    },
+  )
+  let navigation_inline_view = @rui.navigation_menu(
+    id="showcase-navigation-menu-inline",
+    viewport=false,
+    aria_label="Inline navigation menu",
+    scope => {
+      @rui.navigation_menu_list(scope, [
+        @rui.navigation_menu_item(scope, value="learn", item => {
+          @html.fragment([
+            @rui.navigation_menu_trigger(item, "Learn"),
+            @rui.navigation_menu_content(
+              item,
+              style=[IgNavigationContentStyle],
+              [
+                @rui.navigation_menu_link(
+                  href="#guide",
+                  active=true,
+                  style=[IgNavigationLinkStyle],
+                  [
+                    @html.strong("Guide"),
+                    @html.span(style=[MutedStyle], "Active destination"),
+                  ],
+                ),
+                @rui.navigation_menu_link(
+                  href="#examples",
+                  style=[IgNavigationLinkStyle],
+                  [
+                    @html.strong("Examples"),
+                    @html.span(style=[MutedStyle], "Inline content"),
+                  ],
+                ),
+              ],
+            ),
+          ])
+        }),
+        @rui.navigation_menu_item(scope, value="disabled", item => {
+          @rui.navigation_menu_trigger(item, disabled=true, "Unavailable")
+        }),
+      ])
+    },
+  )
+  let sidebar_default_view = ig_sidebar_variant(
+    "showcase-sidebar-default",
+    @rui.SidebarLeft,
+    @rui.SidebarDefault,
+    @rui.SidebarOffcanvas,
+    false,
+    @rui.SidebarMenuDefault,
+    false,
+    false,
+    false,
+  )
+  let sidebar_fixed_view = ig_sidebar_variant(
+    "showcase-sidebar-fixed",
+    @rui.SidebarLeft,
+    @rui.SidebarDefault,
+    @rui.SidebarFixed,
+    false,
+    @rui.SidebarMenuSm,
+    false,
+    false,
+    false,
+  )
+  let sidebar_icon_view = ig_sidebar_variant(
+    "showcase-sidebar-icon",
+    @rui.SidebarLeft,
+    @rui.SidebarDefault,
+    @rui.SidebarIcon,
+    true,
+    @rui.SidebarMenuDefault,
+    false,
+    false,
+    false,
+  )
+  let sidebar_loading_view = ig_sidebar_loading_variant()
+  let sidebar_floating_view = ig_sidebar_variant(
+    "showcase-sidebar-floating",
+    @rui.SidebarLeft,
+    @rui.SidebarFloating,
+    @rui.SidebarIcon,
+    false,
+    @rui.SidebarMenuLg,
+    false,
+    false,
+    false,
+  )
+  let sidebar_inset_view = ig_sidebar_variant(
+    "showcase-sidebar-inset",
+    @rui.SidebarLeft,
+    @rui.SidebarInset,
+    @rui.SidebarOffcanvas,
+    false,
+    @rui.SidebarMenuDefault,
+    true,
+    false,
+    false,
+  )
+  let sidebar_right_view = ig_sidebar_variant(
+    "showcase-sidebar-right",
+    @rui.SidebarRight,
+    @rui.SidebarDefault,
+    @rui.SidebarIcon,
+    false,
+    @rui.SidebarMenuDefault,
+    false,
+    false,
+    false,
+  )
+  let sidebar_resize_view = ig_sidebar_variant(
+    "showcase-sidebar-resize",
+    @rui.SidebarLeft,
+    @rui.SidebarDefault,
+    @rui.SidebarIcon,
+    false,
+    @rui.SidebarMenuDefault,
+    false,
+    false,
+    true,
+  )
+  let sidebar_mobile_view = ig_sidebar_variant(
+    "showcase-sidebar-mobile",
+    @rui.SidebarLeft,
+    @rui.SidebarDefault,
+    @rui.SidebarOffcanvas,
+    false,
+    @rui.SidebarMenuDefault,
+    false,
+    true,
+    false,
+  )
+  let tabs_view = @rui.tabs(
+    id="showcase-tabs",
+    default_value="preview",
+    orientation=@rui.TabsHorizontal,
+    aria_label="Component workflow",
+    items=[
+      @rui.tab_entry(
+        value="preview",
+        label="Preview",
+        content=@html.div(style=[IgDemoSurfaceStyle], [
+          @html.strong("Ready to interact"),
+          @html.p(
+            style=[MutedStyle, "margin:0.375rem 0 0"],
+            "The selected panel is linked to its trigger.",
+          ),
+        ]),
+      ),
+      @rui.tab_entry(
+        value="source",
+        label="Source",
+        content=@html.div(style=[IgDemoSurfaceStyle], [
+          @html.strong("Copy when you need control"),
+          @html.p(
+            style=[MutedStyle, "margin:0.375rem 0 0"],
+            "Otherwise consume the component as a black box.",
+          ),
+        ]),
+      ),
+      @rui.tab_entry(
+        value="accessibility",
+        label="A11y",
+        content=@html.div(style=[IgDemoSurfaceStyle], [
+          @html.strong("Roving focus"),
+          @html.p(
+            style=[MutedStyle, "margin:0.375rem 0 0"],
+            "Use Left and Right to move across tabs.",
+          ),
+        ]),
+      ),
+    ],
+  )
+  let tabs_vertical_view = @rui.tabs(
+    id="showcase-tabs-vertical",
+    default_value="general",
+    orientation=@rui.TabsVertical,
+    aria_label="Vertical settings tabs",
+    items=[
+      @rui.tab_entry(
+        value="general",
+        label="General",
+        content=@html.div(style=[IgDemoSurfaceStyle], [
+          @html.strong("General settings"),
+          @html.p(
+            style=[MutedStyle, "margin:0.375rem 0 0"],
+            "Up and Down move focus in a vertical list.",
+          ),
+        ]),
+      ),
+      @rui.tab_entry(
+        value="members",
+        label="Members",
+        content=@html.div(style=[IgDemoSurfaceStyle], "Member access settings"),
+      ),
+      @rui.tab_entry(
+        value="billing",
+        label="Billing",
+        content=@html.div(style=[IgDemoSurfaceStyle], "Billing settings"),
+      ),
+    ],
+  )
+  let tabs_line_view = @rui.tabs(
+    id="showcase-tabs-line",
+    default_value="account",
+    list_variant=@rui.TabsLine,
+    aria_label="Account sections",
+    items=[
+      @rui.tab_entry(
+        value="account",
+        label="Account",
+        content=@html.div(style=[IgDemoSurfaceStyle], [
+          @html.strong("Account profile"),
+          @html.p(
+            style=[MutedStyle, "margin:0.375rem 0 0"],
+            "The active line follows the selected tab.",
+          ),
+        ]),
+      ),
+      @rui.tab_entry(
+        value="security",
+        label="Security",
+        content=@html.div(style=[IgDemoSurfaceStyle], "Security settings"),
+      ),
+      @rui.tab_entry(
+        value="notifications",
+        label="Notifications",
+        content=@html.div(
+          style=[IgDemoSurfaceStyle],
+          "Notification preferences",
+        ),
+      ),
+    ],
+  )
+  let tabs_disabled_view = @rui.tabs(
+    id="showcase-tabs-disabled",
+    default_value="home",
+    aria_label="Disabled tab example",
+    items=[
+      @rui.tab_entry(
+        value="home",
+        label="Home",
+        content=@html.div(style=[IgDemoSurfaceStyle], "Home content"),
+      ),
+      @rui.tab_entry(
+        value="disabled",
+        label="Disabled",
+        disabled=true,
+        content=@html.div(style=[IgDemoSurfaceStyle], "Unavailable"),
+      ),
+    ],
+  )
+  let tabs_icons_view = @rui.tabs(
+    id="showcase-tabs-icons",
+    default_value="preview",
+    aria_label="View mode",
+    items=[
+      @rui.tab_entry(
+        value="preview",
+        label="Preview",
+        icon=showcase_layout_icon(),
+        content=@html.div(style=[IgDemoSurfaceStyle], "Preview content"),
+      ),
+      @rui.tab_entry(
+        value="code",
+        label="Code",
+        icon=showcase_code_icon(),
+        content=@html.div(style=[IgDemoSurfaceStyle], "Code content"),
+      ),
+    ],
+  )
+  let accordion_component = if selected == "" || selected == "accordion" {
+    accordion_view.view2(accordion_multiple_view, ig_accordion_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let carousel_component = if selected == "" || selected == "carousel" {
+    carousel_view.view2(carousel_vertical_view, ig_carousel_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let collapsible_component = if selected == "" || selected == "collapsible" {
+    collapsible_order_view.view4(
+      collapsible_basic_view, collapsible_settings_view, collapsible_file_tree_view,
+      ig_collapsible_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let navigation_component = if selected == "" || selected == "navigation-menu" {
+    navigation_view.view2(navigation_inline_view, ig_navigation_menu_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let sidebar_component = if selected == "" || selected == "sidebar" {
+    sidebar_default_view.view9(
+      sidebar_fixed_view, sidebar_icon_view, sidebar_loading_view, sidebar_floating_view,
+      sidebar_inset_view, sidebar_right_view, sidebar_resize_view, sidebar_mobile_view,
+      ig_sidebar_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let tabs_component = if selected == "" || selected == "tabs" {
+    tabs_view.view5(
+      tabs_line_view, tabs_vertical_view, tabs_disabled_view, tabs_icons_view, ig_tabs_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  accordion_component.view6(
+    carousel_component,
+    collapsible_component,
+    navigation_component,
+    sidebar_component,
+    tabs_component,
+    (
+      accordion_html,
+      carousel_html,
+      collapsible_html,
+      navigation_html,
+      sidebar_html,
+      tabs_html,
+    ) => {
+      @html.section(
+        id="navigation",
+        style=[IgComponentListStyle, "scroll-margin-top:1rem"],
+        [
+          accordion_html,
+          collapsible_html,
+          tabs_html,
+          if selected == "" || selected == "breadcrumb" {
+            ig_breadcrumb_demo()
+          } else {
+            @html.nothing
+          },
+          if selected == "" || selected == "pagination" {
+            ig_pagination_demo()
+          } else {
+            @html.nothing
+          },
+          carousel_html,
+          navigation_html,
+          sidebar_html,
+        ],
+      )
+    },
+  )
+}
+
+///|
+fn ig_navigation_section() -> @rabbita.Val[@html.Html] {
+  ig_navigation_page("")
+}
+
+///|
+fn ig_dialog_variant(
+  id : String,
+  modal : Bool,
+  trigger_variant : @rui.ButtonVariant,
+  trigger_label : String,
+) -> @rabbita.Val[@html.Html] {
+  @rui.dialog(id~, modal~, scope => {
+    @html.fragment([
+      @rui.dialog_trigger(scope, variant=trigger_variant, trigger_label),
+      @rui.dialog_portal([
+        @rui.dialog_content(scope, show_close=true, [
+          @rui.dialog_header([
+            @rui.dialog_title(scope, trigger_label),
+            @rui.dialog_description(
+              scope,
+              if modal {
+                "Focus stays inside this modal surface until it closes."
+              } else {
+                "This non-modal surface leaves the surrounding page available."
+              },
+            ),
+          ]),
+          @html.div(style=[StackStyle], [
+            @rui.label(for_=id + "-name", "Display name"),
+            @rui.input(id=id + "-name", value="Rabbita team"),
+          ]),
+          @rui.dialog_footer(@rui.dialog_close(scope, "Save changes")),
+        ]),
+      ]),
+    ])
+  })
+}
+
+///|
+fn ig_drawer_variant(
+  id : String,
+  direction : @rui.DrawerDirection,
+  trigger_label : String,
+) -> @rabbita.Val[@html.Html] {
+  @rui.drawer(id~, scope => {
+    @html.fragment([
+      @rui.drawer_trigger(scope, variant=@rui.Outline, trigger_label),
+      @rui.drawer_portal([
+        @rui.drawer_content(
+          scope,
+          direction~,
+          show_handle=true,
+          show_close=true,
+          [
+            @rui.drawer_header([
+              @rui.drawer_title(scope, trigger_label),
+              @rui.drawer_description(
+                scope, "The direction controls placement, motion, and handle orientation.",
+              ),
+            ]),
+            @html.div(style=[IgDemoSurfaceStyle], "All checks passed"),
+            @rui.drawer_footer(@rui.drawer_close(scope, "Close")),
+          ],
+        ),
+      ]),
+    ])
+  })
+}
+
+///|
+fn ig_sheet_variant(
+  id : String,
+  side : @rui.SheetSide,
+  trigger_label : String,
+) -> @rabbita.Val[@html.Html] {
+  @rui.sheet(id~, scope => {
+    @html.fragment([
+      @rui.sheet_trigger(scope, variant=@rui.Outline, trigger_label),
+      @rui.sheet_content(scope, side~, [
+        @rui.sheet_header([
+          @rui.sheet_title(scope, trigger_label),
+          @rui.sheet_description(
+            scope, "Placement changes while focus and dismissal behavior stay consistent.",
+          ),
+        ]),
+        @html.div(style=[StackStyle], [
+          @rui.label(for_=id + "-email", "Notification email"),
+          @rui.input(id=id + "-email", value="team@example.com"),
+        ]),
+        @rui.sheet_footer(@rui.sheet_close(scope, "Save settings")),
+      ]),
+    ])
+  })
+}
+
+///|
+fn ig_popover_variant(
+  id : String,
+  side : @rui.PopupSide,
+  align : @rui.PopupAlign,
+  trigger_label : String,
+) -> @rabbita.Val[@html.Html] {
+  let title_id = id + "-title"
+  let description_id = id + "-description"
+  @rui.popover(
+    id~,
+    side~,
+    align~,
+    title_id~,
+    description_id~,
+    trigger_variant=@rui.Outline,
+    trigger_label,
+    @html.div(style=[StackStyle, "gap:0.75rem"], [
+      @rui.popover_header([
+        @rui.popover_title(id=title_id, trigger_label),
+        @rui.popover_description(
+          id=description_id,
+          "Anchored content stays labelled at this placement.",
+        ),
+      ]),
+      @rui.input(
+        value="320 px",
+        attrs=@html.Attrs::build().aria_label("Preferred width"),
+      ),
+      @rui.popover_close_button(target_id=id, size=@rui.Sm, "Apply"),
+    ]),
+  )
+}
+
+///|
+fn ig_hover_card_variant(
+  id : String,
+  side : @rui.PopupSide,
+  align : @rui.PopupAlign,
+  trigger_label : String,
+) -> @rabbita.Val[@html.Html] {
+  @rui.hover_card(
+    id~,
+    href="#rabbita-profile",
+    open_delay=120,
+    close_delay=80,
+    side~,
+    align~,
+    trigger_variant=@rui.Link,
+    trigger_label,
+    @html.div(style=[StackStyle, "gap:0.5rem"], [
+      @html.strong("Rabbita UI"),
+      @html.p(
+        style=[MutedStyle, "margin:0"],
+        "Native MoonBit components with incremental state.",
+      ),
+      @html.div(style=[RowStyle], [
+        @rui.badge(variant=@rui.Secondary, "Vega"),
+        @rui.badge(variant=@rui.Outline, "Inline"),
+      ]),
+    ]),
+  )
+}
+
+///|
+fn ig_tooltip_variant(
+  id : String,
+  side : @rui.PopupSide,
+  align : @rui.PopupAlign,
+  size : @rui.ButtonSize,
+  label : String,
+) -> @rabbita.Val[@html.Html] {
+  @rui.tooltip(
+    id~,
+    delay=100,
+    side~,
+    align~,
+    show_arrow=true,
+    trigger_variant=@rui.Outline,
+    trigger_size=size,
+    trigger_attrs=@html.Attrs::build().aria_label(label),
+    showcase_circle_help_icon(),
+    label,
+  )
+}
+
+///|
+fn ig_alert_dialog_component(
+  default_html : @html.Html,
+  destructive_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Alert Dialog",
+    "Default and destructive decisions require an explicit action.",
+    [
+      showcase_demo_section(
+        "Default",
+        "A reversible archive decision requires an explicit cancel or action.",
+        showcase_demo_stage(default_html, IgAlertDialogDefaultCode),
+      ),
+      showcase_demo_section(
+        "Destructive",
+        "A permanent action adds destructive treatment and warning media.",
+        showcase_demo_stage(destructive_html, IgAlertDialogDestructiveCode),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_dialog_component(
+  modal_html : @html.Html,
+  nonmodal_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Dialog",
+    "Modal and non-modal top-layer focus behavior.",
+    [
+      showcase_demo_section(
+        "Modal",
+        "The modal surface contains focus until it closes.",
+        showcase_demo_stage(modal_html, ig_dialog_code(IgDialogModalCallCode)),
+      ),
+      showcase_demo_section(
+        "Non-modal",
+        "The non-modal surface leaves the surrounding page available.",
+        showcase_demo_stage(
+          nonmodal_html,
+          ig_dialog_code(IgDialogNonModalCallCode),
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_drawer_component(
+  top_html : @html.Html,
+  right_html : @html.Html,
+  bottom_html : @html.Html,
+  left_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Drawer",
+    "Placement controls motion, edge geometry, and handle orientation.",
+    [
+      showcase_demo_section(
+        "Top",
+        "A horizontal handle accompanies motion from the top edge.",
+        showcase_demo_stage(top_html, ig_drawer_code(IgDrawerTopCallCode)),
+      ),
+      showcase_demo_section(
+        "Right",
+        "A vertical handle accompanies motion from the right edge.",
+        showcase_demo_stage(right_html, ig_drawer_code(IgDrawerRightCallCode)),
+      ),
+      showcase_demo_section(
+        "Bottom",
+        "A horizontal handle accompanies motion from the bottom edge.",
+        showcase_demo_stage(bottom_html, ig_drawer_code(IgDrawerBottomCallCode)),
+      ),
+      showcase_demo_section(
+        "Left",
+        "A vertical handle accompanies motion from the left edge.",
+        showcase_demo_stage(left_html, ig_drawer_code(IgDrawerLeftCallCode)),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_command_component(
+  inline_html : @html.Html,
+  dialog_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Command",
+    "Inline and dialog listboxes share active-descendant navigation.",
+    [
+      showcase_demo_section(
+        "Inline",
+        "An inline filterable list exposes groups, shortcuts, and empty state.",
+        showcase_demo_stage(inline_html, IgCommandInlineCode, tall=true),
+      ),
+      showcase_demo_section(
+        "Dialog",
+        "A trigger opens the same command interaction inside a modal surface.",
+        showcase_demo_stage(dialog_html, IgCommandDialogCode),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_popover_component(
+  bottom_html : @html.Html,
+  right_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Popover",
+    "Anchored forms preserve labels, focus restoration, and close actions.",
+    [
+      showcase_demo_section(
+        "Bottom start",
+        "The labelled form aligns to the start of a bottom anchor.",
+        showcase_demo_stage(
+          bottom_html,
+          ig_popover_code(IgPopoverBottomStartCallCode),
+        ),
+      ),
+      showcase_demo_section(
+        "Right center",
+        "The same form aligns to the center of a right-side anchor.",
+        showcase_demo_stage(
+          right_html,
+          ig_popover_code(IgPopoverRightCenterCallCode),
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_hover_card_component(
+  top_html : @html.Html,
+  left_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Hover Card",
+    "Pointer and keyboard entry share delays while content remains hoverable.",
+    [
+      showcase_demo_section(
+        "Top center",
+        "A keyboard-reachable preview opens above the trigger.",
+        showcase_demo_stage(
+          top_html,
+          ig_hover_card_code(IgHoverCardTopCenterCallCode),
+        ),
+      ),
+      showcase_demo_section(
+        "Left end",
+        "Hoverable content aligns to the end of a left-side trigger.",
+        showcase_demo_stage(
+          left_html,
+          ig_hover_card_code(IgHoverCardLeftEndCallCode),
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_tooltip_component(
+  top_html : @html.Html,
+  right_html : @html.Html,
+  bottom_html : @html.Html,
+  left_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Tooltip",
+    "Placement and trigger size variants align arrows to real icon buttons.",
+    [
+      showcase_demo_section(
+        "Top start",
+        "A small icon trigger places its tooltip above and start-aligned.",
+        showcase_demo_stage(
+          top_html,
+          ig_tooltip_code(IgTooltipTopStartCallCode),
+        ),
+      ),
+      showcase_demo_section(
+        "Right center",
+        "A default icon trigger places its tooltip at the right center.",
+        showcase_demo_stage(
+          right_html,
+          ig_tooltip_code(IgTooltipRightCenterCallCode),
+        ),
+      ),
+      showcase_demo_section(
+        "Bottom end",
+        "A large icon trigger places its tooltip below and end-aligned.",
+        showcase_demo_stage(
+          bottom_html,
+          ig_tooltip_code(IgTooltipBottomEndCallCode),
+        ),
+      ),
+      showcase_demo_section(
+        "Left center",
+        "A default icon trigger places its tooltip at the left center.",
+        showcase_demo_stage(
+          left_html,
+          ig_tooltip_code(IgTooltipLeftCenterCallCode),
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_sheet_component(
+  top_html : @html.Html,
+  right_html : @html.Html,
+  bottom_html : @html.Html,
+  left_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Sheet",
+    "Every side keeps the same labelled content and dismissal behavior.",
+    [
+      showcase_demo_section(
+        "Top",
+        "The modal sheet enters from the top edge.",
+        showcase_demo_stage(top_html, ig_sheet_code(IgSheetTopCallCode)),
+      ),
+      showcase_demo_section(
+        "Right",
+        "The modal sheet enters from the right edge.",
+        showcase_demo_stage(right_html, ig_sheet_code(IgSheetRightCallCode)),
+      ),
+      showcase_demo_section(
+        "Bottom",
+        "The modal sheet enters from the bottom edge.",
+        showcase_demo_stage(bottom_html, ig_sheet_code(IgSheetBottomCallCode)),
+      ),
+      showcase_demo_section(
+        "Left",
+        "The modal sheet enters from the left edge.",
+        showcase_demo_stage(left_html, ig_sheet_code(IgSheetLeftCallCode)),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_overlay_page(selected : String) -> @rabbita.Val[@html.Html] {
+  let alert_dialog_view = @rui.alert_dialog(id="showcase-alert-dialog", scope => {
+    @html.fragment([
+      @rui.alert_dialog_trigger(
+        scope,
+        variant=@rui.Destructive,
+        "Delete snapshot",
+      ),
+      @rui.alert_dialog_portal([
+        @rui.alert_dialog_content(scope, [
+          @rui.alert_dialog_header([
+            @rui.alert_dialog_media(showcase_alert_triangle_icon()),
+            @rui.alert_dialog_title(scope, "Delete this snapshot?"),
+            @rui.alert_dialog_description(
+              scope, "This removes the saved state permanently.",
+            ),
+          ]),
+          @rui.alert_dialog_footer([
+            @rui.alert_dialog_cancel(scope, "Cancel"),
+            @rui.alert_dialog_action(scope, "Delete"),
+          ]),
+        ]),
+      ]),
+    ])
+  })
+  let alert_dialog_default_view = @rui.alert_dialog(
+    id="showcase-alert-dialog-default",
+    scope => {
+      @html.fragment([
+        @rui.alert_dialog_trigger(
+          scope,
+          variant=@rui.Outline,
+          "Archive project",
+        ),
+        @rui.alert_dialog_portal([
+          @rui.alert_dialog_content(scope, [
+            @rui.alert_dialog_header([
+              @rui.alert_dialog_title(scope, "Archive this project?"),
+              @rui.alert_dialog_description(
+                scope, "You can restore an archived project later from workspace settings.",
+              ),
+            ]),
+            @rui.alert_dialog_footer([
+              @rui.alert_dialog_cancel(scope, "Cancel"),
+              @rui.alert_dialog_action(scope, "Archive"),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let command_view = @rui.command(
+    id="showcase-command",
+    style=[IgCommandStyle],
+    scope => {
+      @html.fragment([
+        @rui.command_input(scope~, placeholder="Search actions…"),
+        @rui.command_list(scope~, [
+          @rui.command_empty(scope~, "No matching actions."),
+          @rui.command_group(scope~, heading="Workspace", [
+            @rui.command_item(
+              scope~,
+              value="Open dashboard",
+              keywords=["home"],
+              [@html.span("Open dashboard"), @rui.command_shortcut("⌘D")],
+            ),
+            @rui.command_item(
+              scope~,
+              value="Create project",
+              keywords=["new"],
+              [@html.span("Create project"), @rui.command_shortcut("⌘N")],
+            ),
+            @rui.command_separator(),
+            @rui.command_item(
+              scope~,
+              value="Settings",
+              keywords=["preferences"],
+              "Settings",
+            ),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let command_dialog_view = @rui.command_dialog(
+    id="showcase-command-dialog",
+    aria_label="Command palette",
+    trigger=scope => {
+      @rui.command_dialog_trigger(scope~, variant=@rui.Outline, "Open palette")
+    },
+    scope => {
+      @html.fragment([
+        @rui.command_input(scope~, placeholder="Type a command…"),
+        @rui.command_list(scope~, [
+          @rui.command_empty(scope~, "No matching commands."),
+          @rui.command_group(scope~, heading="Navigation", [
+            @rui.command_item(scope~, value="Go to overview", "Go to overview"),
+            @rui.command_item(scope~, value="Open settings", "Open settings"),
+            @rui.command_item(
+              scope~,
+              value="Unavailable command",
+              disabled=true,
+              "Unavailable command",
+            ),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let context_menu_actions_view = @rui.context_menu(
+    id="showcase-context-menu-actions",
+    scope => {
+      @html.fragment([
+        @rui.context_menu_trigger(
+          scope,
+          style=[IgContextTargetStyle],
+          "Right-click for canvas actions",
+        ),
+        @rui.context_menu_portal([
+          @rui.context_menu_content(scope, aria_label="Canvas actions", [
+            @rui.context_menu_group(aria_label="Canvas", [
+              @rui.context_menu_label("Canvas"),
+              @rui.context_menu_item(scope, [
+                showcase_copy_icon(),
+                @html.span("Duplicate"),
+                @rui.context_menu_shortcut("⌘D"),
+              ]),
+              @rui.context_menu_item(scope, [
+                showcase_settings_icon(),
+                @html.span("Rename"),
+              ]),
+              @rui.context_menu_item(scope, [
+                showcase_file_icon(),
+                @html.span("Export"),
+                @rui.context_menu_shortcut("⇧⌘E"),
+              ]),
+              @rui.context_menu_item(scope, disabled=true, [
+                showcase_archive_icon(),
+                @html.span("Paste"),
+              ]),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let context_menu_submenu_view = @rui.context_menu(
+    id="showcase-context-menu-submenu",
+    scope => {
+      @html.fragment([
+        @rui.context_menu_trigger(
+          scope,
+          style=[IgContextTargetStyle],
+          "Right-click for project options",
+        ),
+        @rui.context_menu_portal([
+          @rui.context_menu_content(scope, aria_label="Project options", [
+            @rui.context_menu_item(scope, [
+              showcase_settings_icon(),
+              @html.span("Project settings"),
+            ]),
+            @rui.context_menu_sub(scope, value="move", sub => {
+              @html.fragment([
+                @rui.context_menu_sub_trigger(sub, [
+                  showcase_archive_icon(),
+                  @html.span("Move to"),
+                ]),
+                @rui.context_menu_sub_content(sub, [
+                  @rui.context_menu_group(aria_label="Destination", [
+                    @rui.context_menu_label("Destination"),
+                    @rui.context_menu_item(scope, [
+                      showcase_layout_icon(),
+                      @html.span("Design system"),
+                    ]),
+                    @rui.context_menu_item(scope, [
+                      showcase_activity_icon(),
+                      @html.span("Experiments"),
+                    ]),
+                  ]),
+                ]),
+              ])
+            }),
+            @rui.context_menu_separator(),
+            @rui.context_menu_item(scope, destructive=true, [
+              showcase_close_icon(),
+              @html.span("Delete project"),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let context_menu_checkbox_view = @rui.context_menu(
+    id="showcase-context-menu-checkbox",
+    default_checked_values=["grid", "activity"],
+    scope => {
+      @html.fragment([
+        @rui.context_menu_trigger(
+          scope,
+          style=[IgContextTargetStyle],
+          "Right-click for visibility controls",
+        ),
+        @rui.context_menu_portal([
+          @rui.context_menu_content(scope, aria_label="Visibility controls", [
+            @rui.context_menu_group(aria_label="Visibility", [
+              @rui.context_menu_label("Visibility"),
+              @rui.context_menu_checkbox_item(scope, value="grid", [
+                showcase_layout_icon(),
+                @html.span("Show grid"),
+              ]),
+              @rui.context_menu_checkbox_item(scope, value="sidebar", [
+                showcase_panel_left_icon(),
+                @html.span("Show sidebar"),
+              ]),
+              @rui.context_menu_checkbox_item(scope, value="activity", [
+                showcase_activity_icon(),
+                @html.span("Show activity"),
+              ]),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let context_menu_radio_view = @rui.context_menu(
+    id="showcase-context-menu-radio",
+    default_radio_values=[("layout", "canvas")],
+    scope => {
+      @html.fragment([
+        @rui.context_menu_trigger(
+          scope,
+          style=[IgContextTargetStyle],
+          "Right-click for layout controls",
+        ),
+        @rui.context_menu_portal([
+          @rui.context_menu_content(scope, aria_label="Layout controls", [
+            @rui.context_menu_group(aria_label="Layout", [
+              @rui.context_menu_label("Layout"),
+              @rui.context_menu_radio_group(scope, value="layout", radio => {
+                @html.fragment([
+                  @rui.context_menu_radio_item(radio, value="canvas", [
+                    showcase_layout_icon(),
+                    @html.span("Canvas"),
+                  ]),
+                  @rui.context_menu_radio_item(radio, value="editor", [
+                    showcase_file_icon(),
+                    @html.span("Editor"),
+                  ]),
+                  @rui.context_menu_radio_item(radio, value="focus", [
+                    showcase_activity_icon(),
+                    @html.span("Focus"),
+                  ]),
+                ])
+              }),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let dialog_modal_view = ig_dialog_variant(
+    "showcase-dialog-modal",
+    true,
+    @rui.Outline,
+    "Edit profile",
+  )
+  let dialog_nonmodal_view = ig_dialog_variant(
+    "showcase-dialog-nonmodal",
+    false,
+    @rui.Secondary,
+    "Open non-modal",
+  )
+  let drawer_top_view = ig_drawer_variant(
+    "showcase-drawer-top",
+    @rui.DrawerTop,
+    "Open top drawer",
+  )
+  let drawer_right_view = ig_drawer_variant(
+    "showcase-drawer-right",
+    @rui.DrawerRight,
+    "Open right drawer",
+  )
+  let drawer_bottom_view = ig_drawer_variant(
+    "showcase-drawer-bottom",
+    @rui.DrawerBottom,
+    "Open bottom drawer",
+  )
+  let drawer_left_view = ig_drawer_variant(
+    "showcase-drawer-left",
+    @rui.DrawerLeft,
+    "Open left drawer",
+  )
+  let dropdown_basic_view = @rui.dropdown_menu(
+    id="showcase-dropdown-menu-basic",
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(
+          scope,
+          variant=@rui.Outline,
+          "Workspace menu",
+        ),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(
+            scope,
+            side=@rui.Bottom,
+            align=@rui.Start,
+            [
+              @rui.dropdown_menu_group(aria_label="Workspace", [
+                @rui.dropdown_menu_label("Workspace"),
+                @rui.dropdown_menu_item(scope, [
+                  @html.span("New tab"),
+                  @rui.dropdown_menu_shortcut("⌘T"),
+                ]),
+                @rui.dropdown_menu_item(scope, "Invite member"),
+                @rui.dropdown_menu_item(scope, "Move workspace"),
+                @rui.dropdown_menu_item(
+                  scope,
+                  disabled=true,
+                  "Duplicate workspace",
+                ),
+              ]),
+            ],
+          ),
+        ]),
+      ])
+    },
+  )
+  let dropdown_icons_view = @rui.dropdown_menu(
+    id="showcase-dropdown-menu-icons",
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Account"),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(
+            scope,
+            side=@rui.Bottom,
+            align=@rui.Start,
+            style=["min-width:12rem"],
+            [
+              @rui.dropdown_menu_item(scope, [
+                showcase_user_icon(),
+                @html.span("Profile"),
+              ]),
+              @rui.dropdown_menu_item(scope, [
+                showcase_credit_card_icon(),
+                @html.span("Billing"),
+              ]),
+              @rui.dropdown_menu_item(scope, [
+                showcase_settings_icon(),
+                @html.span("Settings"),
+              ]),
+              @rui.dropdown_menu_separator(),
+              @rui.dropdown_menu_item(scope, destructive=true, [
+                showcase_log_out_icon(),
+                @html.span("Log out"),
+              ]),
+            ],
+          ),
+        ]),
+      ])
+    },
+  )
+  let dropdown_checkbox_view = @rui.dropdown_menu(
+    id="showcase-dropdown-menu-checkbox",
+    default_checked_values=["email", "push"],
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Notifications"),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(scope, style=["min-width:14rem"], [
+            @rui.dropdown_menu_group(aria_label="Notifications", [
+              @rui.dropdown_menu_label("Notifications"),
+              @rui.dropdown_menu_checkbox_item(scope, value="email", [
+                showcase_mail_icon(),
+                @html.span("Email"),
+              ]),
+              @rui.dropdown_menu_checkbox_item(scope, value="sms", [
+                showcase_message_square_icon(),
+                @html.span("SMS"),
+              ]),
+              @rui.dropdown_menu_checkbox_item(scope, value="push", [
+                showcase_bell_icon(),
+                @html.span("Push notifications"),
+              ]),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let dropdown_radio_view = @rui.dropdown_menu(
+    id="showcase-dropdown-menu-radio",
+    default_radio_values=[("payment", "card")],
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(
+          scope,
+          variant=@rui.Outline,
+          "Payment method",
+        ),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(scope, style=["min-width:14rem"], [
+            @rui.dropdown_menu_group(aria_label="Payment method", [
+              @rui.dropdown_menu_label("Payment method"),
+              @rui.dropdown_menu_radio_group(scope, value="payment", radio => {
+                @html.fragment([
+                  @rui.dropdown_menu_radio_item(radio, value="card", [
+                    showcase_credit_card_icon(),
+                    @html.span("Credit card"),
+                  ]),
+                  @rui.dropdown_menu_radio_item(radio, value="wallet", [
+                    showcase_wallet_icon(),
+                    @html.span("PayPal"),
+                  ]),
+                  @rui.dropdown_menu_radio_item(radio, value="bank", [
+                    showcase_building_icon(),
+                    @html.span("Bank transfer"),
+                  ]),
+                ])
+              }),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let dropdown_submenu_view = @rui.dropdown_menu(
+    id="showcase-dropdown-menu-submenu",
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(
+          scope,
+          variant=@rui.Secondary,
+          size=@rui.Sm,
+          "Top-end menu",
+        ),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(
+            scope,
+            side=@rui.Top,
+            align=@rui.End,
+            style=["min-width:12rem"],
+            [
+              @rui.dropdown_menu_item(scope, [
+                @html.span("Open workspace"),
+                @rui.dropdown_menu_shortcut("⌘O"),
+              ]),
+              @rui.dropdown_menu_sub(scope, value="share", sub => {
+                @html.fragment([
+                  @rui.dropdown_menu_sub_trigger(sub, "Share"),
+                  @rui.dropdown_menu_sub_content(sub, [
+                    @rui.dropdown_menu_group(aria_label="Share workspace", [
+                      @rui.dropdown_menu_label("Share workspace"),
+                      @rui.dropdown_menu_item(scope, "Copy link"),
+                      @rui.dropdown_menu_item(scope, "Invite people"),
+                    ]),
+                  ]),
+                ])
+              }),
+              @rui.dropdown_menu_item(scope, disabled=true, "Unavailable"),
+            ],
+          ),
+        ]),
+      ])
+    },
+  )
+  let dropdown_multilevel_view = @rui.dropdown_menu(
+    id="showcase-dropdown-menu-multilevel",
+    scope => {
+      @html.fragment([
+        @rui.dropdown_menu_trigger(scope, variant=@rui.Outline, "Organize file"),
+        @rui.dropdown_menu_portal([
+          @rui.dropdown_menu_content(scope, style=["min-width:13rem"], [
+            @rui.dropdown_menu_item(scope, [
+              showcase_file_icon(),
+              @html.span("Rename"),
+            ]),
+            @rui.dropdown_menu_sub(scope, value="move", destination => {
+              @html.fragment([
+                @rui.dropdown_menu_sub_trigger(destination, [
+                  showcase_folder_icon(),
+                  @html.span("Move to"),
+                ]),
+                @rui.dropdown_menu_sub_content(
+                  destination,
+                  style=["min-width:12rem"],
+                  [
+                    @rui.dropdown_menu_label("Destination"),
+                    @rui.dropdown_menu_item(scope, [
+                      showcase_folder_icon(),
+                      @html.span("Inbox"),
+                    ]),
+                    @rui.dropdown_menu_sub(scope, value="projects", project => {
+                      @html.fragment([
+                        @rui.dropdown_menu_sub_trigger(project, [
+                          showcase_folder_open_icon(),
+                          @html.span("Projects"),
+                        ]),
+                        @rui.dropdown_menu_sub_content(
+                          project,
+                          style=["min-width:13rem"],
+                          [
+                            @rui.dropdown_menu_group(
+                              aria_label="Project destination",
+                              [
+                                @rui.dropdown_menu_label("Project destination"),
+                                @rui.dropdown_menu_item(scope, [
+                                  showcase_layout_icon(),
+                                  @html.span("Design system"),
+                                ]),
+                                @rui.dropdown_menu_item(scope, [
+                                  showcase_activity_icon(),
+                                  @html.span("Experiments"),
+                                ]),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ])
+                    }),
+                  ],
+                ),
+              ])
+            }),
+            @rui.dropdown_menu_separator(),
+            @rui.dropdown_menu_item(scope, destructive=true, [
+              showcase_archive_icon(),
+              @html.span("Archive"),
+            ]),
+          ]),
+        ]),
+      ])
+    },
+  )
+  let alert_dialog_component = if selected == "" || selected == "alert-dialog" {
+    alert_dialog_default_view.view2(
+      alert_dialog_view, ig_alert_dialog_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let command_component = if selected == "" || selected == "command" {
+    command_view.view2(command_dialog_view, ig_command_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let dialog_component = if selected == "" || selected == "dialog" {
+    dialog_modal_view.view2(dialog_nonmodal_view, ig_dialog_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let drawer_component = if selected == "" || selected == "drawer" {
+    drawer_top_view.view4(
+      drawer_right_view, drawer_bottom_view, drawer_left_view, ig_drawer_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let context_menu_component = if selected == "" || selected == "context-menu" {
+    context_menu_actions_view.view4(
+      context_menu_submenu_view,
+      context_menu_checkbox_view,
+      context_menu_radio_view,
+      (actions_html, submenu_html, checkbox_html, radio_html) => {
+        showcase_component_demos(
+          "Context Menu",
+          "Actions, nested commands, and selection controls use independent right-click surfaces.",
+          [
+            showcase_demo_section(
+              "Actions & shortcuts",
+              "Grouped canvas commands include shortcuts and a disabled action.",
+              showcase_demo_stage(
+                actions_html,
+                ig_menu_code(
+                  IgContextMenuActionsIconsCode,
+                  IgContextMenuActionsCode,
+                ),
+              ),
+            ),
+            showcase_demo_section(
+              "Submenu & destructive action",
+              "Leading icons continue through nested destinations and the destructive row.",
+              showcase_demo_stage(
+                submenu_html,
+                ig_menu_code(
+                  IgContextMenuSubmenuIconsCode,
+                  IgContextMenuSubmenuCode,
+                ),
+              ),
+            ),
+            showcase_demo_section(
+              "Checkbox items",
+              "Visibility choices combine leading icons with trailing checkmarks.",
+              showcase_demo_stage(
+                checkbox_html,
+                ig_menu_code(
+                  IgContextMenuCheckboxIconsCode,
+                  IgContextMenuCheckboxCode,
+                ),
+              ),
+            ),
+            showcase_demo_section(
+              "Radio group",
+              "One layout choice remains active within a labelled radio group.",
+              showcase_demo_stage(
+                radio_html,
+                ig_menu_code(
+                  IgContextMenuRadioIconsCode,
+                  IgContextMenuRadioCode,
+                ),
+              ),
+            ),
+          ],
+        )
+      },
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let first_row = alert_dialog_component.view5(
+    command_component,
+    context_menu_component,
+    dialog_component,
+    drawer_component,
+    (
+      alert_dialog_html,
+      command_html,
+      context_menu_html,
+      dialog_html,
+      drawer_html,
+    ) => {
+      @html.fragment([
+        alert_dialog_html, dialog_html, drawer_html, context_menu_html, command_html,
+      ])
+    },
+  )
+  let hover_card_top_view = ig_hover_card_variant(
+    "showcase-hover-card-top",
+    @rui.Top,
+    @rui.Center,
+    "Top-center preview",
+  )
+  let hover_card_left_view = ig_hover_card_variant(
+    "showcase-hover-card-left",
+    @rui.Left,
+    @rui.End,
+    "Left-end preview",
+  )
+  let menubar_commands_view = @rui.menubar(id="showcase-menubar-commands", scope => {
+    @html.fragment([
+      @rui.menubar_menu(scope, value="file", menu => {
+        @html.fragment([
+          @rui.menubar_trigger(menu, "File"),
+          @rui.menubar_portal([
+            @rui.menubar_content(menu, [
+              @rui.menubar_group(aria_label="Project commands", [
+                @rui.menubar_label("Project"),
+                @rui.menubar_item(menu, [
+                  showcase_plus_icon(),
+                  @html.span("New project"),
+                  @rui.menubar_shortcut("⌘N"),
+                ]),
+                @rui.menubar_item(menu, [
+                  showcase_file_icon(),
+                  @html.span("Open…"),
+                  @rui.menubar_shortcut("⌘O"),
+                ]),
+                @rui.menubar_item(menu, disabled=true, [
+                  showcase_archive_icon(),
+                  @html.span("Import"),
+                ]),
+              ]),
+            ]),
+          ]),
+        ])
+      }),
+      @rui.menubar_menu(scope, value="help", menu => {
+        @html.fragment([
+          @rui.menubar_trigger(menu, "Help"),
+          @rui.menubar_portal([
+            @rui.menubar_content(menu, [
+              @rui.menubar_group(aria_label="Help", [
+                @rui.menubar_label("Help"),
+                @rui.menubar_item(menu, [
+                  showcase_circle_help_icon(),
+                  @html.span("Keyboard shortcuts"),
+                  @rui.menubar_shortcut("?"),
+                ]),
+              ]),
+            ]),
+          ]),
+        ])
+      }),
+    ])
+  })
+  let menubar_submenu_view = @rui.menubar(id="showcase-menubar-submenu", scope => {
+    @html.fragment([
+      @rui.menubar_menu(scope, value="project", menu => {
+        @html.fragment([
+          @rui.menubar_trigger(menu, "Project"),
+          @rui.menubar_portal([
+            @rui.menubar_content(menu, [
+              @rui.menubar_item(menu, [
+                showcase_settings_icon(),
+                @html.span("Project settings"),
+              ]),
+              @rui.menubar_sub(menu, value="recent", sub => {
+                @html.fragment([
+                  @rui.menubar_sub_trigger(sub, [
+                    showcase_layout_icon(),
+                    @html.span("Recent projects"),
+                  ]),
+                  @rui.menubar_sub_content(sub, [
+                    @rui.menubar_group(aria_label="Recent projects", [
+                      @rui.menubar_label("Recent projects"),
+                      @rui.menubar_item(menu, [
+                        showcase_file_icon(),
+                        @html.span("Design system"),
+                      ]),
+                      @rui.menubar_item(menu, [
+                        showcase_activity_icon(),
+                        @html.span("Experiments"),
+                      ]),
+                    ]),
+                  ]),
+                ])
+              }),
+              @rui.menubar_separator(),
+              @rui.menubar_item(menu, destructive=true, [
+                showcase_close_icon(),
+                @html.span("Close project"),
+              ]),
+            ]),
+          ]),
+        ])
+      }),
+    ])
+  })
+  let menubar_checkbox_view = @rui.menubar(
+    id="showcase-menubar-checkbox",
+    default_checked_values=["sidebar", "activity"],
+    scope => {
+      @html.fragment([
+        @rui.menubar_menu(scope, value="view", menu => {
+          @html.fragment([
+            @rui.menubar_trigger(menu, "View"),
+            @rui.menubar_portal([
+              @rui.menubar_content(menu, [
+                @rui.menubar_group(aria_label="Panels", [
+                  @rui.menubar_label("Panels"),
+                  @rui.menubar_checkbox_item(menu, value="sidebar", [
+                    showcase_panel_left_icon(),
+                    @html.span("Sidebar"),
+                  ]),
+                  @rui.menubar_checkbox_item(menu, value="activity", [
+                    showcase_activity_icon(),
+                    @html.span("Activity bar"),
+                  ]),
+                  @rui.menubar_checkbox_item(menu, value="status", [
+                    showcase_layout_icon(),
+                    @html.span("Status bar"),
+                  ]),
+                ]),
+              ]),
+            ]),
+          ])
+        }),
+      ])
+    },
+  )
+  let menubar_radio_view = @rui.menubar(
+    id="showcase-menubar-radio",
+    default_radio_values=[("workspace", "editor")],
+    scope => {
+      @html.fragment([
+        @rui.menubar_menu(scope, value="workspace", menu => {
+          @html.fragment([
+            @rui.menubar_trigger(menu, "Workspace"),
+            @rui.menubar_portal([
+              @rui.menubar_content(menu, [
+                @rui.menubar_group(aria_label="Workspace mode", [
+                  @rui.menubar_label("Workspace mode"),
+                  @rui.menubar_radio_group(menu, value="workspace", radio => {
+                    @html.fragment([
+                      @rui.menubar_radio_item(radio, value="editor", [
+                        showcase_file_icon(),
+                        @html.span("Editor"),
+                      ]),
+                      @rui.menubar_radio_item(radio, value="canvas", [
+                        showcase_layout_icon(),
+                        @html.span("Canvas"),
+                      ]),
+                      @rui.menubar_radio_item(radio, value="focus", [
+                        showcase_activity_icon(),
+                        @html.span("Focus"),
+                      ]),
+                    ])
+                  }),
+                ]),
+              ]),
+            ]),
+          ])
+        }),
+      ])
+    },
+  )
+  let popover_bottom_view = ig_popover_variant(
+    "showcase-popover-bottom",
+    @rui.Bottom,
+    @rui.Start,
+    "Bottom-start popover",
+  )
+  let popover_right_view = ig_popover_variant(
+    "showcase-popover-right",
+    @rui.Right,
+    @rui.Center,
+    "Right-center popover",
+  )
+  let sheet_top_view = ig_sheet_variant(
+    "showcase-sheet-top",
+    @rui.SheetTop,
+    "Open top sheet",
+  )
+  let sheet_right_view = ig_sheet_variant(
+    "showcase-sheet-right",
+    @rui.SheetRight,
+    "Open right sheet",
+  )
+  let sheet_bottom_view = ig_sheet_variant(
+    "showcase-sheet-bottom",
+    @rui.SheetBottom,
+    "Open bottom sheet",
+  )
+  let sheet_left_view = ig_sheet_variant(
+    "showcase-sheet-left",
+    @rui.SheetLeft,
+    "Open left sheet",
+  )
+  let tooltip_top_view = ig_tooltip_variant(
+    "showcase-tooltip-top",
+    @rui.Top,
+    @rui.Start,
+    @rui.IconSm,
+    "Top-start tooltip",
+  )
+  let tooltip_right_view = ig_tooltip_variant(
+    "showcase-tooltip-right",
+    @rui.Right,
+    @rui.Center,
+    @rui.Icon,
+    "Right-center tooltip",
+  )
+  let tooltip_bottom_view = ig_tooltip_variant(
+    "showcase-tooltip-bottom",
+    @rui.Bottom,
+    @rui.End,
+    @rui.IconLg,
+    "Bottom-end tooltip",
+  )
+  let tooltip_left_view = ig_tooltip_variant(
+    "showcase-tooltip-left",
+    @rui.Left,
+    @rui.Center,
+    @rui.Icon,
+    "Left-center tooltip",
+  )
+  let dropdown_component = if selected == "" || selected == "dropdown-menu" {
+    dropdown_basic_view.view6(
+      dropdown_icons_view,
+      dropdown_checkbox_view,
+      dropdown_radio_view,
+      dropdown_submenu_view,
+      dropdown_multilevel_view,
+      (
+        basic_html,
+        icons_html,
+        checkbox_html,
+        radio_html,
+        submenu_html,
+        multilevel_html,
+      ) => {
+        showcase_component_demos(
+          "Dropdown Menu",
+          "Groups, icons, selection controls, placement, and true multi-level navigation use independent menus.",
+          [
+            showcase_demo_section(
+              "Basic groups",
+              "A labelled group combines ordinary commands, shortcuts, and a disabled item.",
+              showcase_demo_stage(basic_html, IgDropdownMenuBasicCode),
+            ),
+            showcase_demo_section(
+              "Leading icons",
+              "Account commands use SVG icons and a separated destructive action.",
+              showcase_demo_stage(
+                icons_html,
+                ig_menu_code(
+                  IgDropdownMenuIconsIconsCode,
+                  IgDropdownMenuIconsCode,
+                ),
+              ),
+            ),
+            showcase_demo_section(
+              "Checkbox items",
+              "Notification choices keep SVG icons at the start and checkmarks at the end.",
+              showcase_demo_stage(
+                checkbox_html,
+                ig_menu_code(
+                  IgDropdownMenuCheckboxIconsCode,
+                  IgDropdownMenuCheckboxCode,
+                ),
+              ),
+            ),
+            showcase_demo_section(
+              "Radio group",
+              "Payment methods keep one active value with its selection mark at the end.",
+              showcase_demo_stage(
+                radio_html,
+                ig_menu_code(
+                  IgDropdownMenuRadioIconsCode,
+                  IgDropdownMenuRadioCode,
+                ),
+              ),
+            ),
+            showcase_demo_section(
+              "Submenu & placement",
+              "A top-end popup contains a labelled nested sharing menu.",
+              showcase_demo_stage(submenu_html, IgDropdownMenuSubmenuCode),
+            ),
+            showcase_demo_section(
+              "Multi-level submenu",
+              "Move through a root menu, destination submenu, and nested project submenu.",
+              showcase_demo_stage(
+                multilevel_html,
+                ig_menu_code(
+                  IgDropdownMenuMultiLevelIconsCode,
+                  IgDropdownMenuMultiLevelCode,
+                ),
+              ),
+            ),
+          ],
+        )
+      },
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let menubar_component = if selected == "" || selected == "menubar" {
+    menubar_commands_view.view4(
+      menubar_submenu_view,
+      menubar_checkbox_view,
+      menubar_radio_view,
+      (commands_html, submenu_html, checkbox_html, radio_html) => {
+        showcase_component_demos(
+          "Menubar",
+          "Application commands, nested projects, and selection controls use separate bars.",
+          [
+            showcase_demo_section(
+              "Application commands",
+              "Grouped File and Help menus include leading icons, shortcuts, and disabled commands.",
+              showcase_demo_stage(
+                commands_html,
+                ig_menu_code(IgMenubarCommandsIconsCode, IgMenubarCommandsCode),
+              ),
+            ),
+            showcase_demo_section(
+              "Submenu & destructive action",
+              "A project submenu keeps icon alignment through nested and destructive commands.",
+              showcase_demo_stage(
+                submenu_html,
+                ig_menu_code(IgMenubarSubmenuIconsCode, IgMenubarSubmenuCode),
+              ),
+            ),
+            showcase_demo_section(
+              "Checkbox items",
+              "Panel visibility choices combine SVG icons with trailing checkmarks.",
+              showcase_demo_stage(
+                checkbox_html,
+                ig_menu_code(IgMenubarCheckboxIconsCode, IgMenubarCheckboxCode),
+              ),
+            ),
+            showcase_demo_section(
+              "Radio group",
+              "Workspace modes combine SVG icons with one trailing selection mark.",
+              showcase_demo_stage(
+                radio_html,
+                ig_menu_code(IgMenubarRadioIconsCode, IgMenubarRadioCode),
+              ),
+            ),
+          ],
+        )
+      },
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let hover_card_component = if selected == "" || selected == "hover-card" {
+    hover_card_top_view.view2(hover_card_left_view, ig_hover_card_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let popover_component = if selected == "" || selected == "popover" {
+    popover_bottom_view.view2(popover_right_view, ig_popover_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let sheet_component = if selected == "" || selected == "sheet" {
+    sheet_top_view.view4(
+      sheet_right_view, sheet_bottom_view, sheet_left_view, ig_sheet_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let tooltip_component = if selected == "" || selected == "tooltip" {
+    tooltip_top_view.view4(
+      tooltip_right_view, tooltip_bottom_view, tooltip_left_view, ig_tooltip_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let second_row = dropdown_component.view6(
+    hover_card_component,
+    menubar_component,
+    popover_component,
+    sheet_component,
+    tooltip_component,
+    (
+      dropdown_html,
+      hover_card_html,
+      menubar_html,
+      popover_html,
+      sheet_html,
+      tooltip_html,
+    ) => {
+      @html.fragment([
+        dropdown_html, menubar_html, popover_html, hover_card_html, tooltip_html,
+        sheet_html,
+      ])
+    },
+  )
+  first_row.view2(second_row, (first_html, second_html) => {
+    @html.section(
+      id="overlays",
+      style=[IgComponentListStyle, "scroll-margin-top:1rem"],
+      [first_html, second_html],
+    )
+  })
+}
+
+///|
+fn ig_overlay_section() -> @rabbita.Val[@html.Html] {
+  ig_overlay_page("")
+}
+
+///|
+fn ig_resizable_component(
+  horizontal_html : @html.Html,
+  vertical_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Resizable",
+    "Horizontal multi-panel and vertical two-panel layouts.",
+    [
+      showcase_demo_section(
+        "Horizontal multi-panel",
+        "Three panels expose two pointer and keyboard resize handles.",
+        showcase_demo_stage(
+          horizontal_html,
+          IgResizableHorizontalCode,
+          tall=true,
+        ),
+      ),
+      showcase_demo_section(
+        "Vertical two-panel",
+        "A bounded vertical handle resizes the preview and console panels.",
+        showcase_demo_stage(vertical_html, IgResizableVerticalCode, tall=true),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_scroll_area_component(
+  vertical_html : @html.Html,
+  horizontal_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Scroll Area",
+    "Vertical and horizontal orientations use measured scrollbars.",
+    [
+      showcase_demo_section(
+        "Vertical",
+        "A measured vertical thumb follows the release checklist viewport.",
+        showcase_demo_stage(vertical_html, IgScrollAreaVerticalCode, tall=true),
+      ),
+      showcase_demo_section(
+        "Horizontal",
+        "A measured horizontal thumb follows an overflowing row of badges.",
+        showcase_demo_stage(horizontal_html, IgScrollAreaHorizontalCode),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_sonner_component(
+  default_html : @html.Html,
+  success_html : @html.Html,
+  destructive_html : @html.Html,
+  queue_html : @html.Html,
+) -> @html.Html {
+  showcase_component_demos(
+    "Sonner",
+    "Each notification treatment and queue behavior has an independent example.",
+    [
+      showcase_demo_section(
+        "Default",
+        "A neutral notification appears in a bounded bottom-right queue.",
+        showcase_demo_stage(default_html, IgSonnerDefaultCode),
+      ),
+      showcase_demo_section(
+        "Success",
+        "A positive notification uses the success treatment.",
+        showcase_demo_stage(success_html, IgSonnerSuccessCode),
+      ),
+      showcase_demo_section(
+        "Destructive",
+        "An error notification uses the destructive treatment.",
+        showcase_demo_stage(destructive_html, IgSonnerDestructiveCode),
+      ),
+      showcase_demo_section(
+        "Queue & dismissal",
+        "Add neutral notifications to a bounded queue or dismiss the queue at once.",
+        showcase_demo_stage(queue_html, IgSonnerQueueCode),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_toast_component() -> @html.Html {
+  showcase_component_demos(
+    "Toast",
+    "Static toast compositions expose semantic visual treatments.",
+    [
+      showcase_demo_section(
+        "Default",
+        "A neutral status can include a compact action.",
+        showcase_demo_stage(
+          @rui.toast(variant=@rui.ToastDefault, [
+            @rui.toast_title("Draft saved"),
+            @rui.toast_description("Your changes remain local."),
+            @rui.toast_action("View"),
+          ]),
+          IgToastDefaultCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Success",
+        "A positive status confirms a completed action.",
+        showcase_demo_stage(
+          @rui.toast(variant=@rui.ToastSuccess, [
+            @rui.toast_title("Published"),
+            @rui.toast_description("The latest preview is live."),
+          ]),
+          IgToastSuccessCode,
+        ),
+      ),
+      showcase_demo_section(
+        "Destructive",
+        "An error status calls attention to a failed action.",
+        showcase_demo_stage(
+          @rui.toast(variant=@rui.ToastDestructive, [
+            @rui.toast_title("Could not sync"),
+            @rui.toast_description("Check the connection and try again."),
+          ]),
+          IgToastDestructiveCode,
+        ),
+      ),
+    ],
+  )
+}
+
+///|
+fn ig_feedback_page(selected : String) -> @rabbita.Val[@html.Html] {
+  let sonner_default_view = @rui.sonner(max_toasts=3, position="bottom-right", scope => {
+    @rui.button(
+      size=@rui.Sm,
+      on_click=scope.show(
+        title="Saved",
+        description="The draft remains in this workspace.",
+        variant=@rui.ToastDefault,
+      ),
+      "Default toast",
+    )
+  })
+  let sonner_success_view = @rui.sonner(max_toasts=3, position="bottom-right", scope => {
+    @rui.button(
+      size=@rui.Sm,
+      variant=@rui.Secondary,
+      on_click=scope.show(
+        title="Published",
+        description="The latest UI preview is live.",
+        variant=@rui.ToastSuccess,
+      ),
+      "Success toast",
+    )
+  })
+  let sonner_destructive_view = @rui.sonner(
+    max_toasts=3,
+    position="bottom-right",
+    scope => {
+      @rui.button(
+        size=@rui.Sm,
+        variant=@rui.Destructive,
+        on_click=scope.show(
+          title="Could not sync",
+          description="Check the connection and try again.",
+          variant=@rui.ToastDestructive,
+        ),
+        "Error toast",
+      )
+    },
+  )
+  let sonner_queue_view = @rui.sonner(max_toasts=3, position="bottom-right", scope => {
+    @html.div(style=[IgControlWrapStyle], [
+      @rui.button(
+        size=@rui.Sm,
+        on_click=scope.show(
+          title="Queued",
+          description="This notification joins the bounded queue.",
+          variant=@rui.ToastDefault,
+        ),
+        "Add toast",
+      ),
+      @rui.button(
+        size=@rui.Sm,
+        variant=@rui.Ghost,
+        on_click=scope.dismiss_all(),
+        "Dismiss queue",
+      ),
+    ])
+  })
+  let scroller_view = @rui.message_scroller(
+    id="showcase-message-scroller",
+    default_at_end=true,
+    scope => {
+      @html.div(style=["position:relative"], [
+        @rui.message_scroller_viewport(
+          scope~,
+          style=[IgMessageViewportStyle],
+          @rui.message_scroller_content(style=[IgMessageListStyle], [
+            @rui.message_scroller_item(
+              @rui.message([
+                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("RA"))),
+                @rui.message_content([
+                  @rui.message_header("Rabbita · 09:41"),
+                  @rui.bubble_group(
+                    @rui.bubble(
+                      variant=@rui.BubbleSecondary,
+                      @rui.bubble_content(
+                        "The component catalogue is ready for review.",
+                      ),
+                    ),
+                  ),
+                ]),
+              ]),
+            ),
+            @rui.message_scroller_item(
+              @rui.message(align=@rui.AlignEnd, [
+                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("YO"))),
+                @rui.message_content([
+                  @rui.message_header("You · 09:42"),
+                  @rui.bubble_group(
+                    @rui.bubble(
+                      align=@rui.AlignEnd,
+                      @rui.bubble_content(
+                        "Great — keep state local and the API black-box.",
+                      ),
+                    ),
+                  ),
+                  @rui.message_footer("Delivered"),
+                ]),
+              ]),
+            ),
+            @rui.message_scroller_item(
+              @rui.message([
+                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("RA"))),
+                @rui.message_content(
+                  @rui.bubble_group(
+                    @rui.bubble(
+                      variant=@rui.BubbleMuted,
+                      @rui.bubble_content(
+                        "This scroller tracks both edges and exposes jump controls.",
+                      ),
+                    ),
+                  ),
+                ),
+              ]),
+            ),
+            @rui.message_scroller_item(
+              scroll_anchor=true,
+              @rui.message(align=@rui.AlignEnd, [
+                @rui.message_avatar(@rui.avatar(@rui.avatar_fallback("YO"))),
+                @rui.message_content(
+                  @rui.bubble_group(
+                    @rui.bubble(
+                      align=@rui.AlignEnd,
+                      @rui.bubble_content("Ship the showcase."),
+                    ),
+                  ),
+                ),
+              ]),
+            ),
+          ]),
+        ),
+        @html.div(
+          style=[
+            "position:absolute;right:0.625rem;bottom:0.625rem;display:flex;gap:0.375rem",
+          ],
+          [
+            @rui.message_scroller_button(
+              scope~,
+              direction=@rui.ScrollStart,
+              label="Jump to first message",
+              size=@rui.IconSm,
+              showcase_arrow_up_icon(),
+            ),
+            @rui.message_scroller_button(
+              scope~,
+              direction=@rui.ScrollEnd,
+              label="Jump to latest message",
+              size=@rui.IconSm,
+              showcase_arrow_down_icon(),
+            ),
+          ],
+        ),
+      ])
+    },
+  )
+  let resizable_view = @rui.resizable_group(
+    id="showcase-resizable",
+    default_sizes=[26, 44, 30],
+    min_sizes=[16, 24, 18],
+    max_sizes=[52, 68, 54],
+    orientation=@rui.Horizontal,
+    style=[IgResizeStyle],
+    scope => {
+      @html.fragment([
+        @rui.resizable_group_panel(
+          scope~,
+          index=0,
+          style=[IgResizePanelStyle],
+          "Files",
+        ),
+        @rui.resizable_group_handle(
+          scope~,
+          between=0,
+          with_handle=true,
+          aria_label="Resize files and editor",
+        ),
+        @rui.resizable_group_panel(
+          scope~,
+          index=1,
+          style=[IgResizePanelStyle],
+          "Editor",
+        ),
+        @rui.resizable_group_handle(
+          scope~,
+          between=1,
+          with_handle=true,
+          aria_label="Resize editor and preview",
+        ),
+        @rui.resizable_group_panel(
+          scope~,
+          index=2,
+          style=[IgResizePanelStyle],
+          "Preview",
+        ),
+      ])
+    },
+  )
+  let resizable_panel_view = @rui.resizable_panel_group(
+    id="showcase-resizable-panel-group",
+    default_size=42,
+    min=24,
+    max=72,
+    orientation=@rui.Vertical,
+    aria_label="Resize preview and console",
+    style=[IgResizeStyle, IgResizableVerticalStyle],
+    scope => {
+      @html.fragment([
+        @rui.resizable_panel(
+          scope~,
+          side=@rui.FirstPanel,
+          style=[IgResizePanelStyle],
+          "Preview",
+        ),
+        @rui.resizable_handle(
+          scope~,
+          with_handle=true,
+          aria_label="Resize preview and console",
+        ),
+        @rui.resizable_panel(
+          scope~,
+          side=@rui.SecondPanel,
+          style=[IgResizePanelStyle],
+          "Console",
+        ),
+      ])
+    },
+  )
+  let scroll_view = @rui.scroll_area_with_scrollbar(
+    id="showcase-scroll-area",
+    orientation=@rui.Vertical,
+    style=[IgScrollAreaStyle],
+    @html.div(style=[IgScrollContentStyle], [
+      @html.strong("Release checklist"),
+      @rui.separator(),
+      @html.span("Check semantic roles"),
+      @html.span("Check keyboard order"),
+      @html.span("Check light and dark themes"),
+      @html.span("Check long labels"),
+      @html.span("Check narrow containers"),
+      @html.span("Check reduced motion"),
+      @html.span("Check empty and error states"),
+      @html.span("Check server rendering"),
+      @html.span("Check native fallback"),
+      @html.span("Ready to publish"),
+    ]),
+  )
+  let scroll_horizontal_view = @rui.scroll_area_with_scrollbar(
+    id="showcase-scroll-area-horizontal",
+    orientation=@rui.Horizontal,
+    style=[IgHorizontalScrollAreaStyle],
+    @html.div(style=[IgHorizontalScrollContentStyle], [
+      @rui.badge(variant=@rui.Secondary, "Keyboard"),
+      @rui.badge(variant=@rui.Secondary, "Pointer"),
+      @rui.badge(variant=@rui.Secondary, "Touch"),
+      @rui.badge(variant=@rui.Secondary, "RTL"),
+      @rui.badge(variant=@rui.Secondary, "Measured thumb"),
+      @rui.badge(variant=@rui.Secondary, "Native fallback"),
+    ]),
+  )
+  let scroller_variants = if selected == "" || selected == "message-scroller" {
+    scroller_view.view(scroller_html => {
+      ig_demo_card(
+        "Message Scroller",
+        "One interactive conversation exposes both jump directions.",
+        scroller_html,
+        "Conversation and edge controls",
+        "Real Message and Bubble compositions sit inside the measured viewport with start and end jump buttons.",
+        IgMessageScrollerCode,
+        wide=true,
+      )
+    })
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let sonner_component = if selected == "" || selected == "sonner" {
+    sonner_default_view.view4(
+      sonner_success_view, sonner_destructive_view, sonner_queue_view, ig_sonner_component,
+    )
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let resizable_component = if selected == "" || selected == "resizable" {
+    resizable_view.view2(resizable_panel_view, ig_resizable_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  let scroll_component = if selected == "" || selected == "scroll-area" {
+    scroll_view.view2(scroll_horizontal_view, ig_scroll_area_component)
+  } else {
+    showcase_static_page(@html.nothing)
+  }
+  sonner_component.view4(
+    scroller_variants,
+    resizable_component,
+    scroll_component,
+    (sonner_html, scroller_html, resizable_html, scroll_html) => {
+      @html.section(
+        id="feedback",
+        style=[IgComponentListStyle, "scroll-margin-top:1rem"],
+        [
+          sonner_html,
+          if selected == "" || selected == "toast" {
+            ig_toast_component()
+          } else {
+            @html.nothing
+          },
+          scroller_html,
+          resizable_html,
+          scroll_html,
+        ],
+      )
+    },
+  )
+}
+
+///|
+fn ig_feedback_section() -> @rabbita.Val[@html.Html] {
+  ig_feedback_page("")
+}

--- a/website/homepage/components/moon.pkg
+++ b/website/homepage/components/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/clipboard",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/svg",
+  "Yoorkin/rui",
+  "Yoorkin/shiki",
+}
+
+supported_targets = "js"

--- a/website/homepage/components/page.mbt
+++ b/website/homepage/components/page.mbt
@@ -1,0 +1,271 @@
+///|
+const PageStyle : String = "flex:1;min-height:calc(100vh - var(--nav-h,60px));padding:2rem 0 4rem;background:var(--rui-background);color:var(--rui-foreground)"
+
+///|
+const ShellStyle : String = "box-sizing:border-box;width:100%;max-width:1232px;margin-inline:auto;padding-inline:1.25rem"
+
+///|
+const StackStyle : String = "display:flex;flex-direction:column;gap:1rem"
+
+///|
+const RowStyle : String = "display:flex;flex-wrap:wrap;align-items:center;gap:0.75rem"
+
+///|
+const ControlRowStyle : String = "display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem"
+
+///|
+const MutedStyle : String = "color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.35"
+
+///|
+const CatalogLayoutStyle : String = "display:grid;grid-template-columns:var(--rui-showcase-catalog-columns,13rem minmax(0,1fr));align-items:start;gap:clamp(1.5rem,3vw,2.5rem)"
+
+///|
+const CatalogRailStyle : String = "box-sizing:border-box;position:var(--rui-showcase-rail-position,sticky);top:calc(var(--nav-h,60px) + 1rem);width:100%;max-width:var(--rui-showcase-rail-max-width,13rem);max-height:var(--rui-showcase-rail-max-height,calc(100vh - var(--nav-h,60px) - 2rem));min-width:0;overflow:auto;padding-block:0.25rem;padding-inline:0.25rem 1rem;scrollbar-width:thin"
+
+///|
+const CatalogRailNavStyle : String = "display:flex;min-width:0;flex-direction:var(--rui-showcase-rail-direction,column);gap:0.125rem"
+
+///|
+const CatalogMainStyle : String = "min-width:0"
+
+///|
+const RailLinkStyle : String = "display:block;padding:0.325rem 0;color:var(--rui-muted-foreground);font-size:0.8125rem;line-height:1.2rem;text-decoration:none"
+
+///|
+const CatalogRailLinkStyle : String = "box-sizing:border-box;display:flex;width:fit-content;max-width:100%;min-height:2rem;align-items:center;padding:0.375rem 0.625rem;border-radius:0.5rem;white-space:nowrap"
+
+///|
+const ActiveRailLinkStyle : String = "color:var(--rui-foreground);font-weight:500"
+
+///|
+const MobileCatalogStyle : String = "display:none;min-width:0"
+
+///|
+const MobileCatalogDetailsStyle : String = "box-sizing:border-box;width:100%;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) - 0.125rem);background:var(--rui-background);overflow:hidden"
+
+///|
+const MobileCatalogSummaryStyle : String = "box-sizing:border-box;display:flex;min-height:2.75rem;align-items:center;justify-content:space-between;gap:0.75rem;padding:0.625rem 0.75rem;color:var(--rui-foreground);font-size:0.875rem;font-weight:600;line-height:1.25rem;cursor:pointer;list-style:none"
+
+///|
+const MobileCatalogNavStyle : String = "box-sizing:border-box;display:grid;max-height:min(22rem,60vh);grid-template-columns:repeat(auto-fit,minmax(9rem,1fr));gap:0.125rem;overflow:auto;border-top:1px solid var(--rui-border);padding:0.5rem"
+
+///|
+const MissingPageStyle : String = "box-sizing:border-box;display:flex;min-height:24rem;flex-direction:column;align-items:flex-start;justify-content:center;gap:0.75rem"
+
+///|
+#cfg(target="js")
+extern "js" fn showcase_local_href(hash : String) -> String =
+  #| hash => `${globalThis.location?.pathname || "/"}${globalThis.location?.search || ""}${hash}`
+
+///|
+#cfg(not(target="js"))
+fn showcase_local_href(hash : String) -> String {
+  hash
+}
+
+///|
+fn rail_link(
+  href : String,
+  label : String,
+  style? : String = RailLinkStyle,
+) -> @html.Html {
+  @html.a(
+    href=showcase_local_href(href),
+    class="rui-showcase-rail-link",
+    style=[style],
+    label,
+  )
+}
+
+///|
+fn showcase_catalog_link(
+  entry : ShowcasePageEntry,
+  current_slug : String,
+) -> @html.Html {
+  let active = entry.slug == current_slug
+  let attrs = @html.Attrs::build()
+  if active {
+    ignore(attrs.aria_current("page"))
+  }
+  @html.a(
+    href=showcase_page_href(entry.slug),
+    class=if active {
+      "rui-showcase-rail-link rui-showcase-rail-link--active"
+    } else {
+      "rui-showcase-rail-link"
+    },
+    attrs~,
+    style=[
+      RailLinkStyle,
+      CatalogRailLinkStyle,
+      if active {
+        ActiveRailLinkStyle
+      } else {
+        ""
+      },
+    ],
+    entry.title,
+  )
+}
+
+///|
+fn showcase_mobile_catalog(current_slug : String) -> @html.Html {
+  @html.aside(
+    class="rui-showcase-mobile-catalog",
+    style=[MobileCatalogStyle],
+    @html.details(style=[MobileCatalogDetailsStyle], [
+      @html.summary(
+        class="rui-showcase-mobile-catalog-summary",
+        style=[MobileCatalogSummaryStyle],
+        [
+          @html.span(showcase_page_title(current_slug)),
+          showcase_chevron_right_icon(),
+        ],
+      ),
+      @html.nav(
+        attrs=@html.Attrs::build().aria_label("Component catalogue"),
+        style=[MobileCatalogNavStyle],
+        [
+          for entry in showcase_page_entries => {
+            showcase_catalog_link(entry, current_slug)
+          }
+        ],
+      ),
+    ]),
+  )
+}
+
+///|
+fn showcase_missing_page(slug : String) -> @html.Html {
+  @html.section(style=[MissingPageStyle], [
+    @html.h1(
+      style=["margin:0;font-size:1.75rem;line-height:1.2"],
+      "Component not found",
+    ),
+    @html.p(
+      style=["margin:0;color:var(--rui-muted-foreground)"],
+      "There is no component page for “\{slug}”.",
+    ),
+    @html.a(
+      href=showcase_page_href(showcase_default_page_slug()),
+      class="rui-showcase-page-navigation-link",
+      style=[ShowcasePageNavigationLinkStyle, "min-height:2.25rem;width:auto"],
+      "Open Accordion",
+    ),
+  ])
+}
+
+///|
+fn showcase_component_page(slug : String) -> @rabbita.Val[@html.Html] {
+  match slug {
+    "alert"
+    | "aspect-ratio"
+    | "attachment"
+    | "avatar"
+    | "badge"
+    | "bubble"
+    | "button"
+    | "button-group"
+    | "card"
+    | "chart"
+    | "data-table"
+    | "direction"
+    | "empty"
+    | "item"
+    | "kbd"
+    | "label"
+    | "marker"
+    | "message"
+    | "progress"
+    | "separator"
+    | "skeleton"
+    | "spinner"
+    | "table"
+    | "toggle"
+    | "toggle-group"
+    | "typography" => showcase_foundations_page(slug)
+    "calendar"
+    | "checkbox"
+    | "combobox"
+    | "date-picker"
+    | "field"
+    | "input"
+    | "input-group"
+    | "input-otp"
+    | "native-select"
+    | "radio-group"
+    | "select"
+    | "slider"
+    | "switch"
+    | "textarea" => showcase_forms_page(slug)
+    "accordion"
+    | "breadcrumb"
+    | "carousel"
+    | "collapsible"
+    | "navigation-menu"
+    | "pagination"
+    | "sidebar"
+    | "tabs" => ig_navigation_page(slug)
+    "alert-dialog"
+    | "command"
+    | "context-menu"
+    | "dialog"
+    | "drawer"
+    | "dropdown-menu"
+    | "hover-card"
+    | "menubar"
+    | "popover"
+    | "sheet"
+    | "tooltip" => ig_overlay_page(slug)
+    "message-scroller" | "resizable" | "scroll-area" | "sonner" | "toast" =>
+      ig_feedback_page(slug)
+    _ => showcase_static_page(showcase_missing_page(slug))
+  }
+}
+
+///|
+fn showcase_view(
+  dark : Bool,
+  current_slug : String,
+  component : @html.Html,
+) -> @html.Html {
+  let mode = if dark { @rui.Dark } else { @rui.Light }
+  @rui.theme(
+    mode~,
+    id="rui-showcase",
+    style=[PageStyle],
+    @html.main_(style=[ShellStyle], [
+      @html.div(style=[CatalogLayoutStyle], [
+        @html.aside(class="rui-showcase-catalog", style=[CatalogRailStyle], [
+          @html.nav(
+            class="rui-showcase-catalog-nav",
+            attrs=@html.Attrs::build().aria_label("Component catalogue"),
+            style=[CatalogRailNavStyle],
+            [
+              for entry in showcase_page_entries => {
+                showcase_catalog_link(entry, current_slug)
+              }
+            ],
+          ),
+        ]),
+        showcase_mobile_catalog(current_slug),
+        @html.div(
+          class="rui-showcase-current-page",
+          style=[CatalogMainStyle],
+          component,
+        ),
+      ]),
+    ]),
+  )
+}
+
+///|
+pub fn components_page(
+  dark : @rabbita.Val[Bool],
+  slug : String,
+) -> @rabbita.Val[@html.Html] {
+  let component = showcase_component_page(slug)
+  dark.view2(component, (dark, component) => {
+    showcase_view(dark, slug, component)
+  })
+}

--- a/website/homepage/components/pkg.generated.mbti
+++ b/website/homepage/components/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "rabbita/website/components"
+
+import {
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+}
+
+// Values
+pub fn components_page(@rabbita.Val[Bool], String) -> @rabbita.Val[@html.Html]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/website/homepage/components/showcase_component_shell.mbt
+++ b/website/homepage/components/showcase_component_shell.mbt
@@ -1,0 +1,454 @@
+///|
+const ShowcaseComponentShellStyle : String = "box-sizing:border-box;display:grid;width:100%;min-width:0;grid-template-columns:var(--rui-showcase-component-columns,minmax(0,46rem) 11rem);justify-content:center;align-items:start;column-gap:clamp(2rem,3vw,3rem);grid-column:1 / -1;scroll-margin-top:calc(var(--nav-h,60px) + 1rem)"
+
+///|
+const ShowcaseComponentMainStyle : String = "box-sizing:border-box;display:flex;width:100%;min-width:0;flex-direction:column;gap:1rem"
+
+///|
+const ShowcasePageNavigationStyle : String = "box-sizing:border-box;display:grid;width:100%;grid-template-columns:minmax(0,1fr) minmax(0,1fr);align-items:stretch;gap:0.75rem"
+
+///|
+const ShowcasePageNavigationLinkStyle : String = "box-sizing:border-box;display:flex;min-width:0;min-height:3.25rem;align-items:center;gap:0.625rem;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) - 0.125rem);background:var(--rui-background);padding:0.625rem 0.75rem;color:var(--rui-foreground);box-shadow:0 1px 2px rgb(0 0 0 / 0.04);text-decoration:none;outline:none;transition:background-color 150ms ease,border-color 150ms ease,box-shadow 150ms ease"
+
+///|
+const ShowcasePageNavigationNextStyle : String = "grid-column:2;justify-content:flex-end;text-align:end"
+
+///|
+const ShowcasePageNavigationTextStyle : String = "display:flex;min-width:0;flex-direction:column;gap:0.125rem"
+
+///|
+const ShowcasePageNavigationDirectionStyle : String = "color:var(--rui-muted-foreground);font-size:0.6875rem;line-height:1rem"
+
+///|
+const ShowcasePageNavigationTitleStyle : String = "min-width:0;overflow:hidden;font-size:0.8125rem;font-weight:600;line-height:1.125rem;text-overflow:ellipsis;white-space:nowrap"
+
+///|
+const ShowcaseComponentHeaderStyle : String = "box-sizing:border-box;display:flex;width:100%;min-width:0;flex-direction:column;align-items:flex-start;gap:0.375rem;margin:0;text-align:start"
+
+///|
+const ShowcaseComponentTitleStyle : String = "margin:0;font-size:clamp(1.375rem,2vw,1.75rem);line-height:1.2;font-weight:650;letter-spacing:-0.035em"
+
+///|
+const ShowcaseComponentDescriptionStyle : String = "max-width:42rem;margin:0;color:var(--rui-muted-foreground);font-size:0.9375rem;line-height:1.55"
+
+///|
+const ShowcaseComponentTocStyle : String = "position:sticky;top:calc(var(--nav-h,60px) + 1rem);min-width:0;padding-left:1rem;border-left:1px solid var(--rui-border)"
+
+///|
+const ShowcaseComponentTocLinkStyle : String = "display:block;padding:0.35rem 0;color:var(--rui-muted-foreground);font-size:0.75rem;line-height:1.2rem;text-decoration:none"
+
+///|
+priv enum ShowcaseStageVariant {
+  ShowcaseStagePlain
+  ShowcaseStageSurface
+}
+
+///|
+priv enum ShowcasePreparedStage {
+  PreparedShowcaseStage(@html.Html)
+}
+
+///|
+priv enum ShowcaseDemoEntry {
+  NamedShowcaseDemo(String, String, @html.Html)
+}
+
+///|
+const ShowcaseComponentStageBodyStyle : String = "width:100%;min-width:0"
+
+///|
+const ShowcaseDemoListStyle : String = "box-sizing:border-box;display:flex;width:100%;min-width:0;flex-direction:column;gap:2.5rem"
+
+///|
+const ShowcaseDemoSectionStyle : String = "box-sizing:border-box;display:flex;width:100%;min-width:0;flex-direction:column;gap:1rem"
+
+///|
+const ShowcaseDemoSectionHeaderStyle : String = "box-sizing:border-box;display:flex;width:100%;min-width:0;flex-direction:column;align-items:flex-start;gap:0.375rem;margin:0;text-align:start"
+
+///|
+const ShowcaseDemoSectionTitleStyle : String = "margin:0;font-size:1.125rem;line-height:1.5rem;font-weight:650;letter-spacing:-0.02em"
+
+///|
+const ShowcaseDemoSectionDescriptionStyle : String = "max-width:42rem;margin:0;color:var(--rui-muted-foreground);font-size:0.875rem;line-height:1.5"
+
+///|
+const ShowcaseDemoFrameStyle : String = "box-sizing:border-box;width:100%;min-width:0;overflow:hidden;border:1px solid var(--rui-border);border-radius:calc(var(--rui-radius) + 0.375rem);background:var(--rui-background)"
+
+///|
+const ShowcaseDemoPreviewStyle : String = "box-sizing:border-box;display:flex;width:100%;min-width:0;min-height:var(--rui-showcase-stage-min-height,16rem);align-items:center;justify-content:center;padding:clamp(1.25rem,4vw,2.5rem)"
+
+///|
+const ShowcaseDemoPlainStyle : String = "background:var(--rui-background)"
+
+///|
+const ShowcaseDemoSurfaceStyle : String = "background:light-dark(color-mix(in oklab,var(--rui-muted) 35%,var(--rui-background)),var(--rui-background))"
+
+///|
+const ShowcaseDemoCodeStyle : String = "--rui-showcase-code-background:light-dark(color-mix(in oklab,var(--rui-muted) 65%,var(--rui-background)),var(--rui-card));border-top:1px solid var(--rui-border);background:var(--rui-showcase-code-background)"
+
+///|
+const ShowcaseDemoCodePeekStyle : String = "box-sizing:border-box;margin:0;overflow:hidden"
+
+///|
+const ShowcaseDemoCodePanelStyle : String = "position:absolute;inset:0 0 auto auto;z-index:3;width:4rem;height:3.25rem;pointer-events:none"
+
+///|
+const ShowcaseDemoCodeScrollStyle : String = "overflow-x:auto"
+
+///|
+const ShowcaseDemoCodeCopyStyle : String = "position:absolute;top:0.75rem;right:1rem;z-index:3;width:1.75rem;height:1.75rem;min-width:1.75rem;min-height:1.75rem;pointer-events:auto;--rui-button-base-bg:var(--rui-showcase-code-background);--rui-control-radius:0.375rem"
+
+///|
+const ShowcaseDemoCodeExpandedStyle : String = "max-height:none;overflow:visible"
+
+///|
+const ShowcaseDemoCodeReadableStyle : String = "pointer-events:auto;user-select:text"
+
+///|
+fn showcase_anchor(value : String) -> String {
+  let builder = StringBuilder::new()
+  let mut separator = false
+  for character in value {
+    match character {
+      'A'..='Z' | 'a'..='z' | '0'..='9' => {
+        if separator && !builder.is_empty() {
+          builder.write_char('-')
+        }
+        builder.write_char(character)
+        separator = false
+      }
+      _ => if !builder.is_empty() { separator = true }
+    }
+  }
+  let anchor = builder.to_string()
+  if anchor == "" {
+    "component"
+  } else {
+    anchor
+  }
+}
+
+///|
+fn showcase_highlighted_code(code : String) -> @html.Html {
+  @shiki.static_code(
+    code,
+    lang="moonbit",
+    light_theme="github-light",
+    dark_theme="github-dark-default",
+  )
+}
+
+///|
+fn showcase_component_anchor(title : String) -> String {
+  "component-\{showcase_anchor(title)}"
+}
+
+///|
+fn showcase_code_line_count(code : String) -> Int {
+  let mut count = 1
+  let mut ends_with_newline = false
+  for character in code {
+    ends_with_newline = character == '\n'
+    if character == '\n' {
+      count += 1
+    }
+  }
+  if ends_with_newline && count > 1 {
+    count - 1
+  } else {
+    count
+  }
+}
+
+///|
+fn showcase_code_copy_panel(code : String) -> @html.Html {
+  @html.div(
+    class="rui-showcase-demo-code-panel",
+    style=[ShowcaseDemoCodePanelStyle],
+    @rui.button(
+      variant=@rui.Ghost,
+      size=@rui.IconSm,
+      class="rui-showcase-demo-code-copy",
+      title="Copy code",
+      attrs=@html.Attrs::build().aria_label("Copy code"),
+      style=[ShowcaseDemoCodeCopyStyle],
+      on_click=@clipboard.copy(@clipboard.Text(code)),
+      showcase_copy_icon(),
+    ),
+  )
+}
+
+///|
+fn showcase_component_header(
+  title : String,
+  description : String,
+) -> @html.Html {
+  @html.header(
+    class="rui-showcase-component-header",
+    style=[ShowcaseComponentHeaderStyle],
+    [
+      @html.h1(
+        class="rui-showcase-component-title",
+        style=[ShowcaseComponentTitleStyle],
+        title,
+      ),
+      @html.p(style=[ShowcaseComponentDescriptionStyle], description),
+    ],
+  )
+}
+
+///|
+fn showcase_page_navigation_link(
+  entry : ShowcasePageEntry,
+  next : Bool,
+) -> @html.Html {
+  let direction = if next { "Next" } else { "Previous" }
+  let text = @html.span(style=[ShowcasePageNavigationTextStyle], [
+    @html.span(style=[ShowcasePageNavigationDirectionStyle], direction),
+    @html.span(style=[ShowcasePageNavigationTitleStyle], entry.title),
+  ])
+  @html.a(
+    href=showcase_page_href(entry.slug),
+    class=if next {
+      "rui-showcase-page-navigation-link rui-showcase-page-navigation-link--next"
+    } else {
+      "rui-showcase-page-navigation-link rui-showcase-page-navigation-link--previous"
+    },
+    attrs=@html.Attrs::build().aria_label("\{direction}: \{entry.title}"),
+    style=[
+      ShowcasePageNavigationLinkStyle,
+      if next {
+        ShowcasePageNavigationNextStyle
+      } else {
+        ""
+      },
+    ],
+    if next {
+      [text, showcase_chevron_right_icon()]
+    } else {
+      [showcase_chevron_left_icon(), text]
+    },
+  )
+}
+
+///|
+fn showcase_component_page_navigation(title : String) -> @html.Html {
+  let index = showcase_page_index_by_title(title)
+  @html.nav(
+    class="rui-showcase-page-navigation",
+    attrs=@html.Attrs::build().aria_label("Component pages"),
+    style=[ShowcasePageNavigationStyle],
+    [
+      if index > 0 {
+        showcase_page_navigation_link(showcase_page_entries[index - 1], false)
+      } else {
+        @html.nothing
+      },
+      if index >= 0 && index + 1 < showcase_page_entries.length() {
+        showcase_page_navigation_link(showcase_page_entries[index + 1], true)
+      } else {
+        @html.nothing
+      },
+    ],
+  )
+}
+
+///|
+fn showcase_stage(
+  body : @html.Html,
+  code : String,
+  variant? : ShowcaseStageVariant = ShowcaseStagePlain,
+  tall? : Bool = false,
+  stage_style? : String = "",
+) -> @html.Html {
+  let highlighted_code = showcase_highlighted_code(code)
+  let show_full_code = showcase_code_line_count(code) < 5
+  let preview_styles = [
+    ShowcaseDemoPreviewStyle,
+    if tall {
+      "--rui-showcase-stage-min-height:22rem"
+    } else {
+      ""
+    },
+    match variant {
+      ShowcaseStagePlain => ShowcaseDemoPlainStyle
+      ShowcaseStageSurface => ShowcaseDemoSurfaceStyle
+    },
+    stage_style,
+  ]
+  @html.div(class="rui-showcase-demo-stage", style=[ShowcaseDemoFrameStyle], [
+    @html.div(
+      class="rui-showcase-demo-preview",
+      style=preview_styles,
+      @html.div(style=[ShowcaseComponentStageBodyStyle], body),
+    ),
+    @html.div(
+      class=if show_full_code {
+        "rui-showcase-demo-code rui-showcase-demo-code--expanded"
+      } else {
+        "rui-showcase-demo-code"
+      },
+      style=[
+        ShowcaseDemoCodeStyle,
+        if show_full_code {
+          ShowcaseDemoCodeExpandedStyle
+        } else {
+          ""
+        },
+      ],
+      [
+        @html.div(
+          class="rui-showcase-shiki rui-showcase-demo-code-peek rui-showcase-demo-code-scroll",
+          style=[
+            ShowcaseDemoCodePeekStyle,
+            ShowcaseDemoCodeScrollStyle,
+            if show_full_code {
+              ShowcaseDemoCodeReadableStyle
+            } else {
+              ""
+            },
+          ],
+          highlighted_code,
+        ),
+        if show_full_code {
+          showcase_code_copy_panel(code)
+        } else {
+          @html.details(class="rui-showcase-demo-code-disclosure", [
+            @html.summary(class="rui-showcase-demo-code-summary", [
+              @html.span(class="rui-showcase-demo-code-toggle", "View Code"),
+            ]),
+            showcase_code_copy_panel(code),
+          ])
+        },
+      ],
+    ),
+  ])
+}
+
+///|
+fn showcase_demo_stage(
+  body : @html.Html,
+  code : String,
+  variant? : ShowcaseStageVariant = ShowcaseStageSurface,
+  tall? : Bool = false,
+  stage_style? : String = "",
+) -> ShowcasePreparedStage {
+  PreparedShowcaseStage(
+    showcase_stage(body, code, variant~, tall~, stage_style~),
+  )
+}
+
+///|
+fn showcase_demo_section(
+  title : String,
+  description : String,
+  stage : ShowcasePreparedStage,
+) -> ShowcaseDemoEntry {
+  let stage_html = match stage {
+    PreparedShowcaseStage(stage_html) => stage_html
+  }
+  NamedShowcaseDemo(title, description, stage_html)
+}
+
+///|
+fn showcase_demo_entry_id(
+  component_id : String,
+  entry : ShowcaseDemoEntry,
+) -> String {
+  match entry {
+    NamedShowcaseDemo(title, _, _) =>
+      "\{component_id}--\{showcase_anchor(title)}"
+  }
+}
+
+///|
+fn showcase_demo_entry_label(entry : ShowcaseDemoEntry) -> String {
+  match entry {
+    NamedShowcaseDemo(title, _, _) => title
+  }
+}
+
+///|
+fn showcase_demo_entry_view(
+  component_id : String,
+  entry : ShowcaseDemoEntry,
+) -> @html.Html {
+  let id = showcase_demo_entry_id(component_id, entry)
+  match entry {
+    NamedShowcaseDemo(title, description, stage) =>
+      @html.section(
+        id~,
+        class="rui-showcase-demo-section",
+        style=[ShowcaseDemoSectionStyle],
+        [
+          @html.header(
+            class="rui-showcase-demo-section-header",
+            style=[ShowcaseDemoSectionHeaderStyle],
+            [
+              @html.h2(style=[ShowcaseDemoSectionTitleStyle], title),
+              @html.p(style=[ShowcaseDemoSectionDescriptionStyle], description),
+            ],
+          ),
+          stage,
+        ],
+      )
+  }
+}
+
+///|
+fn showcase_component_toc(
+  title : String,
+  component_id : String,
+  entries : Array[ShowcaseDemoEntry],
+) -> @html.Html {
+  @html.aside(
+    class="rui-showcase-component-toc",
+    style=[ShowcaseComponentTocStyle],
+    [
+      @html.nav(
+        attrs=@html.Attrs::build().aria_label("\{title} variants"),
+        [
+          for entry in entries => {
+            rail_link(
+              "#\{showcase_demo_entry_id(component_id, entry)}",
+              showcase_demo_entry_label(entry),
+              style=ShowcaseComponentTocLinkStyle,
+            )
+          }
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+fn showcase_component_demos(
+  title : String,
+  description : String,
+  demos : Array[ShowcaseDemoEntry],
+) -> @html.Html {
+  let component_id = showcase_component_anchor(title)
+  @html.section(
+    id=component_id,
+    class="rui-showcase-component",
+    style=[ShowcaseComponentShellStyle],
+    [
+      @html.div(
+        class="rui-showcase-component-main",
+        style=[ShowcaseComponentMainStyle],
+        [
+          showcase_component_page_navigation(title),
+          showcase_component_header(title, description),
+          @html.div(
+            style=[ShowcaseDemoListStyle],
+            [
+              for demo in demos => showcase_demo_entry_view(component_id, demo)
+            ],
+          ),
+          showcase_component_page_navigation(title),
+        ],
+      ),
+      showcase_component_toc(title, component_id, demos),
+    ],
+  )
+}

--- a/website/homepage/components/showcase_component_shell_wbtest.mbt
+++ b/website/homepage/components/showcase_component_shell_wbtest.mbt
@@ -1,0 +1,1021 @@
+///|
+#warnings("-alert_unstable")
+fn render_showcase_stage(html : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+}
+
+///|
+#cfg(target="js")
+extern "js" fn install_showcase_incremental_test_window() =
+  #| () => {
+  #|   if (typeof globalThis.window === "undefined") {
+  #|     globalThis.window = { requestAnimationFrame: () => 0 };
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+#warnings("-alert_unstable")
+fn render_showcase_incremental(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  install_showcase_incremental_test_window()
+  ignore(@rabbita.new(builder))
+  @rabbita.render_to_string(builder)
+}
+
+///|
+#cfg(not(target="js"))
+#warnings("-alert_unstable")
+fn render_showcase_incremental(
+  builder : () -> @rabbita.Val[@html.Html],
+) -> String {
+  @rabbita.render_to_string(builder)
+}
+
+///|
+fn assert_showcase_stage_contains(
+  actual : String,
+  expected : String,
+) -> Unit raise {
+  if !actual.contains(expected) {
+    fail("expected showcase stage HTML to contain `\{expected}`")
+  }
+}
+
+///|
+fn showcase_component_fragment(
+  html : String,
+  component_id : String,
+  next_component_id : String,
+) -> String raise {
+  let component_marker = "id=\"\{component_id}\""
+  let next_component_marker = "id=\"\{next_component_id}\""
+  if html.split(component_marker).to_array() is [_, component_and_rest] {
+    if component_and_rest.split(next_component_marker).to_array()
+      is [component, _] {
+      component.to_owned()
+    } else {
+      fail("expected showcase HTML to contain component `\{next_component_id}`")
+    }
+  } else {
+    fail("expected showcase HTML to contain component `\{component_id}`")
+  }
+}
+
+///|
+fn showcase_component_tail(
+  html : String,
+  component_id : String,
+) -> String raise {
+  let component_marker = "id=\"\{component_id}\""
+  if html.split(component_marker).to_array() is [_, component_and_rest] {
+    component_and_rest.to_owned()
+  } else {
+    fail("expected showcase HTML to contain component `\{component_id}`")
+  }
+}
+
+///|
+fn assert_showcase_component_stages(
+  html : String,
+  component_id : String,
+  expected_stage_ids : Array[String],
+) -> Unit raise {
+  let expected_count = expected_stage_ids.length()
+  assert_eq(
+    html.split("class=\"rui-showcase-demo-section\"").count(),
+    expected_count + 1,
+  )
+  assert_eq(
+    html.split("class=\"rui-showcase-demo-stage\"").count(),
+    expected_count + 1,
+  )
+  assert_eq(html.split("aria-label=\"Copy code\"").count(), expected_count + 1)
+  assert_eq(
+    html.split("class=\"rui-showcase-rail-link\"").count(),
+    expected_count + 1,
+  )
+  assert_eq(html.split("id=\"\{component_id}--").count(), expected_count + 1)
+  for stage_id in expected_stage_ids {
+    assert_showcase_stage_contains(html, "id=\"\{component_id}--\{stage_id}\"")
+    assert_showcase_stage_contains(html, "#\{component_id}--\{stage_id}")
+  }
+}
+
+///|
+fn assert_menu_showcase_component(
+  html : String,
+  component_id : String,
+  expected_stage_ids : Array[String],
+) -> Unit raise {
+  assert_showcase_component_stages(html, component_id, expected_stage_ids)
+  if html.contains("padding-inline-start:2rem") {
+    fail("menu showcase `\{component_id}` must not render inset menu items")
+  }
+}
+
+///|
+test "short showcase code stays expanded and keeps its copy action" {
+  let html = render_showcase_stage(
+    showcase_stage(@html.span("Demo"), "@rui.button(\"Save\")\n"),
+  )
+  for
+    expected in [
+      "rui-showcase-demo-code--expanded", "rui-showcase-demo-code-panel", "rui-showcase-demo-code-scroll",
+      "rui-showcase-demo-code-copy", "aria-label=\"Copy code\"", "title=\"Copy code\"",
+      "type=\"button\"", "overflow-x:auto", "@rui.button",
+    ] {
+    assert_showcase_stage_contains(html, expected)
+  }
+  if html.contains("View Code") ||
+    html.contains("rui-showcase-demo-code-summary") ||
+    html.contains("Hide Code") ||
+    html.contains("rui-showcase-demo-code-hide") ||
+    html.contains("max-height:18rem") {
+    fail(
+      "short showcase code must remain fully visible without a disclosure control",
+    )
+  }
+}
+
+///|
+test "five-line showcase code uses one-way reveal and copy action" {
+  let html = render_showcase_stage(
+    showcase_stage(@html.span("Demo"), "one\ntwo\nthree\nfour\nfive"),
+  )
+  for
+    expected in [
+      "rui-showcase-demo-code-summary", "View Code", "rui-showcase-demo-code-panel",
+      "rui-showcase-demo-code-copy", "aria-label=\"Copy code\"",
+    ] {
+    assert_showcase_stage_contains(html, expected)
+  }
+  if html.contains("rui-showcase-demo-code--expanded") {
+    fail("five-line showcase code must keep the disclosure")
+  }
+}
+
+///|
+test "catalog rail reserves a focus-ring gutter" {
+  assert_showcase_stage_contains(CatalogRailStyle, "padding-block:0.25rem")
+  assert_showcase_stage_contains(
+    CatalogRailStyle,
+    "padding-inline:0.25rem 1rem",
+  )
+  assert_showcase_stage_contains(
+    CatalogRailLinkStyle,
+    "padding:0.375rem 0.625rem",
+  )
+  assert_showcase_stage_contains(CatalogRailLinkStyle, "width:fit-content")
+}
+
+///|
+test "sidebar variants render as independent full-stage examples" {
+  let html = render_showcase_stage(
+    ig_sidebar_component(
+      @html.span("default-demo"),
+      @html.span("fixed-demo"),
+      @html.span("icon-demo"),
+      @html.span("loading-demo"),
+      @html.span("floating-demo"),
+      @html.span("inset-demo"),
+      @html.span("right-demo"),
+      @html.span("resize-demo"),
+      @html.span("mobile-demo"),
+    ),
+  )
+  assert_showcase_component_stages(html, "component-Sidebar", [
+    "Default", "Fixed", "Icon-collapse", "Loading", "Floating", "Inset", "Right-side",
+    "Resize", "Mobile",
+  ])
+  for
+    expected in [
+      "default-demo", "fixed-demo", "icon-demo", "loading-demo", "floating-demo",
+      "inset-demo", "right-demo", "resize-demo", "mobile-demo", "padding:0",
+    ] {
+    assert_showcase_stage_contains(html, expected)
+  }
+}
+
+///|
+test "sidebar stages render the intended public API compositions" {
+  let html = render_showcase_incremental(ig_navigation_section)
+  let sidebar_html = showcase_component_tail(html, "component-Sidebar")
+  for
+    expected in [
+      "showcase-sidebar-default", "showcase-sidebar-fixed", "showcase-sidebar-icon",
+      "showcase-sidebar-loading", "showcase-sidebar-floating", "showcase-sidebar-inset",
+      "showcase-sidebar-right", "showcase-sidebar-resize", "showcase-sidebar-mobile",
+      "M15 3v18", "min_width=192", "mobile=true", "SidebarMenuSm", "SidebarMenuLg",
+      "data-slot=\"sidebar-group-action\"", "data-slot=\"sidebar-menu-skeleton\"",
+    ] {
+    assert_showcase_stage_contains(sidebar_html, expected)
+  }
+  assert_eq(sidebar_html.split("data-slot=\"sidebar-wrapper\"").count(), 10)
+  assert_eq(sidebar_html.split("data-slot=\"sidebar-inset\"").count(), 2)
+  assert_eq(sidebar_html.split("role=\"main\"").count(), 2)
+}
+
+///|
+test "sidebar code belongs to one variant and only inset uses sidebar_inset" {
+  let examples = [
+    (IgSidebarDefaultCode, "showcase-sidebar-default"),
+    (IgSidebarFixedCode, "showcase-sidebar-fixed"),
+    (IgSidebarIconCode, "showcase-sidebar-icon"),
+    (IgSidebarLoadingCode, "showcase-sidebar-loading"),
+    (IgSidebarFloatingCode, "showcase-sidebar-floating"),
+    (IgSidebarRightCode, "showcase-sidebar-right"),
+    (IgSidebarResizeCode, "showcase-sidebar-resize"),
+    (IgSidebarMobileCode, "showcase-sidebar-mobile"),
+  ]
+  for example in examples {
+    let (code, id) = example
+    assert_showcase_stage_contains(code, id)
+    if code.contains("sidebar_inset") || code.contains("sidebar_variant(") {
+      fail("non-inset sidebar code must contain only its rendered composition")
+    }
+  }
+  assert_showcase_stage_contains(IgSidebarInsetCode, "showcase-sidebar-inset")
+  assert_showcase_stage_contains(IgSidebarInsetCode, "@rui.sidebar_inset")
+  assert_showcase_stage_contains(IgSidebarRightCode, "panel_right_icon()")
+  assert_showcase_stage_contains(IgSidebarResizeCode, "min_width=192")
+  assert_showcase_stage_contains(IgSidebarResizeCode, "max_width=352")
+  assert_showcase_stage_contains(IgSidebarMobileCode, "mobile=true")
+  assert_showcase_stage_contains(IgSidebarFixedCode, "SidebarFixed")
+  assert_showcase_stage_contains(IgSidebarFixedCode, "SidebarMenuSm")
+  assert_showcase_stage_contains(IgSidebarFloatingCode, "SidebarMenuLg")
+  assert_showcase_stage_contains(
+    IgSidebarSharedCode,
+    "sidebar_menu_skeleton(show_icon=true)",
+  )
+  assert_showcase_stage_contains(
+    IgSidebarLoadingCode,
+    "sidebar_loading_navigation()",
+  )
+  if IgSidebarFixedCode.contains("sidebar_trigger") ||
+    IgSidebarFixedCode.contains("sidebar_rail") {
+    fail("fixed sidebar code must not advertise controls that cannot change it")
+  }
+  assert_showcase_stage_contains(IgSidebarSharedCode, "on_click=close_command")
+  assert_showcase_stage_contains(
+    IgSidebarSharedCode,
+    "@rui.sidebar_menu_button(href=\"#projects\"",
+  )
+  assert_showcase_stage_contains(
+    IgSidebarSharedCode,
+    "Projects and longer workspace names",
+  )
+  assert_showcase_stage_contains(IgSidebarSharedCode, "@rui.sidebar_menu_sub")
+  assert_eq(IgSidebarSharedCode.split("is_active=true").count(), 2)
+  if IgSidebarVariantFrameStyle.contains("border:") ||
+    IgSidebarVariantFrameStyle.contains("border-radius:") {
+    fail(
+      "sidebar provider must not draw a second frame inside the showcase stage",
+    )
+  }
+}
+
+///|
+test "fixed sidebar specimen omits ineffective controls" {
+  let html = render_showcase_incremental(() => {
+    ig_sidebar_variant(
+      "showcase-sidebar-fixed-test",
+      @rui.SidebarLeft,
+      @rui.SidebarDefault,
+      @rui.SidebarFixed,
+      false,
+      @rui.SidebarMenuDefault,
+      false,
+      false,
+      false,
+    )
+  })
+  for slot in ["sidebar-trigger", "sidebar-rail", "sidebar-menu-action"] {
+    if html.contains("data-slot=\"\{slot}\"") {
+      fail(
+        "fixed sidebar specimen must not render ineffective `\{slot}` controls",
+      )
+    }
+  }
+}
+
+///|
+test "pagination and carousel variants render as independent stages" {
+  let html = render_showcase_incremental(ig_navigation_section)
+  let pagination_html = showcase_component_fragment(
+    html, "component-Pagination", "component-Carousel",
+  )
+  let carousel_html = showcase_component_fragment(
+    html, "component-Carousel", "component-Navigation-Menu",
+  )
+  assert_showcase_component_stages(pagination_html, "component-Pagination", [
+    "Default", "Compact",
+  ])
+  assert_showcase_component_stages(carousel_html, "component-Carousel", [
+    "Horizontal", "Vertical",
+  ])
+  for
+    entry in [
+      (IgPaginationDefaultCode, "pagination_ellipsis"),
+      (IgPaginationCompactCode, "size=@rui.Sm"),
+      (IgCarouselHorizontalCode, "loop_=true"),
+      (IgCarouselVerticalCode, "default_index=1"),
+    ] {
+    let (code, expected) = entry
+    assert_showcase_stage_contains(code, expected)
+    if code.contains("ig_specimen") {
+      fail("split showcase code must contain only its rendered example")
+    }
+  }
+}
+
+///|
+test "resizable variants render as independent stages" {
+  let html = render_showcase_incremental(ig_feedback_section)
+  let resizable_html = showcase_component_fragment(
+    html, "component-Resizable", "component-Scroll-Area",
+  )
+  assert_showcase_component_stages(resizable_html, "component-Resizable", [
+    "Horizontal-multi-panel", "Vertical-two-panel",
+  ])
+  for
+    entry in [
+      (IgResizableHorizontalCode, "resizable_group_handle"),
+      (IgResizableVerticalCode, "resizable_panel_group"),
+    ] {
+    let (code, expected) = entry
+    assert_showcase_stage_contains(code, expected)
+    if code.contains("ig_specimen") {
+      fail("split resizable code must contain only its rendered example")
+    }
+  }
+}
+
+///|
+test "scroll area variants render as independent stages" {
+  let html = render_showcase_stage(
+    ig_scroll_area_component(
+      @html.span("vertical-scroll-demo"),
+      @html.span("horizontal-scroll-demo"),
+    ),
+  )
+  assert_showcase_component_stages(html, "component-Scroll-Area", [
+    "Vertical", "Horizontal",
+  ])
+  for expected in ["vertical-scroll-demo", "horizontal-scroll-demo"] {
+    assert_showcase_stage_contains(html, expected)
+  }
+  for
+    entry in [
+      (IgScrollAreaVerticalCode, "orientation=@rui.Vertical"),
+      (IgScrollAreaHorizontalCode, "orientation=@rui.Horizontal"),
+    ] {
+    let (code, expected) = entry
+    assert_showcase_stage_contains(code, expected)
+    if code.contains("ig_specimen") {
+      fail("split scroll area code must contain only its rendered example")
+    }
+  }
+}
+
+///|
+test "slider variants render as independent stages" {
+  let html = render_showcase_stage(
+    forms_slider_component(
+      @html.span("default-slider-demo"),
+      @html.span("range-slider-demo"),
+      @html.span("vertical-slider-demo"),
+    ),
+  )
+  assert_showcase_component_stages(html, "component-Slider", [
+    "Default", "Range", "Vertical",
+  ])
+  for
+    expected in [
+      "default-slider-demo", "range-slider-demo", "vertical-slider-demo",
+    ] {
+    assert_showcase_stage_contains(html, expected)
+  }
+  for
+    entry in [
+      (FormsSliderDefaultCode, "@rui.slider("),
+      (FormsSliderRangeCode, "@rui.slider_values("),
+      (FormsSliderVerticalCode, "orientation=@rui.Vertical"),
+    ] {
+    let (code, expected) = entry
+    assert_showcase_stage_contains(code, expected)
+    if code.contains("FormsGalleryFormGridStyle") || code.contains("view4") {
+      fail("split slider code must contain only its rendered example")
+    }
+  }
+}
+
+///|
+test "menu showcases render independent stages with matching code actions" {
+  let html = render_showcase_incremental(ig_overlay_section)
+  let context_menu_html = showcase_component_fragment(
+    html, "component-Context-Menu", "component-Command",
+  )
+  let dropdown_menu_html = showcase_component_fragment(
+    html, "component-Dropdown-Menu", "component-Menubar",
+  )
+  let menubar_html = showcase_component_fragment(
+    html, "component-Menubar", "component-Popover",
+  )
+  assert_menu_showcase_component(context_menu_html, "component-Context-Menu", [
+    "Actions-shortcuts", "Submenu-destructive-action", "Checkbox-items", "Radio-group",
+  ])
+  assert_menu_showcase_component(
+    dropdown_menu_html,
+    "component-Dropdown-Menu",
+    [
+      "Basic-groups", "Leading-icons", "Checkbox-items", "Radio-group", "Submenu-placement",
+      "Multi-level-submenu",
+    ],
+  )
+  for
+    marker in [
+      "showcase-dropdown-menu-multilevel", "Move to", "Projects", "Project destination",
+    ] {
+    assert_showcase_stage_contains(dropdown_menu_html, marker)
+  }
+  assert_eq(
+    IgDropdownMenuMultiLevelCode.split("@rui.dropdown_menu_sub(").count(),
+    3,
+  )
+  for
+    marker in [
+      "showcase_folder_icon()", "showcase_folder_open_icon()", "showcase_layout_icon()",
+      "showcase_activity_icon()",
+    ] {
+    assert_showcase_stage_contains(
+      ig_menu_code(
+        IgDropdownMenuMultiLevelIconsCode,
+        IgDropdownMenuMultiLevelCode,
+      ),
+      marker,
+    )
+  }
+  assert_menu_showcase_component(menubar_html, "component-Menubar", [
+    "Application-commands", "Submenu-destructive-action", "Checkbox-items", "Radio-group",
+  ])
+}
+
+///|
+test "navigation variants expose one stage and copy action per example" {
+  let breadcrumb_html = render_showcase_stage(ig_breadcrumb_demo())
+  assert_showcase_component_stages(breadcrumb_html, "component-Breadcrumb", [
+    "Default", "Condensed",
+  ])
+  let accordion_html = render_showcase_stage(
+    ig_accordion_component(@html.span("single"), @html.span("multiple")),
+  )
+  assert_showcase_component_stages(accordion_html, "component-Accordion", [
+    "Single", "Multiple",
+  ])
+  let tabs_html = render_showcase_stage(
+    ig_tabs_component(
+      @html.span("default"),
+      @html.span("line"),
+      @html.span("vertical"),
+      @html.span("disabled"),
+      @html.span("icons"),
+    ),
+  )
+  assert_showcase_component_stages(tabs_html, "component-Tabs", [
+    "Default", "Line", "Vertical", "Disabled", "Icons",
+  ])
+  let collapsible_html = render_showcase_stage(
+    ig_collapsible_component(
+      @html.span("order"),
+      @html.span("basic"),
+      @html.span("settings"),
+      @html.span("file-tree"),
+    ),
+  )
+  assert_showcase_component_stages(collapsible_html, "component-Collapsible", [
+    "Order-details", "Basic", "Settings-panel", "File-tree",
+  ])
+  for
+    code in [
+      IgCollapsibleOrderCode,
+      IgCollapsibleBasicCode,
+      IgCollapsibleSettingsCode,
+      IgCollapsibleFileTreeCode,
+    ] {
+    assert_false(code.contains("ig_collapsible"))
+    assert_false(code.contains("IgCollapsible"))
+    assert_false(code.contains("MutedStyle"))
+  }
+  assert_true(IgCollapsibleFileTreeCode.contains("@rabbita.create_variable"))
+  assert_true(IgCollapsibleFileTreeCode.contains("components/ui"))
+  assert_true(IgCollapsibleFileTreeCode.contains("@rui.tabs("))
+  assert_true(IgCollapsibleFileTreeCode.contains("@rui.card("))
+  assert_true(IgCollapsibleFileTreeCode.contains("label=\"Explorer\""))
+  assert_true(IgCollapsibleFileTreeCode.contains("label=\"Outline\""))
+  let navigation_menu_html = render_showcase_stage(
+    ig_navigation_menu_component(@html.span("viewport"), @html.span("inline")),
+  )
+  assert_showcase_component_stages(
+    navigation_menu_html,
+    "component-Navigation-Menu",
+    ["Viewport", "Inline"],
+  )
+}
+
+///|
+test "component page registry is stable and unique" {
+  assert_eq(showcase_page_entries.length(), 64)
+  assert_eq(showcase_page_entries[0].slug, "accordion")
+  assert_eq(showcase_page_entries[63].slug, "typography")
+  for index = 0; index < showcase_page_entries.length(); index = index + 1 {
+    let entry = showcase_page_entries[index]
+    assert_true(entry.slug != "")
+    assert_true(entry.title != "")
+    assert_eq(showcase_page_index_by_slug(entry.slug), index)
+    assert_eq(showcase_page_index_by_title(entry.title), index)
+    for other = index + 1
+        other < showcase_page_entries.length()
+        other = other + 1 {
+      assert_true(entry.slug != showcase_page_entries[other].slug)
+      assert_true(entry.title != showcase_page_entries[other].title)
+    }
+  }
+}
+
+///|
+test "a selected interaction page renders only its component" {
+  let html = render_showcase_incremental(() => ig_overlay_page("dropdown-menu"))
+  assert_eq(html.split("class=\"rui-showcase-component\"").count(), 2)
+  assert_true(html.contains("id=\"component-Dropdown-Menu\""))
+  assert_false(html.contains("id=\"component-Context-Menu\""))
+  assert_false(html.contains("id=\"component-Menubar\""))
+  assert_showcase_component_stages(html, "component-Dropdown-Menu", [
+    "Basic-groups", "Leading-icons", "Checkbox-items", "Radio-group", "Submenu-placement",
+    "Multi-level-submenu",
+  ])
+}
+
+///|
+test "top and bottom component pagers share one neighbour mapping" {
+  let button_html = render_showcase_stage(foundations_button_demo())
+  assert_eq(button_html.split("aria-label=\"Component pages\"").count(), 3)
+  assert_eq(button_html.split("aria-label=\"Previous: Bubble\"").count(), 3)
+  assert_eq(button_html.split("aria-label=\"Next: Button Group\"").count(), 3)
+  assert_eq(button_html.split("/components/bubble/").count(), 3)
+  assert_eq(button_html.split("/components/button-group/").count(), 3)
+  let first_html = render_showcase_incremental(() => {
+    ig_navigation_page("accordion")
+  })
+  assert_eq(first_html.split("aria-label=\"Component pages\"").count(), 3)
+  assert_eq(first_html.split("aria-label=\"Next: Alert\"").count(), 3)
+  assert_false(first_html.contains("aria-label=\"Previous:"))
+  let last_html = render_showcase_stage(fdv_typography_demo())
+  assert_eq(last_html.split("aria-label=\"Component pages\"").count(), 3)
+  assert_eq(last_html.split("aria-label=\"Previous: Tooltip\"").count(), 3)
+  assert_false(last_html.contains("aria-label=\"Next:"))
+}
+
+///|
+test "components page marks one catalogue link and mounts one component" {
+  let html = render_showcase_incremental(() => {
+    components_page(@rabbita.Val::constant(false), "button")
+  })
+  assert_eq(html.split("class=\"rui-showcase-component\"").count(), 2)
+  assert_eq(html.split("aria-current=\"page\"").count(), 3)
+  assert_true(html.contains("id=\"component-Button\""))
+  assert_false(html.contains("id=\"component-Badge\""))
+  assert_false(html.contains("id=\"component-Button-Group\""))
+}
+
+///|
+test "file tree preserves nested folder state while a parent is closed" {
+  let initial = ["components", "components/ui", "lib"]
+  let parent_closed = ig_collapsible_next_open_paths(
+    initial, "components", false,
+  )
+  assert_false(parent_closed.contains("components"))
+  assert_true(parent_closed.contains("components/ui"))
+  let parent_reopened = ig_collapsible_next_open_paths(
+    parent_closed, "components", true,
+  )
+  assert_true(parent_reopened.contains("components"))
+  assert_true(parent_reopened.contains("components/ui"))
+  assert_eq(parent_reopened.filter(path => path == "components").length(), 1)
+
+  let html = render_showcase_incremental(ig_collapsible_file_tree_view)
+  assert_showcase_stage_contains(html, "data-path=\"components\"")
+  assert_showcase_stage_contains(html, "data-path=\"components/ui\"")
+  assert_showcase_stage_contains(html, "aria-label=\"File tree view\"")
+  assert_showcase_stage_contains(html, ">Explorer</button>")
+  assert_showcase_stage_contains(html, ">Outline</button>")
+  assert_showcase_stage_contains(html, "data-slot=\"card\"")
+  assert_showcase_stage_contains(
+    html, "id=\"showcase-file-tree-components/ui-trigger\"",
+  )
+  assert_showcase_stage_contains(html, "aria-expanded=\"true\"")
+  assert_showcase_stage_contains(html, "data-path=\"public\"")
+  assert_showcase_stage_contains(html, "aria-expanded=\"false\"")
+}
+
+///|
+test "overlay variants expose one stage and copy action per example" {
+  let alert_dialog_html = render_showcase_stage(
+    ig_alert_dialog_component(@html.span("default"), @html.span("destructive")),
+  )
+  assert_showcase_component_stages(
+    alert_dialog_html,
+    "component-Alert-Dialog",
+    ["Default", "Destructive"],
+  )
+  let dialog_html = render_showcase_stage(
+    ig_dialog_component(@html.span("modal"), @html.span("nonmodal")),
+  )
+  assert_showcase_component_stages(dialog_html, "component-Dialog", [
+    "Modal", "Non-modal",
+  ])
+  let drawer_html = render_showcase_stage(
+    ig_drawer_component(
+      @html.span("top"),
+      @html.span("right"),
+      @html.span("bottom"),
+      @html.span("left"),
+    ),
+  )
+  assert_showcase_component_stages(drawer_html, "component-Drawer", [
+    "Top", "Right", "Bottom", "Left",
+  ])
+  let command_html = render_showcase_stage(
+    ig_command_component(@html.span("inline"), @html.span("dialog")),
+  )
+  assert_showcase_component_stages(command_html, "component-Command", [
+    "Inline", "Dialog",
+  ])
+  let popover_html = render_showcase_stage(
+    ig_popover_component(@html.span("bottom"), @html.span("right")),
+  )
+  assert_showcase_component_stages(popover_html, "component-Popover", [
+    "Bottom-start", "Right-center",
+  ])
+  let hover_card_html = render_showcase_stage(
+    ig_hover_card_component(@html.span("top"), @html.span("left")),
+  )
+  assert_showcase_component_stages(hover_card_html, "component-Hover-Card", [
+    "Top-center", "Left-end",
+  ])
+  let tooltip_html = render_showcase_stage(
+    ig_tooltip_component(
+      @html.span("top"),
+      @html.span("right"),
+      @html.span("bottom"),
+      @html.span("left"),
+    ),
+  )
+  assert_showcase_component_stages(tooltip_html, "component-Tooltip", [
+    "Top-start", "Right-center", "Bottom-end", "Left-center",
+  ])
+  let sheet_html = render_showcase_stage(
+    ig_sheet_component(
+      @html.span("top"),
+      @html.span("right"),
+      @html.span("bottom"),
+      @html.span("left"),
+    ),
+  )
+  assert_showcase_component_stages(sheet_html, "component-Sheet", [
+    "Top", "Right", "Bottom", "Left",
+  ])
+}
+
+///|
+test "notification variants expose independent stages" {
+  let sonner_html = render_showcase_stage(
+    ig_sonner_component(
+      @html.span("default"),
+      @html.span("success"),
+      @html.span("destructive"),
+      @html.span("queue"),
+    ),
+  )
+  assert_showcase_component_stages(sonner_html, "component-Sonner", [
+    "Default", "Success", "Destructive", "Queue-dismissal",
+  ])
+  let toast_html = render_showcase_stage(ig_toast_component())
+  assert_showcase_component_stages(toast_html, "component-Toast", [
+    "Default", "Success", "Destructive",
+  ])
+}
+
+///|
+test "form controls expose one stage and copy action per variant" {
+  let html = render_showcase_incremental(forms_gallery)
+  let input_html = showcase_component_fragment(
+    html, "component-Input", "component-Textarea",
+  )
+  assert_showcase_component_stages(input_html, "component-Input", [
+    "Text", "Email", "Disabled",
+  ])
+  let textarea_html = showcase_component_fragment(
+    html, "component-Textarea", "component-Field",
+  )
+  assert_showcase_component_stages(textarea_html, "component-Textarea", [
+    "Default", "Invalid", "Disabled",
+  ])
+  let field_html = showcase_component_fragment(
+    html, "component-Field", "component-Radio-Group",
+  )
+  assert_showcase_component_stages(field_html, "component-Field", [
+    "Complete-form-composition", "Horizontal", "Responsive", "Fieldset-and-legend",
+  ])
+  let radio_html = showcase_component_fragment(
+    html, "component-Radio-Group", "component-Slider",
+  )
+  assert_showcase_component_stages(radio_html, "component-Radio-Group", [
+    "Horizontal", "Vertical",
+  ])
+  let date_picker_html = render_showcase_incremental(date_picker_showcase)
+  assert_showcase_component_stages(date_picker_html, "component-Date-Picker", [
+    "Single-date-with-presets", "Date-range", "Disabled", "Invalid",
+  ])
+}
+
+///|
+test "form variant gallery keeps every copied example independent" {
+  let html = render_showcase_incremental(forms_variants_gallery)
+  let checkbox_html = showcase_component_fragment(
+    html, "component-Checkbox", "component-Switch",
+  )
+  assert_showcase_component_stages(checkbox_html, "component-Checkbox", [
+    "Mixed", "Invalid", "Disabled",
+  ])
+  let switch_html = showcase_component_fragment(
+    html, "component-Switch", "component-Combobox",
+  )
+  assert_showcase_component_stages(switch_html, "component-Switch", [
+    "Default", "Small", "Invalid", "Disabled",
+  ])
+  let combobox_html = showcase_component_fragment(
+    html, "component-Combobox", "component-Select",
+  )
+  assert_showcase_component_stages(combobox_html, "component-Combobox", [
+    "Multiple", "Grouped", "Empty-result", "Invalid", "Disabled",
+  ])
+  let select_html = showcase_component_fragment(
+    html, "component-Select", "component-Input-Group",
+  )
+  assert_showcase_component_stages(select_html, "component-Select", [
+    "Compound-collection", "Invalid", "Disabled",
+  ])
+  let input_group_html = showcase_component_fragment(
+    html, "component-Input-Group", "component-Native-Select",
+  )
+  assert_showcase_component_stages(input_group_html, "component-Input-Group", [
+    "Basic", "Inline-start", "Inline-end", "Block-start-input", "Block-start-textarea",
+    "Block-end-input", "Block-end-textarea", "Icon-search", "Icon-email", "Icons-card-validation",
+    "Icons-metadata", "Text-currency", "Text-URL", "Text-username-suffix", "Text-character-count",
+    "Button-copy", "Buttons-connection-actions", "Button-search", "Keyboard-shortcut",
+    "Dropdown-icon-trigger", "Dropdown-text-trigger", "Spinner-trailing", "Spinner-leading",
+    "Spinner-status-text", "Spinner-dual-status", "Textarea-toolbar", "Custom-control",
+  ])
+  for
+    marker in [
+      "forms-variants-input-group-block-start-textarea", "forms-variants-input-group-icon-metadata",
+      "forms-variants-input-group-secure", "forms-variants-input-group-query", "forms-variants-input-group-spinner-status",
+      "forms-variants-input-group-custom",
+    ] {
+    assert_showcase_stage_contains(input_group_html, marker)
+  }
+  for
+    recipe in [
+      (
+        FormsInputGroupBlockStartTextareaCode,
+        "forms-variants-input-group-block-start-textarea",
+      ),
+      (
+        FormsInputGroupIconMetadataCode,
+        "forms-variants-input-group-icon-metadata",
+      ),
+      (
+        FormsInputGroupConnectionButtonsCode,
+        "forms-variants-input-group-secure",
+      ),
+      (FormsInputGroupDropdownQueryCode, "forms-variants-input-group-query"),
+      (
+        FormsInputGroupSpinnerStatusCode,
+        "forms-variants-input-group-spinner-status",
+      ),
+      (FormsInputGroupCustomControlCode, "forms-variants-input-group-custom"),
+    ] {
+    let (code, marker) = recipe
+    assert_showcase_stage_contains(code, marker)
+  }
+  assert_showcase_stage_contains(
+    FormsInputGroupCustomControlCode,
+    "@rui.input_group_control",
+  )
+  if FormsInputGroupCustomControlCode.contains("data_set(\"slot\"") {
+    fail("custom Input Group recipe must use the public black-box adapter")
+  }
+  let native_select_html = showcase_component_fragment(
+    html, "component-Native-Select", "component-Input-OTP",
+  )
+  assert_showcase_component_stages(
+    native_select_html,
+    "component-Native-Select",
+    ["Default-with-groups", "Small", "Invalid", "Disabled"],
+  )
+  let otp_html = render_showcase_incremental(forms_otp_variants)
+  assert_showcase_component_stages(otp_html, "component-Input-OTP", [
+    "Default", "Pattern", "2-2-2-Separator", "3-3", "4-4", "Four-Digits", "Alphanumeric",
+    "Invalid-and-editable", "Disabled", "Form",
+  ])
+  if FormsOtpContinuousCode.contains("separator_after") {
+    fail("Default Input OTP recipe must not render a separator")
+  }
+  assert_eq(FormsOtpSeparatorCode.split("@rui.input_otp_separator").count(), 3)
+  assert_showcase_stage_contains(FormsOtpAlphanumericCode, "inputmode=\"text\"")
+  assert_showcase_stage_contains(FormsOtpFormCode, "@rui.card(")
+}
+
+///|
+test "foundation variants expose one stage and copy action per example" {
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_button_demo()),
+    "component-Button",
+    [
+      "Default", "Secondary", "Outline", "Ghost", "Destructive", "Link", "Large",
+      "Default-size", "Small", "Extra-small", "Large-icon", "Default-icon", "Small-icon",
+      "Extra-small-icon",
+    ],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_badge_demo()),
+    "component-Badge",
+    ["Default", "Secondary", "Outline", "Destructive", "Ghost", "Link"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(
+      foundations_toggle_demo(@html.span("outline"), @html.span("default")),
+    ),
+    "component-Toggle",
+    ["Outline-large", "Default-small"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_label_demo()),
+    "component-Label",
+    ["Default", "Disabled"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_kbd_demo()),
+    "component-Kbd",
+    ["Key", "Shortcut"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_spinner_demo()),
+    "component-Spinner",
+    ["Inline", "In-a-button"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_skeleton_demo()),
+    "component-Skeleton",
+    ["Default", "Avatar", "Card", "Text", "Form", "Table"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_alert_demo()),
+    "component-Alert",
+    ["Default", "Destructive"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_message_demo()),
+    "component-Message",
+    ["Start-aligned", "End-aligned"],
+  )
+  assert_showcase_component_stages(
+    render_showcase_stage(foundations_bubble_demo()),
+    "component-Bubble",
+    [
+      "Default", "Secondary", "Muted", "Tinted", "Outline-link", "Ghost", "Destructive",
+    ],
+  )
+}
+
+///|
+test "identity variants keep copied examples independent" {
+  let html = render_showcase_stage(foundations_identity_variants())
+  let avatar_html = showcase_component_fragment(
+    html, "component-Avatar", "component-Card",
+  )
+  assert_showcase_component_stages(avatar_html, "component-Avatar", [
+    "Default", "Small", "Large", "Image-and-badge", "Group-and-count",
+  ])
+  let card_html = showcase_component_fragment(
+    html, "component-Card", "component-Aspect-Ratio",
+  )
+  assert_showcase_component_stages(card_html, "component-Card", [
+    "Default", "Small",
+  ])
+  let aspect_html = showcase_component_fragment(
+    html, "component-Aspect-Ratio", "component-Direction",
+  )
+  assert_showcase_component_stages(aspect_html, "component-Aspect-Ratio", [
+    "Square-1-1", "Standard-4-3", "Widescreen-16-9",
+  ])
+  let separator_html = showcase_component_tail(html, "component-Separator")
+  assert_showcase_component_stages(separator_html, "component-Separator", [
+    "Horizontal", "Vertical",
+  ])
+}
+
+///|
+test "data display variants keep copied examples independent" {
+  let html = render_showcase_stage(
+    foundations_data_variants(@html.span("data-table")),
+  )
+  let attachment_html = showcase_component_fragment(
+    html, "component-Attachment", "component-Typography",
+  )
+  assert_showcase_component_stages(attachment_html, "component-Attachment", [
+    "Image-attachment", "File-attachment", "Idle", "Uploading", "Processing", "Error",
+    "Done", "Default-size", "Small", "Extra-small", "Group", "Full-card-trigger",
+  ])
+  assert_eq(
+    attachment_html
+    .split("class=\"rui-showcase-attachment-stage-content\"")
+    .count(),
+    13,
+  )
+  for
+    expected in [
+      "width:min(100%,24rem)", "align-items:center", "justify-content:center",
+    ] {
+    assert_showcase_stage_contains(attachment_html, expected)
+  }
+  assert_showcase_stage_contains(FdvAttachmentTriggerCode, "width:100%")
+  assert_showcase_stage_contains(
+    FdvAttachmentGroupCode,
+    "Open briefing notes in group",
+  )
+  assert_showcase_stage_contains(
+    FdvAttachmentGroupCode,
+    "Open customers in group",
+  )
+  assert_showcase_stage_contains(
+    FdvAttachmentGroupCode,
+    "width:100%;max-width:24rem",
+  )
+  assert_showcase_stage_contains(FdvAttachmentImageCode, "@html.img")
+  assert_showcase_stage_contains(FdvAttachmentImageCode, "alt=\"Workspace\"")
+  assert_showcase_stage_contains(FdvAttachmentImageCode, "alt=\"Desk\"")
+  assert_showcase_stage_contains(FdvAttachmentImageCode, "alt=\"Office\"")
+  assert_false(FdvAttachmentImageCode.contains("linear-gradient"))
+  assert_eq(attachment_html.split("<img").count(), 4)
+  for
+    expected in [
+      "photo-1497366754035-f200968a6e72", "photo-1497215728101-856f4ea42174", "photo-1497366811353-6870744d04b2",
+      "alt=\"Workspace\"", "alt=\"Desk\"", "alt=\"Office\"",
+    ] {
+    assert_showcase_stage_contains(attachment_html, expected)
+  }
+  assert_false(
+    attachment_html.contains("linear-gradient(145deg,#d7dfeb,#8ba0b5)"),
+  )
+  assert_showcase_stage_contains(FdvAttachmentUploadingCode, "@rui.spinner")
+  assert_showcase_stage_contains(FdvAttachmentUploadingCode, "Cancel upload")
+  assert_false(FdvAttachmentProcessingCode.contains("@rui.spinner"))
+  assert_showcase_stage_contains(FdvAttachmentProcessingCode, "M16 13H8")
+  assert_showcase_stage_contains(
+    FdvAttachmentProcessingCode,
+    "Remove market-research.pdf",
+  )
+  assert_showcase_stage_contains(FdvAttachmentErrorCode, "Retry upload")
+  let typography_html = showcase_component_fragment(
+    html, "component-Typography", "component-Data-Table",
+  )
+  assert_showcase_component_stages(typography_html, "component-Typography", [
+    "H1", "H2", "H3", "H4", "Paragraph", "Lead", "Large", "Small", "Muted", "Blockquote",
+    "List", "Inline-code",
+  ])
+  let item_html = showcase_component_fragment(
+    html, "component-Item", "component-Empty",
+  )
+  assert_showcase_component_stages(item_html, "component-Item", [
+    "Default", "Outline-small", "Muted-image",
+  ])
+  let empty_html = showcase_component_fragment(
+    html, "component-Empty", "component-Marker",
+  )
+  assert_showcase_component_stages(empty_html, "component-Empty", [
+    "Default-media", "Icon-media",
+  ])
+  let marker_html = showcase_component_fragment(
+    html, "component-Marker", "component-Progress",
+  )
+  assert_showcase_component_stages(marker_html, "component-Marker", [
+    "Default", "Separator", "Border",
+  ])
+  let progress_html = showcase_component_tail(html, "component-Progress")
+  assert_showcase_component_stages(progress_html, "component-Progress", [
+    "Indeterminate", "Determinate",
+  ])
+}

--- a/website/homepage/components/showcase_icons.mbt
+++ b/website/homepage/components/showcase_icons.mbt
@@ -1,0 +1,255 @@
+///|
+/// Static Lucide-compatible strokes used by the showcase. These are visual
+/// assets only; component state and interaction remain inside the public UI
+/// components being demonstrated.
+fn showcase_stroke_icon(
+  path : String,
+  box_size? : String = "1rem",
+) -> @html.Html {
+  let line_attrs = @svg.Attrs::build()
+    .stroke_linecap("round")
+    .stroke_linejoin("round")
+  @html.span(
+    style=[
+      "display:inline-flex;width:\{box_size};height:\{box_size};flex:none;align-items:center;justify-content:center;vertical-align:middle;pointer-events:none;user-select:none",
+    ],
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(
+      width=24,
+      height=24,
+      view_box="0 0 24 24",
+      style=["display:block;width:100%;height:100%"],
+      [
+        @svg.path(
+          d=path,
+          fill="none",
+          stroke="currentColor",
+          stroke_width=2,
+          attrs=line_attrs,
+        ),
+      ],
+    ),
+  )
+}
+
+///|
+fn showcase_close_icon() -> @html.Html {
+  showcase_stroke_icon("M18 6 6 18M6 6l12 12")
+}
+
+///|
+fn showcase_file_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6",
+  )
+}
+
+///|
+fn showcase_folder_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z",
+  )
+}
+
+///|
+fn showcase_folder_open_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M6 14l1.5-4h12.8a1.5 1.5 0 0 1 1.42 2l-2.1 6.2A2 2 0 0 1 17.72 20H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2",
+  )
+}
+
+///|
+fn showcase_chevron_right_icon() -> @html.Html {
+  showcase_stroke_icon("m9 18 6-6-6-6", box_size="0.875rem")
+}
+
+///|
+fn showcase_chevron_left_icon() -> @html.Html {
+  showcase_stroke_icon("m15 18-6-6 6-6", box_size="0.875rem")
+}
+
+///|
+fn showcase_archive_icon() -> @html.Html {
+  showcase_stroke_icon("M21 8v13H3V8M1 3h22v5H1zM10 12h4")
+}
+
+///|
+fn showcase_separator_dot_icon() -> @html.Html {
+  showcase_stroke_icon("M12 12h.01")
+}
+
+///|
+fn showcase_check_icon() -> @html.Html {
+  showcase_stroke_icon("M20 6 9 17l-5-5")
+}
+
+///|
+fn showcase_copy_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2ZM4 16a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2",
+  )
+}
+
+///|
+fn showcase_runtime_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M9 3v2M15 3v2M9 19v2M15 19v2M3 9h2M3 15h2M19 9h2M19 15h2M7 7h10v10H7z",
+  )
+}
+
+///|
+fn showcase_layout_icon() -> @html.Html {
+  showcase_stroke_icon("M4 4h16v16H4zM4 9h16M9 9v11")
+}
+
+///|
+fn showcase_code_icon() -> @html.Html {
+  showcase_stroke_icon("m16 18 6-6-6-6M8 6l-6 6 6 6")
+}
+
+///|
+fn showcase_plus_icon() -> @html.Html {
+  showcase_stroke_icon("M12 5v14M5 12h14")
+}
+
+///|
+fn showcase_panel_left_icon() -> @html.Html {
+  showcase_stroke_icon("M3 3h18v18H3zM9 3v18")
+}
+
+///|
+fn showcase_activity_icon() -> @html.Html {
+  showcase_stroke_icon("M3 12h4l2-8 4 16 2-8h6")
+}
+
+///|
+fn showcase_settings_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z",
+  )
+}
+
+///|
+fn showcase_user_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M20 21a8 8 0 0 0-16 0M12 13a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z",
+  )
+}
+
+///|
+fn showcase_credit_card_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M2 10h20M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z",
+  )
+}
+
+///|
+fn showcase_log_out_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "m16 17 5-5-5-5M21 12H9M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4",
+  )
+}
+
+///|
+fn showcase_mail_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z",
+  )
+}
+
+///|
+fn showcase_message_square_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M21 15a4 4 0 0 1-4 4H7l-4 4V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4Z",
+  )
+}
+
+///|
+fn showcase_bell_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M10.268 21a2 2 0 0 0 3.464 0M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326",
+  )
+}
+
+///|
+fn showcase_wallet_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M20 7V6a2 2 0 0 0-2-2H5a3 3 0 0 0 0 6h15v10H5a3 3 0 0 1-3-3V7M16 14h.01",
+  )
+}
+
+///|
+fn showcase_building_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18M6 12H4a2 2 0 0 0-2 2v8h20v-8a2 2 0 0 0-2-2h-2M10 6h4M10 10h4M10 14h4M10 18h4",
+  )
+}
+
+///|
+fn showcase_alert_triangle_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M21.73 18 13.73 4a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3ZM12 9v4M12 17h.01",
+    box_size="2rem",
+  )
+}
+
+///|
+fn showcase_circle_help_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.1 9a3 3 0 1 1 5.8 1c0 2-2.9 2-2.9 4M12 17h.01",
+  )
+}
+
+///|
+fn showcase_arrow_up_icon() -> @html.Html {
+  showcase_stroke_icon("m18 15-6-6-6 6")
+}
+
+///|
+fn showcase_arrow_down_icon() -> @html.Html {
+  showcase_stroke_icon("m6 9 6 6 6-6")
+}
+
+///|
+fn showcase_bold_icon() -> @html.Html {
+  showcase_stroke_icon("M6 4h8a4 4 0 0 1 0 8H6zM6 12h9a4 4 0 0 1 0 8H6z")
+}
+
+///|
+fn showcase_italic_icon() -> @html.Html {
+  showcase_stroke_icon("M19 4h-9M14 20H5M15 4 9 20")
+}
+
+///|
+fn showcase_underline_icon() -> @html.Html {
+  showcase_stroke_icon("M6 3v7a6 6 0 0 0 12 0V3M4 21h16")
+}
+
+///|
+fn showcase_search_icon() -> @html.Html {
+  showcase_stroke_icon("M21 21l-4.35-4.35M19 11a8 8 0 1 1-16 0 8 8 0 0 1 16 0")
+}
+
+///|
+fn showcase_eye_off_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "m2 2 20 20M6.71 6.71C4.9 8.02 3.5 9.76 3 12c1.2 5.4 7.2 8.2 12.4 5.5M10.73 5.08A10.9 10.9 0 0 1 12 5c5 0 8.5 3 9 7a11.1 11.1 0 0 1-2.1 4.2M14.12 14.12A3 3 0 0 1 9.88 9.88",
+  )
+}
+
+///|
+fn showcase_more_horizontal_icon() -> @html.Html {
+  showcase_stroke_icon("M5 12h.01M12 12h.01M19 12h.01")
+}
+
+///|
+fn showcase_refresh_icon() -> @html.Html {
+  showcase_stroke_icon(
+    "M20 6v6h-6M4 18v-6h6M5.1 9A7 7 0 0 1 16.5 5.5L20 9M4 15l3.5 3.5A7 7 0 0 0 18.9 15",
+  )
+}
+
+///|
+fn showcase_corner_down_left_icon() -> @html.Html {
+  showcase_stroke_icon("M9 10 4 15l5 5M20 4v7a4 4 0 0 1-4 4H4")
+}

--- a/website/homepage/components/showcase_pages_forms.mbt
+++ b/website/homepage/components/showcase_pages_forms.mbt
@@ -1,0 +1,380 @@
+///|
+fn showcase_input_page() -> @rabbita.Val[@html.Html] {
+  let (input_name, set_input_name) = @rabbita.create_variable("Ada Lovelace")
+  let (input_email, set_input_email) = @rabbita.create_variable(
+    "ada@example.com",
+  )
+  let input_text_view = input_name.view(name => {
+    @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.input(
+        id="forms-gallery-input-name",
+        name="standalone-display-name",
+        value=name,
+        placeholder="Ada Lovelace",
+        on_input=set_input_name.map(value => _ => value),
+      ),
+    )
+  })
+  let input_email_view = input_email.view(email => {
+    @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.input(
+        id="forms-gallery-input-email",
+        input_type=@html.Email,
+        value=email,
+        invalid=email == "invalid",
+        placeholder="ada@example.com",
+        on_input=set_input_email.map(value => _ => value),
+      ),
+    )
+  })
+  let input_disabled = @html.div(
+    style=["width:min(100%,24rem);margin-inline:auto"],
+    @rui.input(
+      id="forms-gallery-input-disabled",
+      value="Inherited workspace",
+      disabled=true,
+    ),
+  )
+  input_text_view.view2(input_email_view, (text_html, email_html) => {
+    forms_input_component(text_html, email_html, input_disabled)
+  })
+}
+
+///|
+fn showcase_textarea_page() -> @rabbita.Val[@html.Html] {
+  let (textarea_note, set_textarea_note) = @rabbita.create_variable(
+    "Ship the first programmable workspace.",
+  )
+  textarea_note.view(note => {
+    let default_html = @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.textarea(
+        id="forms-gallery-textarea-default",
+        value=note,
+        rows=4,
+        placeholder="What should collaborators know?",
+        on_input=set_textarea_note.map(value => _ => value),
+      ),
+    )
+    let invalid_html = @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.textarea(
+        id="forms-gallery-textarea-invalid",
+        rows=4,
+        invalid=true,
+        placeholder="Explain what failed…",
+      ),
+    )
+    let disabled_html = @html.div(
+      style=["width:min(100%,24rem);margin-inline:auto"],
+      @rui.textarea(
+        id="forms-gallery-textarea-disabled",
+        rows=4,
+        value="Managed by your organization",
+        disabled=true,
+      ),
+    )
+    forms_textarea_component(default_html, invalid_html, disabled_html)
+  })
+}
+
+///|
+fn showcase_radio_group_page() -> @rabbita.Val[@html.Html] {
+  let (plan, set_plan) = @rabbita.create_variable("monthly")
+  let horizontal = @rui.radio_group(
+    default_value="monthly",
+    name="forms-gallery-billing",
+    orientation=@rui.RadioHorizontal,
+    aria_label="Billing cycle",
+    on_value_change=set_plan.map(value => _ => value),
+    scope => {
+      @html.div(style=[RowStyle], [
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="monthly",
+            id="forms-gallery-monthly",
+            aria_label="Monthly",
+          ),
+          @rui.label(for_="forms-gallery-monthly", "Monthly"),
+        ]),
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="annual",
+            id="forms-gallery-annual",
+            aria_label="Annual",
+          ),
+          @rui.label(for_="forms-gallery-annual", "Annual"),
+        ]),
+      ])
+    },
+  )
+  let vertical = @rui.radio_group(
+    default_value="automatic",
+    name="forms-gallery-sync",
+    orientation=@rui.RadioVertical,
+    aria_label="Sync strategy",
+    scope => {
+      @html.div(style=[StackStyle, "gap:0.625rem"], [
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="automatic",
+            id="forms-gallery-sync-automatic",
+            aria_label="Automatic sync",
+          ),
+          @rui.label(for_="forms-gallery-sync-automatic", "Automatic"),
+        ]),
+        @html.div(style=[FormsGalleryChoiceStyle], [
+          @rui.radio_group_item(
+            scope~,
+            value="manual",
+            id="forms-gallery-sync-manual",
+            aria_label="Manual sync",
+          ),
+          @rui.label(for_="forms-gallery-sync-manual", "Manual"),
+        ]),
+      ])
+    },
+  )
+  let horizontal_stage = plan.view2(horizontal, (plan, horizontal_html) => {
+    @html.div(
+      style=[
+        "display:flex;width:min(100%,32rem);margin-inline:auto;flex-direction:column;gap:1rem",
+      ],
+      [
+        horizontal_html,
+        @html.output(style=[MutedStyle], "Billing value: \{plan}"),
+      ],
+    )
+  })
+  let vertical_stage = vertical.view(vertical_html => {
+    @html.div(style=["width:min(100%,32rem);margin-inline:auto"], vertical_html)
+  })
+  horizontal_stage.view2(vertical_stage, forms_radio_component)
+}
+
+///|
+fn showcase_slider_page() -> @rabbita.Val[@html.Html] {
+  let (density_value, set_density) = @rabbita.create_variable(64)
+  let density_slider = @rui.slider(
+    id="forms-gallery-density",
+    default_value=64,
+    min=0,
+    max=100,
+    step=4,
+    aria_label="Interface density",
+    on_value_change=set_density.map(value => _ => value),
+  )
+  let range_slider = @rui.slider_values(
+    id="forms-gallery-budget-range",
+    default_values=[28, 72],
+    min=0,
+    max=100,
+    step=4,
+    large_step=12,
+    min_steps_between_values=3,
+    aria_label="Budget range",
+  )
+  let vertical_slider = @rui.slider(
+    id="forms-gallery-volume",
+    default_value=68,
+    orientation=@rui.Vertical,
+    aria_label="Preview volume",
+    style=["height:10rem"],
+  )
+  let default_stage = density_value.view2(density_slider, (
+    density_value,
+    density_html,
+  ) => {
+    @html.div(
+      style=[
+        "display:flex;width:min(100%,32rem);margin-inline:auto;flex-direction:column;gap:1rem",
+      ],
+      [
+        @html.div(style=[ControlRowStyle], [
+          @rui.label(for_="forms-gallery-density", "Interface density"),
+          @html.output(style=[MutedStyle], "\{density_value}%"),
+        ]),
+        density_html,
+      ],
+    )
+  })
+  let range_stage = range_slider.view(range_html => {
+    @html.div(style=["width:min(100%,32rem);margin-inline:auto"], range_html)
+  })
+  let vertical_stage = vertical_slider.view(vertical_html => {
+    @html.div(
+      style=[
+        "display:flex;min-height:12rem;align-items:center;justify-content:center",
+      ],
+      vertical_html,
+    )
+  })
+  default_stage.view3(range_stage, vertical_stage, forms_slider_component)
+}
+
+///|
+fn showcase_field_page() -> @rabbita.Val[@html.Html] {
+  let (form_state, set_form_state) = @rabbita.create_variable(
+    (
+      "Ada Lovelace", "ada@example.com", "analytical-engine", "Ship the first programmable workspace.",
+      false,
+    ),
+  )
+  form_state.view(state => {
+    let (name, email, website, note, submitted) = state
+    let email_invalid = email == "invalid"
+    let field_composition = @rui.form(
+      id="forms-gallery-profile-form",
+      name="workspace-profile",
+      on_submit=set_form_state(state => {
+        (state.0, state.1, state.2, state.3, true)
+      }),
+      @rui.field_set([
+        @rui.field_legend("Create a workspace"),
+        @rui.field_group(style=[FormsGalleryFormGridStyle], [
+          @rui.form_field(
+            name="display-name",
+            required=true,
+            describedby="forms-gallery-name-description",
+            [
+              @rui.form_label(for_="forms-gallery-name", "Display name"),
+              @rui.form_control(
+                @rui.input(
+                  id="forms-gallery-name",
+                  name="display-name",
+                  value=name,
+                  required=true,
+                  auto_complete=@html.On,
+                  placeholder="Ada Lovelace",
+                  on_input=set_form_state.map(value => {
+                    state => (value, state.1, state.2, state.3, false)
+                  }),
+                ),
+              ),
+              @rui.form_description(
+                id="forms-gallery-name-description",
+                "Shown to collaborators across the workspace.",
+              ),
+            ],
+          ),
+          @rui.form_field(
+            name="email",
+            invalid=email_invalid,
+            required=true,
+            describedby="forms-gallery-email-description",
+            errormessage="forms-gallery-email-error",
+            [
+              @rui.form_label(for_="forms-gallery-email", "Email"),
+              @rui.form_control(
+                @rui.input(
+                  input_type=@html.Email,
+                  id="forms-gallery-email",
+                  name="email",
+                  value=email,
+                  required=true,
+                  invalid=email_invalid,
+                  auto_complete=@html.On,
+                  placeholder="ada@example.com",
+                  on_input=set_form_state.map(value => {
+                    state => (state.0, value, state.2, state.3, false)
+                  }),
+                ),
+              ),
+              @rui.form_description(
+                id="forms-gallery-email-description",
+                "Type “invalid” to preview the destructive state.",
+              ),
+              if email_invalid {
+                @rui.form_message(
+                  id="forms-gallery-email-error",
+                  "Enter a valid email address.",
+                )
+              } else {
+                @html.nothing
+              },
+            ],
+          ),
+          @rui.field([
+            @rui.field_label(for_="forms-gallery-site", "Workspace URL"),
+            @rui.input_group([
+              @rui.input_group_addon(
+                for_="forms-gallery-site",
+                @rui.input_group_text("https://"),
+              ),
+              @rui.input_group_input(
+                id="forms-gallery-site",
+                name="workspace-url",
+                value=website,
+                placeholder="project-name",
+                on_input=set_form_state.map(value => {
+                  state => (state.0, state.1, value, state.3, false)
+                }),
+              ),
+              @rui.input_group_addon(
+                align=@rui.InputInlineEnd,
+                @rui.input_group_text(".moonbit.app"),
+              ),
+            ]),
+            @rui.field_description(
+              "Input Group keeps prefixes and suffixes on one control surface.",
+            ),
+          ]),
+          @rui.field([
+            @rui.field_label(for_="forms-gallery-note", "Launch note"),
+            @rui.textarea(
+              id="forms-gallery-note",
+              name="launch-note",
+              value=note,
+              rows=4,
+              placeholder="What should collaborators know?",
+              on_input=set_form_state.map(value => {
+                state => (state.0, state.1, state.2, value, false)
+              }),
+            ),
+            @rui.field_description(
+              "Textarea remains a native, parent-controlled value.",
+            ),
+          ]),
+        ]),
+        @html.div(style=[ControlRowStyle], [
+          @html.output(
+            style=[MutedStyle],
+            if submitted {
+              "Saved locally — submit default was prevented."
+            } else {
+              "Edit a field, then submit the native form."
+            },
+          ),
+          @rui.button(type_="submit", "Save workspace"),
+        ]),
+      ]),
+    )
+    forms_field_variants(field_composition)
+  })
+}
+
+///|
+fn showcase_forms_page(slug : String) -> @rabbita.Val[@html.Html] {
+  match slug {
+    "calendar" => calendar_showcase()
+    "checkbox" => forms_checkbox_variants()
+    "combobox" => forms_combobox_variants()
+    "date-picker" => date_picker_showcase()
+    "field" => showcase_field_page()
+    "input" => showcase_input_page()
+    "input-group" => forms_input_group_variants()
+    "input-otp" => forms_otp_variants()
+    "native-select" => showcase_static_page(forms_native_select_variants())
+    "radio-group" => showcase_radio_group_page()
+    "select" => forms_select_variants()
+    "slider" => showcase_slider_page()
+    "switch" => forms_switch_variants()
+    "textarea" => showcase_textarea_page()
+    _ => showcase_static_page(@html.nothing)
+  }
+}

--- a/website/homepage/components/showcase_pages_foundations.mbt
+++ b/website/homepage/components/showcase_pages_foundations.mbt
@@ -1,0 +1,100 @@
+///|
+fn showcase_static_page(body : @html.Html) -> @rabbita.Val[@html.Html] {
+  @rabbita.Val::constant(body)
+}
+
+///|
+fn showcase_toggle_page() -> @rabbita.Val[@html.Html] {
+  let pin_view = @rui.toggle(
+    variant=@rui.Outline,
+    size=@rui.Lg,
+    aria_label="Pin release",
+    "Pin release",
+  )
+  let watch_view = @rui.toggle(
+    variant=@rui.Default,
+    size=@rui.Sm,
+    aria_label="Watch release",
+    "Watch",
+  )
+  pin_view.view2(watch_view, foundations_toggle_demo)
+}
+
+///|
+fn showcase_toggle_group_page() -> @rabbita.Val[@html.Html] {
+  let density_view = @rui.toggle_group(
+    default_values=["grid"],
+    variant=@rui.Outline,
+    size=@rui.Sm,
+    aria_label="Preview layout",
+    scope => {
+      @html.fragment([
+        @rui.toggle_group_item(scope~, value="list", aria_label="List", "List"),
+        @rui.toggle_group_item(scope~, value="grid", aria_label="Grid", "Grid"),
+      ])
+    },
+  )
+  let formatting_view = @rui.toggle_group(
+    default_values=["bold"],
+    multiple=true,
+    variant=@rui.Default,
+    size=@rui.Lg,
+    aria_label="Text formatting",
+    scope => {
+      @html.fragment([
+        @rui.toggle_group_item(
+          scope~,
+          value="bold",
+          aria_label="Bold",
+          showcase_bold_icon(),
+        ),
+        @rui.toggle_group_item(
+          scope~,
+          value="italic",
+          aria_label="Italic",
+          showcase_italic_icon(),
+        ),
+        @rui.toggle_group_item(
+          scope~,
+          value="underline",
+          aria_label="Underline",
+          showcase_underline_icon(),
+        ),
+      ])
+    },
+  )
+  density_view.view2(formatting_view, foundations_toggle_group_demo)
+}
+
+///|
+fn showcase_foundations_page(slug : String) -> @rabbita.Val[@html.Html] {
+  match slug {
+    "alert" => showcase_static_page(foundations_alert_demo())
+    "aspect-ratio" => showcase_static_page(foundations_aspect_ratio_demo())
+    "attachment" => showcase_static_page(fdv_attachments_demo())
+    "avatar" => showcase_static_page(foundations_avatar_demo())
+    "badge" => showcase_static_page(foundations_badge_demo())
+    "bubble" => showcase_static_page(foundations_bubble_demo())
+    "button" => showcase_static_page(foundations_button_demo())
+    "button-group" => showcase_static_page(foundations_button_group_demo())
+    "card" => showcase_static_page(foundations_card_demo())
+    "chart" => showcase_static_page(foundations_chart_demo())
+    "data-table" => fdv_data_table_view().view(fdv_data_table_demo)
+    "direction" => showcase_static_page(foundations_direction_demo())
+    "empty" => showcase_static_page(fdv_empty_demo())
+    "item" => showcase_static_page(fdv_items_demo())
+    "kbd" => showcase_static_page(foundations_kbd_demo())
+    "label" => showcase_static_page(foundations_label_demo())
+    "marker" => showcase_static_page(fdv_marker_demo())
+    "message" => showcase_static_page(foundations_message_demo())
+    "progress" => showcase_static_page(fdv_progress_demo())
+    "separator" => showcase_static_page(foundations_separator_demo())
+    "skeleton" => showcase_static_page(foundations_skeleton_demo())
+    "spinner" => showcase_static_page(foundations_spinner_demo())
+    "table" => showcase_static_page(foundations_table_demo())
+    "toggle" => showcase_toggle_page()
+    "toggle-group" => showcase_toggle_group_page()
+    "typography" => showcase_static_page(fdv_typography_demo())
+    _ => showcase_static_page(@html.nothing)
+  }
+}

--- a/website/homepage/components/showcase_registry.mbt
+++ b/website/homepage/components/showcase_registry.mbt
@@ -1,0 +1,125 @@
+///|
+priv struct ShowcasePageEntry {
+  slug : String
+  title : String
+}
+
+///|
+let showcase_page_entries : Array[ShowcasePageEntry] = [
+  { slug: "accordion", title: "Accordion" },
+  { slug: "alert", title: "Alert" },
+  { slug: "alert-dialog", title: "Alert Dialog" },
+  { slug: "aspect-ratio", title: "Aspect Ratio" },
+  { slug: "attachment", title: "Attachment" },
+  { slug: "avatar", title: "Avatar" },
+  { slug: "badge", title: "Badge" },
+  { slug: "breadcrumb", title: "Breadcrumb" },
+  { slug: "bubble", title: "Bubble" },
+  { slug: "button", title: "Button" },
+  { slug: "button-group", title: "Button Group" },
+  { slug: "calendar", title: "Calendar" },
+  { slug: "card", title: "Card" },
+  { slug: "carousel", title: "Carousel" },
+  { slug: "chart", title: "Chart" },
+  { slug: "checkbox", title: "Checkbox" },
+  { slug: "collapsible", title: "Collapsible" },
+  { slug: "combobox", title: "Combobox" },
+  { slug: "command", title: "Command" },
+  { slug: "context-menu", title: "Context Menu" },
+  { slug: "data-table", title: "Data Table" },
+  { slug: "date-picker", title: "Date Picker" },
+  { slug: "dialog", title: "Dialog" },
+  { slug: "direction", title: "Direction" },
+  { slug: "drawer", title: "Drawer" },
+  { slug: "dropdown-menu", title: "Dropdown Menu" },
+  { slug: "empty", title: "Empty" },
+  { slug: "field", title: "Field" },
+  { slug: "hover-card", title: "Hover Card" },
+  { slug: "input", title: "Input" },
+  { slug: "input-group", title: "Input Group" },
+  { slug: "input-otp", title: "Input OTP" },
+  { slug: "item", title: "Item" },
+  { slug: "kbd", title: "Kbd" },
+  { slug: "label", title: "Label" },
+  { slug: "marker", title: "Marker" },
+  { slug: "menubar", title: "Menubar" },
+  { slug: "message", title: "Message" },
+  { slug: "message-scroller", title: "Message Scroller" },
+  { slug: "native-select", title: "Native Select" },
+  { slug: "navigation-menu", title: "Navigation Menu" },
+  { slug: "pagination", title: "Pagination" },
+  { slug: "popover", title: "Popover" },
+  { slug: "progress", title: "Progress" },
+  { slug: "radio-group", title: "Radio Group" },
+  { slug: "resizable", title: "Resizable" },
+  { slug: "scroll-area", title: "Scroll Area" },
+  { slug: "select", title: "Select" },
+  { slug: "separator", title: "Separator" },
+  { slug: "sheet", title: "Sheet" },
+  { slug: "sidebar", title: "Sidebar" },
+  { slug: "skeleton", title: "Skeleton" },
+  { slug: "slider", title: "Slider" },
+  { slug: "sonner", title: "Sonner" },
+  { slug: "spinner", title: "Spinner" },
+  { slug: "switch", title: "Switch" },
+  { slug: "table", title: "Table" },
+  { slug: "tabs", title: "Tabs" },
+  { slug: "textarea", title: "Textarea" },
+  { slug: "toast", title: "Toast" },
+  { slug: "toggle", title: "Toggle" },
+  { slug: "toggle-group", title: "Toggle Group" },
+  { slug: "tooltip", title: "Tooltip" },
+  { slug: "typography", title: "Typography" },
+]
+
+///|
+fn showcase_page_index_by_slug(slug : String) -> Int {
+  for index = 0; index < showcase_page_entries.length(); index = index + 1 {
+    if showcase_page_entries[index].slug == slug {
+      return index
+    }
+  }
+  -1
+}
+
+///|
+fn showcase_page_index_by_title(title : String) -> Int {
+  for index = 0; index < showcase_page_entries.length(); index = index + 1 {
+    if showcase_page_entries[index].title == title {
+      return index
+    }
+  }
+  -1
+}
+
+///|
+fn showcase_default_page_slug() -> String {
+  showcase_page_entries[0].slug
+}
+
+///|
+fn showcase_page_title(slug : String) -> String {
+  let index = showcase_page_index_by_slug(slug)
+  if index >= 0 {
+    showcase_page_entries[index].title
+  } else {
+    "Components"
+  }
+}
+
+///|
+#cfg(target="js")
+extern "js" fn showcase_page_href(slug : String) -> String =
+  #| slug => {
+  #|   const pathname = globalThis.location?.pathname || "/components/";
+  #|   const marker = "/components";
+  #|   const markerIndex = pathname.indexOf(marker);
+  #|   const root = markerIndex >= 0 ? pathname.slice(0, markerIndex) : "";
+  #|   return `${root}/components/${encodeURIComponent(slug)}/`;
+  #| }
+
+///|
+#cfg(not(target="js"))
+fn showcase_page_href(slug : String) -> String {
+  "/components/" + slug + "/"
+}

--- a/website/homepage/main/main.mbt
+++ b/website/homepage/main/main.mbt
@@ -52,6 +52,7 @@ enum Theme {
 enum Page {
   Home
   Tour(TourModel)
+  Components(String)
 } derive(Eq)
 
 ///|
@@ -59,6 +60,7 @@ impl @rabbita.Enumerate for Page with fn tag(self) {
   match self {
     Home => "home"
     Tour(_) => "tour"
+    Components(slug) => "components:" + slug
   }
 }
 
@@ -350,6 +352,10 @@ fn theme_icon(theme : Theme) -> Html {
   }
 }
 
+///|
+extern "js" fn prefers_dark_color_scheme() -> Bool =
+  #| () => globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false
+
 // ─── Navigation ───────────────────────────────────────────────────────────
 
 ///|
@@ -376,23 +382,45 @@ fn hamburger(is_open : Bool) -> Html {
 }
 
 ///|
+enum NavPage {
+  NavHome
+  NavTour
+  NavComponents
+} derive(Eq)
+
+///|
 struct NavModel {
   theme : Theme
-  is_home : Bool
+  current : NavPage
 } derive(Eq)
+
+///|
+fn nav_link_attrs(is_current : Bool) -> @html.Attrs {
+  let attrs = @html.Attrs::build()
+  if is_current {
+    ignore(attrs.aria_current("page"))
+  }
+  attrs
+}
 
 ///|
 fn site_nav(model : Val[NavModel], on_cycle_theme : Cmd) -> Val[Html] {
   let (menu_open, set_menu_open) = @rabbita.create_variable(false)
   model.map2(menu_open, (model, menu_open) => {
-    let is_home = model.is_home
-    let is_tour = !model.is_home
+    let is_home = model.current == NavHome
+    let is_tour = model.current == NavTour
+    let is_components = model.current == NavComponents
     let home_cls = if is_home {
       "nav-link nav-link--active"
     } else {
       "nav-link"
     }
     let tour_cls = if is_tour {
+      "nav-link nav-link--active"
+    } else {
+      "nav-link"
+    }
+    let components_cls = if is_components {
       "nav-link nav-link--active"
     } else {
       "nav-link"
@@ -407,40 +435,103 @@ fn site_nav(model : Val[NavModel], on_cycle_theme : Cmd) -> Val[Html] {
     } else {
       "mobile-link"
     }
+    let components_m = if is_components {
+      "mobile-link mobile-link--active"
+    } else {
+      "mobile-link"
+    }
+    let theme_label = match model.theme {
+      System => "Theme: system"
+      Light => "Theme: light"
+      Dark => "Theme: dark"
+    }
     header(class="site-header", [
-      nav(class="navbar", [
-        a(class="nav-logo", href=github_url, "Rabbita"),
-        div(class="nav-links", [
-          a(href=site_base_url(), class=home_cls, "Home"),
-          a(href=tour_base_url(), class=tour_cls, "Tour"),
-          a(
-            href=playground_url(),
-            class="nav-link nav-link--ext",
-            escape=true,
-            [text("Playground"), icon_ext_link()],
-          ),
-          a(href=docs_url, target=Blank, class="nav-link nav-link--ext", [
-            text("Docs"),
-            icon_ext_link(),
+      nav(
+        class="navbar",
+        attrs=@html.Attrs::build().aria_label("Primary navigation"),
+        [
+          a(class="nav-logo", href=github_url, "Rabbita"),
+          div(class="nav-links", [
+            a(
+              href=site_base_url(),
+              class=home_cls,
+              attrs=nav_link_attrs(is_home),
+              "Home",
+            ),
+            a(
+              href=tour_base_url(),
+              class=tour_cls,
+              attrs=nav_link_attrs(is_tour),
+              "Tour",
+            ),
+            a(
+              href=components_base_url(),
+              class=components_cls,
+              attrs=nav_link_attrs(is_components),
+              "Components",
+            ),
+            a(
+              href=playground_url(),
+              class="nav-link nav-link--ext",
+              escape=true,
+              [text("Playground"), icon_ext_link()],
+            ),
+            a(href=docs_url, target=Blank, class="nav-link nav-link--ext", [
+              text("Docs"),
+              icon_ext_link(),
+            ]),
+            a(href=github_url, target=Blank, class="nav-link nav-link--ext", [
+              text("GitHub"),
+              icon_ext_link(),
+            ]),
           ]),
-          a(href=github_url, target=Blank, class="nav-link nav-link--ext", [
-            text("GitHub"),
-            icon_ext_link(),
+          div(class="nav-actions", [
+            button(
+              class="theme-toggle",
+              title=theme_label,
+              attrs=@html.Attrs::build().aria_label(theme_label),
+              on_click=on_cycle_theme,
+              [theme_icon(model.theme)],
+            ),
+            button(
+              class="nav-toggle",
+              title=if menu_open { "Close menu" } else { "Open menu" },
+              attrs=@html.Attrs::build()
+                .aria_label(if menu_open { "Close menu" } else { "Open menu" })
+                .aria_controls("mobile-navigation")
+                .aria_expanded(if menu_open { "true" } else { "false" }),
+              on_click=set_menu_open(open => !open),
+              [hamburger(menu_open)],
+            ),
           ]),
-        ]),
-        div(class="nav-actions", [
-          button(class="theme-toggle", on_click=on_cycle_theme, [
-            theme_icon(model.theme),
-          ]),
-          button(class="nav-toggle", on_click=set_menu_open(open => !open), [
-            hamburger(menu_open),
-          ]),
-        ]),
-      ]),
+        ],
+      ),
       if menu_open {
-        div(class="mobile-menu", [
-          a(href=site_base_url(), class=home_m, "Home"),
-          a(href=tour_base_url(), class=tour_m, "Tour"),
+        div(id="mobile-navigation", class="mobile-menu", [
+          a(
+            href=site_base_url(),
+            class=home_m,
+            attrs=nav_link_attrs(is_home).on_click(_ => {
+              set_menu_open(_ => false)
+            }),
+            "Home",
+          ),
+          a(
+            href=tour_base_url(),
+            class=tour_m,
+            attrs=nav_link_attrs(is_tour).on_click(_ => {
+              set_menu_open(_ => false)
+            }),
+            "Tour",
+          ),
+          a(
+            href=components_base_url(),
+            class=components_m,
+            attrs=nav_link_attrs(is_components).on_click(_ => {
+              set_menu_open(_ => false)
+            }),
+            "Components",
+          ),
           a(
             href=playground_url(),
             class="mobile-link mobile-link--ext",
@@ -923,7 +1014,16 @@ fn app() -> Val[Html] {
             External(url) => (@nav.load(url), model)
           }
         UrlChanged(url) =>
-          if is_tour_url(chapters, url.path) {
+          if is_components_url(url.path) {
+            let scroll_cmd = match url.fragment {
+              Some(frag) => scroll_to_heading(frag)
+              None => @nav.scroll_to_top()
+            }
+            (
+              scroll_cmd,
+              { page: Components(component_slug_from_path(url.path)) },
+            )
+          } else if is_tour_url(chapters, url.path) {
             let idx = chapter_idx_from_path(chapters, url.path)
             let scroll_cmd = match url.fragment {
               Some(frag) => scroll_to_heading(frag)
@@ -951,17 +1051,22 @@ fn app() -> Val[Html] {
   let (theme, set_theme) = @rabbita.create_variable(System)
   let page = model.map(model => model.page)
   let nav_model = theme.map2(page, (theme, page) => {
-    let is_home = match page {
-      Home => true
-      Tour(_) => false
+    let current = match page {
+      Home => NavHome
+      Tour(_) => NavTour
+      Components(_) => NavComponents
     }
-    { theme, is_home }
+    { theme, current }
   })
-  let site_class_name = theme.map(theme => {
-    match theme {
+  let site_class_name = theme.map2(page, (theme, page) => {
+    let theme_class = match theme {
       System => "site"
       Light => "site light"
       Dark => "site dark"
+    }
+    match page {
+      Components(_) => theme_class + " site--components"
+      Home | Tour(_) => theme_class
     }
   })
   let header_html = site_nav(
@@ -974,15 +1079,23 @@ fn app() -> Val[Html] {
       }
     }),
   )
+  let components_dark = theme.map(theme => {
+    match theme {
+      System => prefers_dark_color_scheme()
+      Light => false
+      Dark => true
+    }
+  })
   let page_html = page.switch(current => {
     match current {
       Home => home()
+      Components(slug) => @components.components_page(components_dark, slug)
       Tour(_) =>
         tour(
           page.map2(chapters, (page, chapters) => {
             let tour = match page {
               Tour(model) => model
-              Home => init_tour
+              Home | Components(_) => init_tour
             }
             { chapters, tour }
           }),
@@ -1001,7 +1114,7 @@ fn app() -> Val[Html] {
 /// see README.md to get started.
 #warnings("-alert_unstable")
 fn main {
-  @shiki.initialize(langs=["moonbit", "text"], themes=[
+  @shiki.initialize(langs=["moonbit"], themes=[
     "github-light", "github-dark-default",
   ])
   @rabbita.new(app).mount("app")

--- a/website/homepage/main/moon.pkg
+++ b/website/homepage/main/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbit-community/rabbita/url",
   "moonbit-community/rabbita/http",
   "moonbit-community/rabbita/sub",
+  "rabbita/website/components",
   "moonbitlang/core/json",
   "Yoorkin/shiki",
   "moonbit-community/cmark/cmark",

--- a/website/homepage/main/navigation_wbtest.mbt
+++ b/website/homepage/main/navigation_wbtest.mbt
@@ -1,0 +1,30 @@
+///|
+test "components route accepts component pages only" {
+  assert_true(is_components_url("components"))
+  assert_true(is_components_url("components/"))
+  assert_true(is_components_url("components/button"))
+  assert_true(is_components_url("components/button/"))
+  assert_false(is_components_url("component"))
+  assert_false(is_components_url("components-extra"))
+  assert_false(is_components_url("components/button/example"))
+}
+
+///|
+test "components route extracts a stable page slug" {
+  assert_eq(component_slug_from_path("components"), "accordion")
+  assert_eq(component_slug_from_path("components/"), "accordion")
+  assert_eq(component_slug_from_path("components/button"), "button")
+  assert_eq(component_slug_from_path("components/input-group/"), "input-group")
+  assert_eq(component_slug_from_path("components/button/example"), "")
+}
+
+///|
+test "components has its own page and navigation identity" {
+  assert_eq(@rabbita.Enumerate::tag(Components("button")), "components:button")
+  assert_true(
+    @rabbita.Enumerate::tag(Components("button")) !=
+    @rabbita.Enumerate::tag(Components("tabs")),
+  )
+  assert_true(NavComponents != NavHome)
+  assert_true(NavComponents != NavTour)
+}

--- a/website/homepage/main/pkg.generated.mbti
+++ b/website/homepage/main/pkg.generated.mbti
@@ -29,6 +29,8 @@ type Msg
 
 type NavModel derive(Eq)
 
+type NavPage derive(Eq)
+
 type Page derive(Eq)
 
 type Theme derive(Eq)

--- a/website/homepage/main/tour.mbt
+++ b/website/homepage/main/tour.mbt
@@ -65,6 +65,11 @@ extern "js" fn tour_base_url() -> String =
   #| }
 
 ///|
+fn components_base_url() -> String {
+  site_base_url() + "components/"
+}
+
+///|
 fn playground_url() -> String {
   site_base_url() + "playground/"
 }
@@ -118,6 +123,44 @@ fn is_tour_url(chapters : Array[TourChapter], path : String) -> Bool {
     }
   }
   false
+}
+
+///|
+fn is_components_url(path : String) -> Bool {
+  component_slug_from_path(path) != ""
+}
+
+///|
+fn component_slug_from_path(path : String) -> String {
+  let p = strip_base(path)
+  if p == "components" || p == "components/" {
+    return "accordion"
+  }
+  let prefix = "components/"
+  if !p.has_prefix(prefix) {
+    return ""
+  }
+  let builder = StringBuilder::new()
+  let mut index = 0
+  let mut invalid = false
+  for character in p {
+    if index >= prefix.length() {
+      if character == '/' {
+        if index != p.length() - 1 {
+          invalid = true
+        }
+      } else {
+        builder.write_char(character)
+      }
+    }
+    index = index + 1
+  }
+  let slug = builder.to_string()
+  if invalid || slug == "" {
+    ""
+  } else {
+    slug
+  }
 }
 
 // Finds the chapter index matching a URL path; defaults to 0

--- a/website/homepage/moon.mod
+++ b/website/homepage/moon.mod
@@ -3,7 +3,8 @@ name = "rabbita/website"
 version = "0.2.0"
 
 import {
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.13.1",
+  "Yoorkin/rui@0.1.0",
   "Yoorkin/shiki@0.1.0",
   "moonbitlang/async@0.16.6",
   "moonbit-community/cmark@0.4.3",

--- a/website/homepage/public/components/index.html
+++ b/website/homepage/public/components/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Components — rabbita</title>
+    <meta name="description" content="Rabbita components, built natively for MoonBit.">
+    <base href="../">
+    <link rel="stylesheet" type="text/css" href="./styles.css" />
+    <script src="./index.js" type="module"></script>
+</head>
+<body>
+    <div id="app"></div>
+</body>
+</html>

--- a/website/homepage/public/styles.css
+++ b/website/homepage/public/styles.css
@@ -210,7 +210,15 @@ body::before {
 
 .nav-link--active:hover {
   color: var(--accent);
-  opacity: 0.8;
+}
+
+.nav-logo:focus-visible,
+.nav-link:focus-visible,
+.mobile-link:focus-visible,
+.theme-toggle:focus-visible,
+.nav-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .nav-link--ext {
@@ -331,6 +339,16 @@ body::before {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+@media (max-width: 800px) {
+  .nav-links {
+    display: none;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
 }
 
 /* ─── Hero ────────────────────────────────────────────────── */
@@ -1660,5 +1678,339 @@ body::before {
   .tour-content {
     border-left: none;
     padding: 1.5rem 1rem;
+  }
+}
+
+/* ─── Components showcase ────────────────────────────────── */
+
+.rui-showcase-demo-code-summary {
+  position: absolute;
+  inset: 0;
+  display: block;
+  height: 6.75rem;
+  overflow: hidden;
+  cursor: pointer;
+  list-style: none;
+  outline: none;
+}
+
+.rui-showcase-demo-code {
+  position: relative;
+  max-height: 6.75rem;
+  overflow: hidden;
+}
+
+.rui-showcase-demo-code-peek {
+  pointer-events: none;
+  user-select: none;
+}
+
+.rui-showcase-demo-code-disclosure {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.rui-showcase-demo-code-disclosure > .rui-showcase-demo-code-summary {
+  pointer-events: auto;
+}
+
+.rui-showcase-demo-code-summary::-webkit-details-marker {
+  display: none;
+}
+
+.rui-showcase-demo-code-summary::marker {
+  content: "";
+}
+
+.rui-showcase-demo-code-summary::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    color-mix(
+        in oklab,
+        var(--rui-showcase-code-background) 30%,
+        transparent
+      )
+      26%,
+    var(--rui-showcase-code-background) 88%
+  );
+  pointer-events: none;
+}
+
+.rui-showcase-demo-code-toggle {
+  box-sizing: border-box;
+  position: absolute;
+  left: 50%;
+  bottom: 1rem;
+  z-index: 2;
+  display: inline-flex;
+  height: 2rem;
+  min-height: 2rem;
+  width: 6rem;
+  min-width: 6rem;
+  align-items: center;
+  justify-content: center;
+  transform: translateX(-50%);
+  border: 1px solid var(--rui-border);
+  border-radius: 0.625rem;
+  background: var(--rui-background);
+  padding: 0 0.75rem;
+  color: var(--rui-foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.rui-showcase-demo-code-summary:hover .rui-showcase-demo-code-toggle {
+  background: var(--rui-muted);
+}
+
+.rui-showcase-demo-code-summary:focus-visible
+  .rui-showcase-demo-code-toggle {
+  outline: 2px solid var(--rui-ring);
+  outline-offset: 2px;
+}
+
+.rui-showcase-demo-code:has(> .rui-showcase-demo-code-disclosure[open]) {
+  max-height: none;
+  overflow: visible;
+}
+
+.rui-showcase-demo-code-disclosure[open]
+  > .rui-showcase-demo-code-summary {
+  display: none;
+}
+
+.rui-showcase-demo-code:has(> .rui-showcase-demo-code-disclosure[open])
+  > .rui-showcase-demo-code-peek {
+  overflow-x: auto !important;
+  pointer-events: auto;
+  user-select: text;
+}
+
+.rui-showcase-demo-code-disclosure[open]
+  > .rui-showcase-demo-code-panel {
+  animation: rui-showcase-code-in 160ms ease-out;
+}
+
+.rui-showcase-shiki,
+.rui-showcase-shiki > yoorkin-shiki-code {
+  display: block;
+  min-width: 0;
+}
+
+.rui-showcase-shiki .shiki,
+.rui-showcase-shiki yoorkin-shiki-code > pre {
+  box-sizing: border-box;
+  min-width: max-content;
+  margin: 0;
+  background: transparent !important;
+  padding: 1.5rem 0;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.75;
+  tab-size: 2;
+  white-space: pre;
+}
+
+.rui-showcase-shiki code {
+  display: grid;
+  counter-reset: rui-showcase-code-line;
+}
+
+/* Keep the unloaded plain-text fallback on the same text baseline as Shiki's
+   numbered lines. Highlighting can then replace paint without moving layout. */
+.rui-showcase-shiki
+  > yoorkin-shiki-code:not([data-shiki-highlighted])
+  > pre
+  > code {
+  display: block;
+  box-sizing: border-box;
+  padding-inline: 4rem;
+}
+
+.rui-showcase-shiki code > .line {
+  display: block;
+  min-height: 1lh;
+  padding: 0 4rem 0 0;
+  counter-increment: rui-showcase-code-line;
+}
+
+.rui-showcase-shiki code > .line::before {
+  content: counter(rui-showcase-code-line);
+  display: inline-block;
+  box-sizing: border-box;
+  width: 4rem;
+  padding-right: 1.5rem;
+  color: var(--rui-muted-foreground);
+  text-align: right;
+  opacity: 0.65;
+  user-select: none;
+}
+
+.rui-showcase-demo-code-peek .shiki,
+.rui-showcase-demo-code-peek yoorkin-shiki-code > pre {
+  padding: 1.125rem 0;
+}
+
+.rui-showcase-demo-section {
+  scroll-margin-top: calc(var(--nav-h, 60px) + 1rem);
+}
+
+.rui-showcase-rail-link {
+  border-radius: 0.5rem;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease;
+}
+
+.rui-showcase-rail-link:hover {
+  color: var(--rui-foreground) !important;
+}
+
+.rui-showcase-catalog .rui-showcase-rail-link:hover,
+.rui-showcase-catalog .rui-showcase-rail-link--active {
+  background: var(--rui-accent);
+  color: var(--rui-foreground) !important;
+}
+
+.rui-showcase-page-navigation-link:hover {
+  border-color: color-mix(
+    in oklab,
+    var(--rui-foreground) 22%,
+    var(--rui-border)
+  );
+  background: var(--rui-accent);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.07);
+}
+
+.rui-showcase-page-navigation-link:active {
+  background: color-mix(
+    in oklab,
+    var(--rui-accent) 82%,
+    var(--rui-foreground)
+  );
+  transform: translateY(1px);
+}
+
+.rui-showcase-page-navigation-link:focus-visible {
+  outline: 2px solid var(--rui-ring);
+  outline-offset: 2px;
+}
+
+.rui-showcase-rail-link:focus-visible {
+  outline: 2px solid var(--rui-ring);
+  outline-offset: 2px;
+  color: var(--rui-foreground) !important;
+}
+
+.rui-showcase-component-toc .rui-showcase-rail-link:hover {
+  background: var(--rui-accent);
+}
+
+@keyframes rui-showcase-code-in {
+  from {
+    opacity: 0;
+    transform: translateY(-0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rui-showcase-demo-code-disclosure[open]
+    > .rui-showcase-demo-code-panel {
+    animation: none;
+  }
+
+  .rui-showcase-demo-code-toggle,
+  .rui-showcase-rail-link,
+  .rui-showcase-page-navigation-link {
+    transition: none;
+  }
+}
+
+@media (max-width: 80rem) {
+  #rui-showcase {
+    --rui-showcase-component-columns: minmax(0, 46rem);
+  }
+
+  .rui-showcase-component-toc {
+    display: none;
+  }
+}
+
+@media (max-width: 1024px) {
+  #rui-showcase {
+    --rui-showcase-catalog-columns: minmax(0, 1fr);
+    --rui-showcase-component-columns: minmax(0, 1fr);
+  }
+
+  .rui-showcase-component {
+    grid-template-columns: minmax(0, 1fr) !important;
+    justify-content: stretch !important;
+  }
+
+  .rui-showcase-component-toc {
+    display: none !important;
+  }
+
+  .rui-showcase-catalog {
+    display: none !important;
+  }
+
+  .rui-showcase-mobile-catalog {
+    display: block !important;
+  }
+
+  .rui-showcase-mobile-catalog-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .rui-showcase-mobile-catalog-summary::marker {
+    content: "";
+  }
+
+  .rui-showcase-mobile-catalog details[open]
+    .rui-showcase-mobile-catalog-summary > :last-child {
+    transform: rotate(90deg);
+  }
+
+  .rui-showcase-mobile-catalog .rui-showcase-rail-link {
+    padding: 0.375rem 0.625rem !important;
+  }
+
+  .rui-showcase-mobile-catalog .rui-showcase-rail-link:hover,
+  .rui-showcase-mobile-catalog .rui-showcase-rail-link--active {
+    background: var(--rui-accent);
+    color: var(--rui-foreground) !important;
+  }
+}
+
+@media (max-width: 640px) {
+  #rui-showcase {
+    padding: 1rem 0 3rem !important;
+  }
+
+  .rui-showcase-page-navigation {
+    gap: 0.5rem !important;
+  }
+
+  .rui-showcase-page-navigation-link {
+    min-height: 2.75rem !important;
+    padding: 0.5rem 0.625rem !important;
   }
 }


### PR DESCRIPTION
Adds the experimental `Yoorkin/rui` component library, built natively on Rabbita with shadcn/ui Vega-inspired visuals, inline styles, and black-box APIs.

It also adds the DOM and event primitives required by interactive components and integrates a page-per-component showcase into the Rabbita website.

[Browse the component showcase](https://moonbit-community.github.io/rabbita/components/)