### PR TITLE
fix: avoid relocating unchanged keyed children

### DIFF
--- a/rabbita/internal/runtime/vdom.mbt
+++ b/rabbita/internal/runtime/vdom.mbt
@@ -46,6 +46,19 @@ fn INode::end(s : Self) -> @dom.Node {
 
 ///|
 #cfg(target="js")
+fn INode::needs_relocation(
+  self : Self,
+  anchor : @js.Nullable[@dom.Node],
+) -> Bool {
+  match (self.end().get_next_sibling().to_option(), anchor.to_option()) {
+    (None, None) => false
+    (Some(actual), Some(expected)) => !actual.is_same_node(expected)
+    _ => true
+  }
+}
+
+///|
+#cfg(target="js")
 fn INode::remove(self : Self, sandbox : Sandbox, parent : @dom.Node) -> Unit {
   match self {
     Elem(_, _, _, e, ..) | Text(_, e) => parent.remove_child(e.as_node())
@@ -72,6 +85,7 @@ fn INode::relocate(
   parent : @dom.Node,
   before : @js.Nullable[@dom.Node],
 ) -> Unit {
+  guard self.needs_relocation(before) else { return }
   match self {
     Elem(_, _, _, e, ..) | Text(_, e) =>
       parent.insert_before(e.as_node(), before)

--- a/rabbita/internal/runtime/vdom_relocation_wbtest.mbt
+++ b/rabbita/internal/runtime/vdom_relocation_wbtest.mbt
@@ -1,0 +1,68 @@
+///|
+#cfg(target="js")
+extern "js" fn relocation_test_document() -> @dom.Document =
+  #| () => {
+  #|   return {
+  #|     createElement() {
+  #|       return {
+  #|         childNodes: [],
+  #|         insertCount: 0,
+  #|         appendChild(child) {
+  #|           const previous = this.childNodes.at(-1)
+  #|           if (previous) previous.nextSibling = child
+  #|           child.nextSibling = null
+  #|           this.childNodes.push(child)
+  #|         },
+  #|         insertBefore() {
+  #|           this.insertCount += 1
+  #|         },
+  #|         getAttribute(name) {
+  #|           return name === "data-insert-count" ? String(this.insertCount) : null
+  #|         },
+  #|       }
+  #|     },
+  #|     createTextNode(value) {
+  #|       return { nodeValue: value, nextSibling: null }
+  #|     },
+  #|   }
+  #| }
+
+///|
+#cfg(target="js")
+test "diffing unchanged keyed children does not reinsert DOM nodes" {
+  let document = relocation_test_document()
+  let parent = document.create_element("div")
+  let first = document.create_text_node("first")
+  let second = document.create_text_node("second")
+  parent..append_child(first.as_node()).append_child(second.as_node())
+  let old : Children[INode] = Map(
+    Map::from_array([
+      ("first", INode::Text("first", first)),
+      ("second", INode::Text("second", second)),
+    ]),
+  )
+  let new : Children[VNode] = Map(
+    Map::from_array([
+      ("first", VNode::text("first")),
+      ("second", VNode::text("second")),
+    ]),
+  )
+
+  ignore(diff_children(old, new, Sandbox::new(), parent.as_node(), null()))
+
+  assert_eq(parent.get_attribute("data-insert-count"), Some("0"))
+}
+
+///|
+#cfg(target="js")
+test "relocate inserts a DOM node when its position differs" {
+  let document = relocation_test_document()
+  let parent = document.create_element("div")
+  let first = document.create_text_node("first")
+  let second = document.create_text_node("second")
+  parent..append_child(first.as_node()).append_child(second.as_node())
+
+  INode::Text("first", first).relocate(parent.as_node(), null())
+
+  assert_eq(parent.get_attribute("data-insert-count"), Some("1"))
+}


### PR DESCRIPTION
Keyed reconciliation called `insertBefore` for every retained child, even when the node was already at the requested position. This could cause unchanged text inputs and textareas to lose focus or move the text cursor unexpectedly.

`INode::relocate` now checks whether a retained keyed child is already in the correct DOM position before calling `insertBefore`. If it is, the DOM is left untouched. Keyed children that actually changed order are still moved as before.

Tests cover both cases: when a child is already in place and when it needs to be moved.